### PR TITLE
make IntoDynamic public

### DIFF
--- a/py-raphtory/src/dynamic.rs
+++ b/py-raphtory/src/dynamic.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct DynamicGraph(Arc<dyn GraphViewInternalOps + Send + Sync + 'static>);
 
-pub(crate) trait IntoDynamic {
+pub trait IntoDynamic {
     fn into_dynamic(self) -> DynamicGraph;
 }
 

--- a/py-raphtory/src/lib.rs
+++ b/py-raphtory/src/lib.rs
@@ -4,7 +4,7 @@ extern crate core;
 mod macros;
 
 pub mod algorithms;
-mod dynamic;
+pub mod dynamic;
 pub mod edge;
 pub mod graph;
 pub mod graph_gen;


### PR DESCRIPTION
### What changes were proposed in this pull request?

makes the DynamicGraph public so it can be used by dependencies

### Why are the changes needed?

DynamicGraph is very useful for external structs that want to store a graph and expose it to python

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

Only visibility is changed, all the usual tests still pass

### Issues

### Are there any further changes required?

No

