### PR TITLE
make docstring signatures work with type hints

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -64,7 +64,7 @@ requests==2.31.0
 six==1.16.0
 snowballstemmer==2.2.0
 soupsieve==2.4.1
-Sphinx==6.2.1
+sphinx==6.2.1
 sphinx-copybutton==0.5.2
 sphinx-toggleprompt==0.4.0
 sphinx_design==0.4.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,12 +2,19 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+from typing import Tuple, Any
+
 from sphinx.ext.autosummary import _import_by_name
 
 import os
+import re
 import sys
 import warnings
 import raphtory
+from sphinx.util.typing import stringify_annotation
+from sphinx.util import inspect
+import typing
+from typing import *
 
 import jinja2
 
@@ -18,6 +25,10 @@ project = 'Raphtory'
 copyright = '2023, Pometry'
 author = 'Pometry'
 release = '2023'
+
+
+
+
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -61,17 +72,14 @@ header = f"""\
 
 """
 
-
 html_context = {
     "header": header,
 }
-
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "pydata_sphinx_theme"
-
 
 html_static_path = ['_static', 'images']
 html_css_files = [
@@ -96,6 +104,9 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 autosummary_generate = True
 autosummary_imported_members = True
+autodoc_typehints = "both"
+autodoc_typehints_description_target = "documented"
+autodoc_type_aliases = {}
 
 
 # numpydoc
@@ -111,6 +122,57 @@ def rstjinja(app, docname, source):
     rendered = app.builder.templates.render_string(src, app.config.html_context)
     source[0] = rendered
 
+
+def add_typehints(app, objtype: str, name: str, obj,
+                  options: dict, args: str, retann: str) -> tuple[str | Any, str | Any] | tuple[str, None]:
+    """Record type hints to env object."""
+    if not hasattr(obj, "__annotations__"):
+        if app.config.autodoc_typehints_format == 'short':
+            mode = 'smart'
+        else:
+            mode = 'fully-qualified'
+
+        try:
+            if callable(obj):
+                exec_parts = [f"def _annotations_moc"]
+                if args is not None:
+                    exec_parts.append(args)
+                else:
+                    exec_parts.append("()")
+                if retann:
+                    exec_parts.append(f" -> {retann}")
+                exec_parts.append(":\n    pass")
+                res = globals()
+                exec("".join(exec_parts), res)
+
+                annotations = app.env.temp_data.setdefault('annotations', {})
+                annotation = annotations.setdefault(name, {})
+                sig = inspect.signature(res["_annotations_moc"], type_aliases=app.config.autodoc_type_aliases)
+                for param in sig.parameters.values():
+                    if param.annotation is not param.empty:
+                        annotation[param.name] = stringify_annotation(param.annotation, mode)
+                if sig.return_annotation is not sig.empty:
+                    retann = stringify_annotation(sig.return_annotation, mode)
+                    annotation['return'] = retann
+                kwargs = {}
+                if app.config.autodoc_typehints in ('none', 'description'):
+                    kwargs.setdefault('show_annotation', False)
+                if app.config.autodoc_typehints_format == "short":
+                    kwargs.setdefault('unqualified_typehints', True)
+                args = inspect.stringify_signature(sig, **kwargs)
+                if args:
+                    matched = re.match(r'^(\(.*\))\s+->\s+(.*)$', args)
+                    if matched:
+                        args = matched.group(1)
+                        retann = matched.group(2)
+                        return args, retann
+                    else:
+                        return args, None
+        except (TypeError, ValueError) as e:
+            e
+            pass
+
+
 def setup(app):
     app.connect("source-read", rstjinja)
-
+    app.connect('autodoc-process-signature', add_typehints, priority=0)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,8 +1,10 @@
+# do not add from __future__ import annotations as it will break the typehints parsing
+# (I think this is a bug in autodoc and may be fixed at some point)
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-from typing import Tuple, Any
 
 from sphinx.ext.autosummary import _import_by_name
 
@@ -13,8 +15,10 @@ import warnings
 import raphtory
 from sphinx.util.typing import stringify_annotation
 from sphinx.util import inspect
-import typing
+
+# for type annotations resolution (need to actually import everything that we want to use in a type hint in the docs)
 from typing import *
+from raphtory import *
 
 import jinja2
 
@@ -131,7 +135,8 @@ def add_typehints(app, objtype: str, name: str, obj,
     signatures that are defined in the docstring.
     """
     if not hasattr(obj, "__annotations__"):
-        # If an object has annotations, typehints extension will handle it, otherwise, we need to look at the signature for the type hints
+        # If an object has annotations, typehints extension will handle it, otherwise,
+        # we need to look at the signature for the type hints
 
         # make sure we set the configuration option in the same way
         if app.config.autodoc_typehints_format == 'short':

--- a/raphtory/src/python/graph/properties/constant_props.rs
+++ b/raphtory/src/python/graph/properties/constant_props.rs
@@ -89,6 +89,9 @@ impl PyConstProperties {
 
     /// get(key: str) -> Any | None
     ///
+    /// Arguments:
+    ///     key: the name of the property
+    ///
     /// get property value by key (returns `None` if key does not exist)
     pub fn get(&self, key: &str) -> Option<Prop> {
         // Fixme: Add option to specify default?


### PR DESCRIPTION
### What changes were proposed in this pull request?

Hacked into autodocs to make docstring signatures and type hints work smoothly together

### Why are the changes needed?

much cleaner and easier to write documentation

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

the docs look better

### Issues

### Are there any further changes required?

writing more signatures

