### PR TITLE
Fix perspective ready check

### DIFF
--- a/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
+++ b/core/src/main/scala/com/raphtory/internals/components/querymanager/QueryHandler.scala
@@ -421,7 +421,10 @@ private[raphtory] class QueryHandler(
 
   def perspectiveIsReady(perspective: Perspective): Boolean = {
     val time = getLatestTime
-    perspective.timestamp <= time
+    perspective.window match {
+      case Some(_) => perspective.actualEnd <= time
+      case None    => perspective.timestamp <= time
+    }
   }
 
   @tailrec


### PR DESCRIPTION
- Single implementation for checking if a perspective is ready to run
- Removes 1s latency due to different checks between `recheckTime` and `executeNextPerspective`
- Perspectives run as soon as the window is partially within the data (we should revisit this choice and improve handling of partial windows)