### PR TITLE
Bug/partial windows

### DIFF
--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -1,3 +1,4 @@
+import math
 import re
 import sys
 import time
@@ -648,10 +649,10 @@ def test_graph_time_api():
     earliest_time = g.earliest_time()
     latest_time = g.latest_time()
     assert len(list(g.rolling(1))) == latest_time - earliest_time + 1
-    assert len(list(g.expanding(2))) == (latest_time - earliest_time) / 2
+    assert len(list(g.expanding(2))) == math.ceil((latest_time+1 - earliest_time) / 2)
 
     w = g.window(2, 6)
-    assert len(list(w.rolling(window=10, step=3))) == 1
+    assert len(list(w.rolling(window=10, step=3))) == 2
 
 
 def test_save_load_graph():

--- a/raphtory/src/db/view_api/time.rs
+++ b/raphtory/src/db/view_api/time.rs
@@ -1,5 +1,6 @@
 use crate::core::time::error::ParseTimeError;
 use crate::core::time::{Interval, IntoTime};
+use std::cmp::min;
 
 /// Trait defining time query operations
 pub trait TimeOps {
@@ -90,7 +91,7 @@ impl<T: TimeOps + Clone + 'static> WindowSet<T> {
         // } else {
         //     timeline_start + step - 1
         // };
-        let cursor_start = start + step - 1;
+        let cursor_start = start + step;
         Self {
             view,
             cursor: cursor_start,
@@ -145,8 +146,8 @@ impl<T: TimeOps + Clone> Iterator for TimeIndex<T> {
 impl<T: TimeOps + Clone> Iterator for WindowSet<T> {
     type Item = T::WindowedViewType;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.cursor < self.end {
-            let window_end = self.cursor + 1;
+        if self.cursor < self.end + self.step {
+            let window_end = self.cursor;
             let window_start = self.window.map(|w| window_end - w).unwrap_or(i64::MIN);
             let window = self.view.window(window_start, window_end);
             self.cursor = self.cursor + self.step;
@@ -212,7 +213,7 @@ mod time_tests {
 
         let g = graph_with_timeline(1, 6);
         let windows = g.expanding(2).unwrap();
-        let expected = vec![(min, 3), (min, 5)];
+        let expected = vec![(min, 3), (min, 5), (min, 7)];
         assert_bounds(windows, expected.clone());
 
         let g = graph_with_timeline(0, 9).window(1, 6);
@@ -274,7 +275,10 @@ mod time_tests {
         let end = "2020-06-07 23:59:59.999".try_into_time().unwrap();
         let g = graph_with_timeline(start, end);
         let windows = g.expanding("1 day").unwrap();
-        let expected = vec![(min, "2020-06-07 00:00:00".try_into_time().unwrap())];
+        let expected = vec![
+            (min, "2020-06-07 00:00:00".try_into_time().unwrap()),
+            (min, "2020-06-08 00:00:00".try_into_time().unwrap()),
+        ];
         assert_bounds(windows, expected);
 
         let start = "2020-06-06 00:00:00".try_into_time().unwrap();

--- a/raphtory/src/db/view_api/time.rs
+++ b/raphtory/src/db/view_api/time.rs
@@ -195,7 +195,7 @@ mod time_tests {
 
         let g = graph_with_timeline(1, 6);
         let windows = g.rolling(3, Some(2)).unwrap();
-        let expected = vec![(0, 3), (2, 5)];
+        let expected = vec![(0, 3), (2, 5), (4, 7)];
         assert_bounds(windows, expected.clone());
 
         let g = graph_with_timeline(0, 9).window(1, 6);
@@ -227,10 +227,16 @@ mod time_tests {
         let end = "2020-06-07 23:59:59.999".try_into_time().unwrap();
         let g = graph_with_timeline(start, end);
         let windows = g.rolling("1 day", None).unwrap();
-        let expected = vec![(
-            "2020-06-06 00:00:00".try_into_time().unwrap(), // entire 2020-06-06
-            "2020-06-07 00:00:00".try_into_time().unwrap(),
-        )];
+        let expected = vec![
+            (
+                "2020-06-06 00:00:00".try_into_time().unwrap(), // entire 2020-06-06
+                "2020-06-07 00:00:00".try_into_time().unwrap(),
+            ),
+            (
+                "2020-06-07 00:00:00".try_into_time().unwrap(), // entire 2020-06-06
+                "2020-06-08 00:00:00".try_into_time().unwrap(),
+            ),
+        ];
         assert_bounds(windows, expected);
 
         let start = "2020-06-06 00:00:00".try_into_time().unwrap();

--- a/raphtory/src/db/view_api/time.rs
+++ b/raphtory/src/db/view_api/time.rs
@@ -28,8 +28,8 @@ pub trait TimeOps {
         self.window(i64::MIN, end.into_time().saturating_add(1))
     }
 
-    /// Creates a `WindowSet` with the given `step` size and optional `start` and `end` times,    
-    /// using an expanding window.
+    /// Creates a `WindowSet` with the given `step` size    
+    /// using an expanding window. The last window may fall partially outside the range of the data/view.
     ///
     /// An expanding window is a window that grows by `step` size at each iteration.
     fn expanding<I>(&self, step: I) -> Result<WindowSet<Self>, ParseTimeError>
@@ -48,8 +48,8 @@ pub trait TimeOps {
         }
     }
 
-    /// Creates a `WindowSet` with the given `window` size and optional `step`, `start` and `end` times,
-    /// using a rolling window.
+    /// Creates a `WindowSet` with the given `window` size and optional `step`
+    /// using a rolling window. The last window may fall partially outside the range of the data/view.
     ///
     /// A rolling window is a window that moves forward by `step` size at each iteration.
     fn rolling<I>(&self, window: I, step: Option<I>) -> Result<WindowSet<Self>, ParseTimeError>

--- a/raphtory/src/python/edge.rs
+++ b/raphtory/src/python/edge.rs
@@ -286,10 +286,8 @@ impl PyEdge {
     /// A rolling window is a window that moves forward by `step` size at each iteration.
     ///
     /// Arguments:
-    ///   window (int): The size of the window.
-    ///   step (int): The step size to use when calculating the duration.
-    ///   start (int): The start time to use when calculating the duration.
-    ///   end (int): The end time to use when calculating the duration.
+    ///   window (int | str): The size of the window.
+    ///   step (int | str): The step size to use when calculating the duration.
     ///
     /// Returns:
     ///   A set of windows containing edges that fall in the time period
@@ -300,8 +298,8 @@ impl PyEdge {
     /// Get a new Edge with the properties of this Edge within the specified time window.
     ///
     /// Arguments:
-    ///   t_start (int): The start time of the window.
-    ///   t_end (int): The end time of the window.
+    ///   t_start (int | str): The start time of the window (optional).
+    ///   t_end (int | str): The end time of the window (optional).
     ///
     /// Returns:
     ///   A new Edge with the properties of this Edge within the specified time window.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the semantics for `expanding` and `rolling` such that partial windows at the end are returned

### Why are the changes needed?

`expanding` and `rolling` are currently ignoring some of the data

### Does this PR introduce any user-facing change? If yes is this documented?

Yes, documentation is tweaked to reflect the change (it was already outdated before)

### How was this patch tested?

Changed the tests for the new semantics



