### PR TITLE
Fixed small bug where .ds_store was attempted to be read as a graph

### DIFF
--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -1,6 +1,7 @@
 use raphtory::db::graph::Graph;
 use std::collections::HashMap;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 pub(crate) struct Data {
     pub(crate) graphs: HashMap<String, Graph>,
@@ -14,11 +15,15 @@ impl Data {
 
         let graphs = paths
             .filter_map(|entry| {
-                let path = entry.unwrap().path();
-                let graph = Graph::load_from_file(&path).ok()?;
-                let filename = path.file_name()?.to_str()?.to_string();
-
-                Some((filename, graph))
+                let path:PathBuf = entry.unwrap().path();
+                if path.is_dir(){
+                    let graph = Graph::load_from_file(&path).ok()?;
+                    let filename = path.file_name()?.to_str()?.to_string();
+                    Some((filename, graph))
+                }
+                else{
+                    None
+                }
             })
             .collect();
 

--- a/raphtory/src/db/graph.rs
+++ b/raphtory/src/db/graph.rs
@@ -807,7 +807,7 @@ impl InternalGraph {
         // use BufReader for better performance
 
         //TODO turn to logging?
-        //println!("loading from {:?}", path.as_ref());
+        println!("loading from {:?}", path.as_ref());
         let mut p = PathBuf::from(path.as_ref());
         p.push("graphdb_nr_shards");
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added a filter when graphql reads in graphs removing any singular files
### Why are the changes needed?
graphql panic'd when reading .ds_store
### Does this PR introduce any user-facing change? If yes is this documented?
no
### How was this patch tested?
No longer crashes 
### Issues
None raised for this as it was found and patched

### Are there any further changes required?
Not outside of refactoring how data is ingested
