### PR TITLE
improved formatting git hook

### DIFF
--- a/dev/hooks/pre-commit
+++ b/dev/hooks/pre-commit
@@ -8,6 +8,11 @@ RESULT=$?
 
 # If the result is non-zero (i.e., there were formatting errors), abort the commit
 if [ $RESULT -ne 0 ]; then
-    echo "There are formatting errors. Please run 'cargo +nightly fmt' and fix them before committing."
-    exit 1
+  if [ -z "$(git ls-files --others --modified --exclude-standard)" ]; then
+    echo "There are formatting errors. Running cargo fmt. Please check the formatting changes and add them before committing."
+    cargo +nightly fmt --all
+  else
+    echo "There are formatting errors and un-staged files. Please run 'cargo +nightly fmt --all' to fix the formatting before committing."
+  fi
+   exit 1
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes the commit hook such that it automatically runs the formatter if there are no untracked or untagged modifications. 
This makes the formatting changes easy to undo if they cause problems for any reason and also easy to apply. 

### Why are the changes needed?

Should make the commit hook less annoying and code more likely to be formatted.

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

manually tested it against different dirty working trees

### Issues

### Are there any further changes required?


