### PR TITLE
Fix __getitem__ for python TemporalProperties

### DIFF
--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -264,6 +264,13 @@ def test_name():
     assert g.vertex("Hamza").name() == "Hamza"
 
 
+def test_getitem():
+    g = Graph()
+    g.add_vertex(0, 1, {"cost": 0})
+    g.add_vertex(1, 1, {"cost": 1})
+
+    assert g.vertex(1).properties.temporal.get("cost") == g.vertex(1).properties.temporal["cost"]
+
 def test_graph_properties():
     g = create_graph()
 

--- a/raphtory/src/python/graph/properties/temporal_props.rs
+++ b/raphtory/src/python/graph/properties/temporal_props.rs
@@ -129,25 +129,25 @@ impl PyTemporalProperties {
             .collect()
     }
 
+    /// __getitem__(key: str) -> TemporalProp
+    ///
     /// Get property value for `key`
     ///
     /// Returns:
-    ///     TemporalProp: the property view
+    ///     the property view
     ///
     /// Raises:
     ///     KeyError: if property `key` does not exist
-    fn __getitem__(&self, key: &str) -> PyResult<Prop> {
-        let v = self
-            .props
-            .get(key)
-            .ok_or(PyKeyError::new_err("No such property"))?;
-        Ok(v.latest().unwrap())
+    fn __getitem__(&self, key: &str) -> PyResult<DynTemporalProperty> {
+        self.get(key).ok_or(PyKeyError::new_err("No such property"))
     }
 
+    /// get(key: str) -> Optional[TemporalProp]
+    ///
     /// Get property value for `key` if it exists
     ///
     /// Returns:
-    ///     Option[TemporalProp]: the property view
+    ///     the property view if it exists, otherwise `None`
     fn get(&self, key: &str) -> Option<DynTemporalProperty> {
         // Fixme: Add option to specify default?
         self.props.get(key)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`get` and `__getitem__` now both return the full history

### Why are the changes needed?

make these methods behave as expected

### Does this PR introduce any user-facing change? If yes is this documented?

the new behaviour is consistent with the documentation

### How was this patch tested?

added test reproducing the bug

### Issues

fixes #1144 

### Are there any further changes required?


