### PR TITLE
Fix properties method for vertices and edges

### DIFF
--- a/raphtory/src/db/edge.rs
+++ b/raphtory/src/db/edge.rs
@@ -270,3 +270,22 @@ impl<G: GraphViewOps> EdgeListOps for BoxedIter<BoxedIter<EdgeView<G>>> {
 }
 
 pub type EdgeList<G> = Box<dyn Iterator<Item = EdgeView<G>> + Send>;
+
+#[cfg(test)]
+mod test_edge {
+    use crate::prelude::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_properties() {
+        let g = Graph::new(1);
+        let props = [("test".to_string(), Prop::Str("test".to_string()))];
+        g.add_edge(0, 1, 2, [], None).unwrap();
+        g.add_edge(2, 1, 2, props.clone(), None).unwrap();
+
+        let e1 = g.edge(1, 2, None).unwrap();
+        let e1_w = g.window(0, 1).edge(1, 2, None).unwrap();
+        assert_eq!(e1.properties(false), props.into());
+        assert_eq!(e1_w.properties(false), HashMap::default())
+    }
+}

--- a/raphtory/src/db/vertex.rs
+++ b/raphtory/src/db/vertex.rs
@@ -472,7 +472,8 @@ impl<G: GraphViewOps> VertexListOps for BoxedIter<BoxedIter<VertexView<G>>> {
 mod vertex_test {
     use crate::db::graph::Graph;
     use crate::db::mutation_api::AdditionOps;
-    use crate::db::view_api::*;
+    use crate::prelude::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_earliest_time() {
@@ -487,5 +488,18 @@ mod vertex_test {
         view = g.at(3);
         assert_eq!(view.vertex(1).expect("v").earliest_time().unwrap(), 0);
         assert_eq!(view.vertex(1).expect("v").latest_time().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_properties() {
+        let g = Graph::new(1);
+        let props = [("test".to_string(), Prop::Str("test".to_string()))];
+        g.add_vertex(0, 1, []).unwrap();
+        g.add_vertex(2, 1, props.clone()).unwrap();
+
+        let v1 = g.vertex(1).unwrap();
+        let v1_w = g.window(0, 1).vertex(1).unwrap();
+        assert_eq!(v1.properties(false), props.into());
+        assert_eq!(v1_w.properties(false), HashMap::default())
     }
 }

--- a/raphtory/src/db/vertex.rs
+++ b/raphtory/src/db/vertex.rs
@@ -95,8 +95,8 @@ impl<G: GraphViewOps> VertexViewOps for VertexView<G> {
     fn properties(&self, include_static: bool) -> HashMap<String, Prop> {
         let mut props: HashMap<String, Prop> = self
             .property_histories()
-            .iter()
-            .map(|(key, values)| (key.clone(), values.last().unwrap().1.clone()))
+            .into_iter()
+            .filter_map(|(key, values)| values.last().map(|v| (key, v.1.clone())))
             .collect();
 
         if include_static {

--- a/raphtory/src/db/vertex.rs
+++ b/raphtory/src/db/vertex.rs
@@ -93,20 +93,10 @@ impl<G: GraphViewOps> VertexViewOps for VertexView<G> {
     }
 
     fn properties(&self, include_static: bool) -> HashMap<String, Prop> {
-        let mut props: HashMap<String, Prop> = self
-            .property_histories()
+        self.property_names(include_static)
             .into_iter()
-            .filter_map(|(key, values)| values.last().map(|v| (key, v.1.clone())))
-            .collect();
-
-        if include_static {
-            for prop_name in self.graph.static_vertex_prop_names(self.vertex) {
-                if let Some(prop) = self.graph.static_vertex_prop(self.vertex, &prop_name) {
-                    props.insert(prop_name, prop);
-                }
-            }
-        }
-        props
+            .filter_map(|key| self.property(key.clone(), include_static).map(|v| (key, v)))
+            .collect()
     }
 
     fn property_histories(&self) -> HashMap<String, Vec<(i64, Prop)>> {

--- a/raphtory/src/db/view_api/edge.rs
+++ b/raphtory/src/db/view_api/edge.rs
@@ -54,20 +54,10 @@ pub trait EdgeViewOps: EdgeViewInternalOps<Self::Graph, Self::Vertex> {
     }
 
     fn properties(&self, include_static: bool) -> HashMap<String, Prop> {
-        let mut props: HashMap<String, Prop> = self
-            .property_histories()
-            .iter()
-            .map(|(key, values)| (key.clone(), values.last().unwrap().1.clone()))
-            .collect();
-
-        if include_static {
-            for prop_name in self.graph().static_edge_prop_names(self.eref()) {
-                if let Some(prop) = self.graph().static_edge_prop(self.eref(), &prop_name) {
-                    props.insert(prop_name, prop);
-                }
-            }
-        }
-        props
+        self.property_names(include_static)
+            .into_iter()
+            .filter_map(|key| self.property(&key, include_static).map(|v| (key, v)))
+            .collect()
     }
 
     fn property_histories(&self) -> HashMap<String, Vec<(i64, Prop)>> {

--- a/raphtory/src/lib.rs
+++ b/raphtory/src/lib.rs
@@ -117,7 +117,7 @@ pub mod python;
 pub mod graph_loader;
 
 pub mod prelude {
-    pub use crate::core::Prop;
+    pub use crate::core::{Prop, PropUnwrap};
     pub use crate::db::graph::Graph;
     pub use crate::db::graph_deletions::GraphWithDeletions;
     pub use crate::db::mutation_api::{AdditionOps, DeletionOps, PropertyAdditionOps};


### PR DESCRIPTION
### What changes were proposed in this pull request?

vertex and edge `properties` method now correctly handles the case where history is empty

### Why are the changes needed?

empty history was causing an unwrap on a `None` value

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

Added new test that reproduces the bug

### Issues

fixes #1070 

### Are there any further changes required?

no

