### PR TITLE
fix subgraph neighbours returning duplicates

### DIFF
--- a/raphtory/src/db/graph/views/vertex_subgraph.rs
+++ b/raphtory/src/db/graph/views/vertex_subgraph.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{
-        entities::{edges::edge_ref::EdgeRef, vertices::vertex_ref::VertexRef, VID, EID},
+        entities::{edges::edge_ref::EdgeRef, vertices::vertex_ref::VertexRef, EID, VID},
         Direction,
     },
     db::api::view::internal::{
@@ -8,6 +8,7 @@ use crate::{
     },
     prelude::GraphViewOps,
 };
+use itertools::Itertools;
 use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
@@ -41,7 +42,6 @@ impl<G: GraphViewOps> VertexSubgraph<G> {
 }
 
 impl<G: GraphViewOps> GraphOps for VertexSubgraph<G> {
-
     fn find_edge_id(&self, e_id: EID) -> Option<EdgeRef> {
         let edge_ref = self.graph.find_edge_id(e_id)?;
         let vid_src = self.local_vertex_ref(edge_ref.src())?;
@@ -139,12 +139,20 @@ impl<G: GraphViewOps> GraphOps for VertexSubgraph<G> {
         d: Direction,
         layer: Option<usize>,
     ) -> Box<dyn Iterator<Item = VertexRef> + Send> {
-        Box::new(self.vertex_edges(v, d, layer).map(|e| e.remote()))
+        match d {
+            Direction::BOTH => Box::new(
+                self.neighbours(v, Direction::IN, layer)
+                    .merge(self.neighbours(v, Direction::OUT, layer))
+                    .dedup(),
+            ),
+            _ => Box::new(self.vertex_edges(v, d, layer).map(|e| e.remote())),
+        }
     }
 }
 
 #[cfg(test)]
 mod subgraph_tests {
+    use crate::algorithms::triangle_count::triangle_count;
     use crate::prelude::*;
 
     #[test]
@@ -156,5 +164,42 @@ mod subgraph_tests {
         let sg = g.subgraph([1, 2]);
         let actual = sg.materialize().unwrap().into_events().unwrap();
         assert_eq!(actual, sg);
+    }
+
+    #[test]
+    fn test_triangle_count() {
+        let graph = Graph::new();
+        let edges = vec![
+            (1, 2, 1),
+            (1, 3, 2),
+            (1, 4, 3),
+            (3, 1, 4),
+            (3, 4, 5),
+            (3, 5, 6),
+            (4, 5, 7),
+            (5, 6, 8),
+            (5, 8, 9),
+            (7, 5, 10),
+            (8, 5, 11),
+            (1, 9, 12),
+            (9, 1, 13),
+            (6, 3, 14),
+            (4, 8, 15),
+            (8, 3, 16),
+            (5, 10, 17),
+            (10, 5, 18),
+            (10, 8, 19),
+            (1, 11, 20),
+            (11, 1, 21),
+            (9, 11, 22),
+            (11, 9, 23),
+        ];
+        for (src, dst, ts) in edges {
+            graph.add_edge(ts, src, dst, NO_PROPS, None).unwrap();
+        }
+        let subgraph = graph.subgraph(graph.vertices());
+        let ts = triangle_count(&subgraph, None);
+        let tg = triangle_count(&graph, None);
+        assert_eq!(ts, tg)
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

the neighbours for subgraph are no longer duplicate

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

triangle count for subgraph and original graph now matches

### Issues


### Are there any further changes required?

more tests for subgraphs

