### PR TITLE
Added constant props to pandas loaders

### DIFF
--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -1608,9 +1608,9 @@ def test_load_from_pandas_with_types():
     g.load_edges_from_pandas(edges_df, "src", "dst", "time", ["weight", "marbles"], const_props=["marbles_const"], shared_const_props={"type": "Edge", "tag": "test_tag"}, layer="test_layer")
 
     assert g.layers(["test_layer"]).edges().src().id().collect() == [1, 2, 3, 4, 5]
-    assert g.edges().properties().constant.get("type").collect() == [{'test_layer': 'Edge'},{'test_layer': 'Edge'},{'test_layer': 'Edge'},{'test_layer': 'Edge'},{'test_layer': 'Edge'}]
-    assert g.edges().properties().constant.get("tag").collect() == [{'test_layer': 'test_tag'},{'test_layer': 'test_tag'},{'test_layer': 'test_tag'},{'test_layer': 'test_tag'},{'test_layer': 'test_tag'}]
-    assert g.edges().properties().constant.get("marbles_const").collect() == [{'test_layer': 'red'},{'test_layer': 'blue'},{'test_layer': 'green'},{'test_layer': 'yellow'},{'test_layer': 'purple'}]
+    assert g.edges().properties.constant.get("type").collect() == [{'test_layer': 'Edge'},{'test_layer': 'Edge'},{'test_layer': 'Edge'},{'test_layer': 'Edge'},{'test_layer': 'Edge'}]
+    assert g.edges().properties.constant.get("tag").collect() == [{'test_layer': 'test_tag'},{'test_layer': 'test_tag'},{'test_layer': 'test_tag'},{'test_layer': 'test_tag'},{'test_layer': 'test_tag'}]
+    assert g.edges().properties.constant.get("marbles_const").collect() == [{'test_layer': 'red'},{'test_layer': 'blue'},{'test_layer': 'green'},{'test_layer': 'yellow'},{'test_layer': 'purple'}]
 
 
     g = Graph()
@@ -1630,6 +1630,29 @@ def test_load_from_pandas_with_types():
     assert g.layers(["layer 1","layer 2"]).edges().src().id().collect() == [1,2]
     assert g.layers(["layer 1","layer 2","layer 3"]).edges().src().id().collect() == [1,2,3]
     assert g.layers(["layer 1","layer 4","layer 5"]).edges().src().id().collect() == [1,4,5]
+
+    g = Graph.load_from_pandas(edges_df, src="src", dst="dst", time="time", props=["weight", "marbles"],
+                               vertex_df=vertices_df, vertex_col="id", vertex_time_col="time", vertex_props=["name"],layer_in_df="layers")
+
+    g.load_vertex_props_from_pandas(vertices_df, "id", const_props=["type"], shared_const_props={"tag": "test_tag"})
+    assert g.vertices().properties.constant.get("type").collect() == ["Person 1", "Person 2", "Person 3", "Person 4", "Person 5", "Person 6"]
+    assert g.vertices().properties.constant.get("tag").collect() == ["test_tag", "test_tag", "test_tag", "test_tag", "test_tag", "test_tag"]
+
+    # TODO Currently can't be tested because of the below issue
+    #g.load_edge_props_from_pandas(edges_df, "src", "dst", const_props=["marbles_const"], shared_const_props={"tag": "test_tag"},layer_in_df="layers")
+    #assert g.layers(['layer 1']).edges().properties.constant.get("marbles_const").collect() == ["red"]
+    #assert g.edges()#.properties.constant.get("tag").collect() == ["red"]
+
+#TODO this test is failing
+# def test_edge_layer():
+#     g = Graph()
+#     g.add_edge(1,1,2,layer="layer 1")
+#     g.add_edge(1,2,3,layer="layer 2")
+#     g.add_edge_properties(1,2, {"test_prop": "test_val"},layer="layer 1")
+#     g.add_edge_properties(2,3, {"test_prop": "test_val 2"},layer="layer 2")
+#     assert g.edges().properties.constant.get("test_prop").collect() == ["test_val"]
+
+
 
 
 def test_hits_algorithm():

--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -1638,26 +1638,10 @@ def test_load_from_pandas_with_types():
     assert g.vertices().properties.constant.get("type").collect() == ["Person 1", "Person 2", "Person 3", "Person 4", "Person 5", "Person 6"]
     assert g.vertices().properties.constant.get("tag").collect() == ["test_tag", "test_tag", "test_tag", "test_tag", "test_tag", "test_tag"]
 
-    # TODO Currently can't be tested because of the below issue
-    #g.load_edge_props_from_pandas(edges_df, "src", "dst", const_props=["marbles_const"], shared_const_props={"tag": "test_tag"},layer_in_df="layers")
-    #assert g.layers(['layer 1']).edges().properties.constant.get("marbles_const").collect() == ["red"]
-    #assert g.edges()#.properties.constant.get("tag").collect() == ["red"]
+    g.load_edge_props_from_pandas(edges_df, "src", "dst", const_props=["marbles_const"], shared_const_props={"tag": "test_tag"},layer_in_df="layers")
+    assert g.layers(["layer 1", "layer 2", "layer 3"]).edges().properties.constant.get("marbles_const").collect() == [{'layer 1': 'red'}, {'layer 2': 'blue'}, {'layer 3': 'green'}]
+    assert g.edges().properties.constant.get("tag").collect() == [{'layer 1': 'test_tag'}, {'layer 2': 'test_tag'}, {'layer 3': 'test_tag'}, {'layer 4': 'test_tag'}, {'layer 5': 'test_tag'}]
 
-#TODO this test is failing
-# def test_edge_layer():
-#     g = Graph()
-#     g.add_edge(1,1,2,layer="layer 1")
-#     g.add_edge(1,2,3,layer="layer 2")
-#     g.add_edge_properties(1,2, {"test_prop": "test_val"},layer="layer 1")
-#     g.add_edge_properties(2,3, {"test_prop": "test_val 2"},layer="layer 2")
-#     assert g.edges().properties.constant.get("test_prop").collect() == ["test_val"]
-
-
-
-
-def test_hits_algorithm():
-    g = graph_loader.lotr_graph()
-    assert algorithms.hits(g).get('Aldor') == (0.0035840950440615416, 0.007476256228983402)
 
 def test_edge_layer():
     g = Graph()
@@ -1666,3 +1650,9 @@ def test_edge_layer():
     g.add_edge_properties(1, 2, {"test_prop": "test_val"}, layer="layer 1")
     g.add_edge_properties(2, 3, {"test_prop": "test_val 2"}, layer="layer 2")
     assert g.edges().properties.constant.get("test_prop") == [{'layer 1': 'test_val'}, {'layer 2': 'test_val 2'}]
+
+
+def test_hits_algorithm():
+    g = graph_loader.lotr_graph()
+    assert algorithms.hits(g).get('Aldor') == (0.0035840950440615416, 0.007476256228983402)
+

--- a/raphtory/src/core/mod.rs
+++ b/raphtory/src/core/mod.rs
@@ -374,6 +374,12 @@ impl From<Vec<Prop>> for Prop {
     }
 }
 
+impl From<&Prop> for Prop {
+    fn from(value: &Prop) -> Self {
+        value.clone()
+    }
+}
+
 pub trait IntoPropMap {
     fn into_prop_map(self) -> Prop;
 }

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -15,9 +15,11 @@ use crate::{
 use pyo3::prelude::*;
 
 use crate::{
-    db::api::view::internal::{DynamicGraph, IntoDynamic},
+    db::{
+        api::view::internal::{DynamicGraph, IntoDynamic},
+        graph::{edge::EdgeView, vertex::VertexView},
+    },
     python::graph::pandas::{load_edges_props_from_df, load_vertex_props_from_df},
-    graph::{edge::EdgeView, vertex::VertexView},
 };
 use std::{
     collections::HashMap,

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -233,7 +233,7 @@ impl PyGraph {
     }
 
     #[staticmethod]
-    #[pyo3(signature = (edges_df, src = "source", dst = "destination", time = "time", props = None, layer = None, layer_in_df = None, vertex_df = None, vertex_col = None, vertex_time_col = None, vertex_props = None))]
+    #[pyo3(signature = (edges_df, src = "source", dst = "destination", time = "time", props = None, layer = None, layer_in_df = None, vertex_df = None, vertex_col = None, vertex_time_col = None, vertex_props = None, vertex_type = None, vertex_type_in_df = None))]
     fn load_from_pandas(
         edges_df: &PyAny,
         src: &str,
@@ -246,6 +246,8 @@ impl PyGraph {
         vertex_col: Option<&str>,
         vertex_time_col: Option<&str>,
         vertex_props: Option<Vec<&str>>,
+        vertex_type: Option<&str>,
+        vertex_type_in_df: Option<&str>,
     ) -> Result<Graph, GraphError> {
         let graph = PyGraph {
             graph: Graph::new(),
@@ -259,24 +261,36 @@ impl PyGraph {
                 vertex_col,
                 vertex_time_col,
                 vertex_props,
+                vertex_type,
+                vertex_type_in_df,
             )?;
         }
         Ok(graph.graph)
     }
 
-    #[pyo3(signature = (vertices_df, vertex_col = "id", time_col = "time", props = None))]
+    #[pyo3(signature = (vertices_df, vertex_col = "id", time_col = "time", props = None, vertex_type = None, type_in_df = None))]
     fn load_vertices_from_pandas(
         &self,
         vertices_df: &PyAny,
         vertex_col: &str,
         time_col: &str,
         props: Option<Vec<&str>>,
+        vertex_type: Option<&str>,
+        type_in_df: Option<&str>,
     ) -> Result<(), GraphError> {
         let graph = &self.graph;
         Python::with_gil(|py| {
             let df = process_pandas_py_df(vertices_df, py)?;
-            load_vertices_from_df(&df, vertex_col, time_col, props, graph)
-                .map_err(|e| GraphLoadException::new_err(format!("{:?}", e)))?;
+            load_vertices_from_df(
+                &df,
+                vertex_col,
+                time_col,
+                props,
+                vertex_type,
+                type_in_df,
+                graph,
+            )
+            .map_err(|e| GraphLoadException::new_err(format!("{:?}", e)))?;
 
             Ok::<(), PyErr>(())
         })

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -20,6 +20,7 @@ use std::{
     fmt::{Debug, Formatter},
     path::{Path, PathBuf},
 };
+use crate::db::api::mutation::CollectProperties;
 
 use super::pandas::{
     load_edges_from_df, load_vertices_from_df, process_pandas_py_df, GraphLoadException,
@@ -233,26 +234,28 @@ impl PyGraph {
     }
 
     #[staticmethod]
-    #[pyo3(signature = (edges_df, src = "source", dst = "destination", time = "time", props = None, layer = None, layer_in_df = None, vertex_df = None, vertex_col = None, vertex_time_col = None, vertex_props = None, vertex_type = None, vertex_type_in_df = None))]
+    #[pyo3(signature = (edges_df, src = "source", dst = "destination", time = "time", props = None, const_props=None,shared_const_props=None,layer = None, layer_in_df = None, vertex_df = None, vertex_col = None, vertex_time_col = None, vertex_props = None, vertex_const_props = None, vertex_shared_const_props = None))]
     fn load_from_pandas(
         edges_df: &PyAny,
         src: &str,
         dst: &str,
         time: &str,
         props: Option<Vec<&str>>,
+        const_props: Option<Vec<&str>>,
+        shared_const_props: Option<HashMap<String,Prop>>,
         layer: Option<&str>,
         layer_in_df: Option<&str>,
         vertex_df: Option<&PyAny>,
         vertex_col: Option<&str>,
         vertex_time_col: Option<&str>,
         vertex_props: Option<Vec<&str>>,
-        vertex_type: Option<&str>,
-        vertex_type_in_df: Option<&str>,
+        vertex_const_props: Option<Vec<&str>>,
+        vertex_shared_const_props: Option<HashMap<String,Prop>>,
     ) -> Result<Graph, GraphError> {
         let graph = PyGraph {
             graph: Graph::new(),
         };
-        graph.load_edges_from_pandas(edges_df, src, dst, time, props, layer, layer_in_df)?;
+        graph.load_edges_from_pandas(edges_df, src, dst, time, props, const_props,shared_const_props, layer, layer_in_df)?;
         if let (Some(vertex_df), Some(vertex_col), Some(vertex_time_col)) =
             (vertex_df, vertex_col, vertex_time_col)
         {
@@ -261,22 +264,22 @@ impl PyGraph {
                 vertex_col,
                 vertex_time_col,
                 vertex_props,
-                vertex_type,
-                vertex_type_in_df,
+                vertex_const_props,
+                vertex_shared_const_props,
             )?;
         }
         Ok(graph.graph)
     }
 
-    #[pyo3(signature = (vertices_df, vertex_col = "id", time_col = "time", props = None, vertex_type = None, type_in_df = None))]
+    #[pyo3(signature = (vertices_df, vertex_col = "id", time_col = "time", props = None, const_props = None, shared_const_props = None))]
     fn load_vertices_from_pandas(
         &self,
         vertices_df: &PyAny,
         vertex_col: &str,
         time_col: &str,
         props: Option<Vec<&str>>,
-        vertex_type: Option<&str>,
-        type_in_df: Option<&str>,
+        const_props: Option<Vec<&str>>,
+        shared_const_props: Option<HashMap<String,Prop>>,
     ) -> Result<(), GraphError> {
         let graph = &self.graph;
         Python::with_gil(|py| {
@@ -286,8 +289,8 @@ impl PyGraph {
                 vertex_col,
                 time_col,
                 props,
-                vertex_type,
-                type_in_df,
+                const_props,
+                shared_const_props,
                 graph,
             )
             .map_err(|e| GraphLoadException::new_err(format!("{:?}", e)))?;
@@ -298,7 +301,7 @@ impl PyGraph {
         Ok(())
     }
 
-    #[pyo3(signature = (edge_df, src_col = "source", dst_col = "destination", time_col = "time", props = None, layer=None,layer_in_df=None))]
+    #[pyo3(signature = (edge_df, src_col = "source", dst_col = "destination", time_col = "time", props = None, const_props=None,shared_const_props=None,layer=None,layer_in_df=None))]
     fn load_edges_from_pandas(
         &self,
         edge_df: &PyAny,
@@ -306,6 +309,8 @@ impl PyGraph {
         dst_col: &str,
         time_col: &str,
         props: Option<Vec<&str>>,
+        const_props: Option<Vec<&str>>,
+        shared_const_props: Option<HashMap<String,Prop>>,
         layer: Option<&str>,
         layer_in_df: Option<&str>,
     ) -> Result<(), GraphError> {
@@ -318,6 +323,8 @@ impl PyGraph {
                 dst_col,
                 time_col,
                 props,
+                const_props,
+                shared_const_props,
                 layer,
                 layer_in_df,
                 graph,

--- a/raphtory/src/python/graph/pandas.rs
+++ b/raphtory/src/python/graph/pandas.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::hash::Hash;
 use arrow2::{
     array::{Array, BooleanArray, PrimitiveArray, Utf8Array},
     ffi,
@@ -8,6 +10,7 @@ use pyo3::{
 };
 
 use crate::{core::utils::errors::GraphError, prelude::*};
+use crate::db::api::mutation::CollectProperties;
 
 fn i64_opt_into_u64_opt(x: Option<&i64>) -> Option<u64> {
     x.map(|x| (*x).try_into().unwrap())
@@ -46,13 +49,13 @@ pub(crate) fn process_pandas_py_df(df: &PyAny, py: Python) -> PyResult<PretendDF
     Ok(df)
 }
 
-pub(crate) fn load_vertices_from_df<'a, S: AsRef<str>>(
+pub(crate) fn load_vertices_from_df<'a>(
     df: &'a PretendDF,
     vertex_id: &str,
     time: &str,
     props: Option<Vec<&str>>,
-    vertex_type: Option<S>,
-    type_in_df: Option<S>,
+    const_props: Option<Vec<&str>>,
+    shared_const_props: Option<HashMap<String,Prop>>,
     graph: &Graph,
 ) -> Result<(), GraphError> {
     let prop_iter = props
@@ -62,27 +65,34 @@ pub(crate) fn load_vertices_from_df<'a, S: AsRef<str>>(
         .reduce(combine_prop_iters)
         .unwrap_or_else(|| Box::new(std::iter::repeat(vec![])));
 
-    let v_type = lift_layer(vertex_type, type_in_df, &df)
-        .map(|op| op.map(|s| vec![("type", Prop::str(s.as_str()))]));
+    let const_prop_iter = const_props
+        .unwrap_or_default()
+        .into_iter()
+        .map(|name| lift_property(name, &df))
+        .reduce(combine_prop_iters)
+        .unwrap_or_else(|| Box::new(std::iter::repeat(vec![])));
+
+
 
     if let (Some(vertex_id), Some(time)) = (df.iter_col::<u64>(vertex_id), df.iter_col::<i64>(time))
     {
         let iter = vertex_id.map(|i| i.copied()).zip(time);
-        load_vertices_from_num_iter(graph, iter, prop_iter, v_type)?;
+        load_vertices_from_num_iter(graph, iter, prop_iter, const_prop_iter,shared_const_props)?;
     } else if let (Some(vertex_id), Some(time)) =
         (df.iter_col::<i64>(vertex_id), df.iter_col::<i64>(time))
     {
         let iter = vertex_id.map(i64_opt_into_u64_opt).zip(time);
-        load_vertices_from_num_iter(graph, iter, prop_iter, v_type)?;
+        load_vertices_from_num_iter(graph, iter, prop_iter, const_prop_iter,shared_const_props)?;
     } else if let (Some(vertex_id), Some(time)) =
         (df.utf8::<i32>(vertex_id), df.iter_col::<i64>(time))
     {
         let iter = vertex_id.into_iter().zip(time);
-        for (((vertex_id, time), props), types) in iter.zip(prop_iter).zip(v_type) {
+        for (((vertex_id, time), props), const_props) in iter.zip(prop_iter).zip(const_prop_iter) {
             if let (Some(vertex_id), Some(time)) = (vertex_id, time) {
                 graph.add_vertex(*time, vertex_id, props)?;
-                if let Some(types) = types {
-                    graph.add_vertex_properties(vertex_id, types)?;
+                graph.add_vertex_properties(vertex_id, const_props)?;
+                if let Some(shared_const_props) = &shared_const_props {
+                    graph.add_vertex_properties(vertex_id, shared_const_props.iter())?;
                 }
             }
         }
@@ -90,11 +100,12 @@ pub(crate) fn load_vertices_from_df<'a, S: AsRef<str>>(
         (df.utf8::<i64>(vertex_id), df.iter_col::<i64>(time))
     {
         let iter = vertex_id.into_iter().zip(time);
-        for (((vertex_id, time), props), types) in iter.zip(prop_iter).zip(v_type) {
+        for (((vertex_id, time), props), const_props) in iter.zip(prop_iter).zip(const_prop_iter) {
             if let (Some(vertex_id), Some(time)) = (vertex_id, time) {
                 graph.add_vertex(*time, vertex_id, props)?;
-                if let Some(types) = types {
-                    graph.add_vertex_properties(vertex_id, types)?;
+                graph.add_vertex_properties(vertex_id, const_props)?;
+                if let Some(shared_const_props) = &shared_const_props {
+                    graph.add_vertex_properties(vertex_id, shared_const_props)?;
                 }
             }
         }
@@ -113,11 +124,20 @@ pub(crate) fn load_edges_from_df<'a, S: AsRef<str>>(
     dst: &str,
     time: &str,
     props: Option<Vec<&str>>,
+    const_props: Option<Vec<&str>>,
+    shared_const_props: Option<HashMap<String,Prop>>,
     layer: Option<S>,
     layer_in_df: Option<S>,
     graph: &Graph,
 ) -> Result<(), GraphError> {
     let prop_iter = props
+        .unwrap_or_default()
+        .into_iter()
+        .map(|name| lift_property(name, &df))
+        .reduce(combine_prop_iters)
+        .unwrap_or_else(|| Box::new(std::iter::repeat(vec![])));
+
+    let const_prop_iter = const_props
         .unwrap_or_default()
         .into_iter()
         .map(|name| lift_property(name, &df))
@@ -135,7 +155,7 @@ pub(crate) fn load_edges_from_df<'a, S: AsRef<str>>(
             .map(|i| i.copied())
             .zip(dst.map(|i| i.copied()))
             .zip(time);
-        load_edges_from_num_iter(&graph, triplets, prop_iter, layer)?;
+        load_edges_from_num_iter(&graph, triplets, prop_iter, const_prop_iter, shared_const_props, layer)?;
     } else if let (Some(src), Some(dst), Some(time)) = (
         df.iter_col::<i64>(src),
         df.iter_col::<i64>(dst),
@@ -145,16 +165,20 @@ pub(crate) fn load_edges_from_df<'a, S: AsRef<str>>(
             .map(i64_opt_into_u64_opt)
             .zip(dst.map(i64_opt_into_u64_opt))
             .zip(time);
-        load_edges_from_num_iter(&graph, triplets, prop_iter, layer)?;
+        load_edges_from_num_iter(&graph, triplets, prop_iter, const_prop_iter,shared_const_props, layer)?;
     } else if let (Some(src), Some(dst), Some(time)) = (
         df.utf8::<i32>(src),
         df.utf8::<i32>(dst),
         df.iter_col::<i64>(time),
     ) {
         let triplets = src.into_iter().zip(dst.into_iter()).zip(time.into_iter());
-        for ((((src, dst), time), props), layer) in triplets.zip(prop_iter).zip(layer) {
+        for (((((src, dst), time), props), const_props), layer) in triplets.zip(prop_iter).zip(const_prop_iter).zip(layer) {
             if let (Some(src), Some(dst), Some(time)) = (src, dst, time) {
                 graph.add_edge(*time, src, dst, props, layer.as_deref())?;
+                graph.add_edge_properties(src, dst, const_props,layer.as_deref())?;
+                if let Some(shared_const_props) = &shared_const_props {
+                    graph.add_edge_properties(src, dst, shared_const_props.iter(),layer.as_deref())?;
+                }
             }
         }
     } else if let (Some(src), Some(dst), Some(time)) = (
@@ -163,9 +187,13 @@ pub(crate) fn load_edges_from_df<'a, S: AsRef<str>>(
         df.iter_col::<i64>(time),
     ) {
         let triplets = src.into_iter().zip(dst.into_iter()).zip(time.into_iter());
-        for ((((src, dst), time), props), layer) in triplets.zip(prop_iter).zip(layer) {
+        for (((((src, dst), time), props), const_props), layer) in triplets.zip(prop_iter).zip(const_prop_iter).zip(layer) {
             if let (Some(src), Some(dst), Some(time)) = (src, dst, time) {
                 graph.add_edge(*time, src, dst, props, layer.as_deref())?;
+                graph.add_edge_properties(src, dst, const_props,layer.as_deref())?;
+                if let Some(shared_const_props) = &shared_const_props {
+                    graph.add_edge_properties(src, dst, shared_const_props.iter(),layer.as_deref())?;
+                }
             }
         }
     } else {
@@ -277,11 +305,17 @@ fn load_edges_from_num_iter<
     graph: &Graph,
     edges: I,
     props: PI,
+    const_props: PI,
+    shared_const_props: Option<HashMap<String, Prop>>,
     layer: IL,
 ) -> Result<(), GraphError> {
-    for ((((src, dst), time), edge_props), layer) in edges.zip(props).zip(layer) {
+    for (((((src, dst), time), edge_props),const_props), layer) in edges.zip(props).zip(const_props).zip(layer) {
         if let (Some(src), Some(dst), Some(time)) = (src, dst, time) {
             graph.add_edge(*time, src, dst, edge_props, layer.as_deref())?;
+            graph.add_edge_properties(src, dst, const_props,layer.as_deref())?;
+            if let Some(shared_const_props) = &shared_const_props {
+                graph.add_edge_properties(src, dst, shared_const_props.iter(),layer.as_deref())?;
+            }
         }
     }
     Ok(())
@@ -292,18 +326,20 @@ fn load_vertices_from_num_iter<
     S: AsRef<str>,
     I: Iterator<Item = (Option<u64>, Option<&'a i64>)>,
     PI: Iterator<Item = Vec<(S, Prop)>>,
-    IL: Iterator<Item = Option<Vec<(S, Prop)>>>,
 >(
     graph: &Graph,
     vertices: I,
     props: PI,
-    types: IL,
+    const_props: PI,
+    shared_const_props: Option<HashMap<String, Prop>>,
 ) -> Result<(), GraphError> {
-    for (((vertex, time), edge_props), types) in vertices.zip(props).zip(types) {
-        if let (Some(v), Some(t), props, types) = (vertex, time, edge_props, types) {
+    for (((vertex, time), props), const_props) in vertices.zip(props).zip(const_props) {
+        if let (Some(v), Some(t), props, const_props) = (vertex, time, props,const_props) {
             graph.add_vertex(*t, v, props)?;
-            if let Some(types) = types {
-                graph.add_vertex_properties(v, types)?;
+            graph.add_vertex_properties(v, const_props)?;
+
+            if let Some(shared_const_props) = &shared_const_props {
+                graph.add_vertex_properties(v, shared_const_props.iter())?;
             }
         }
     }
@@ -434,6 +470,8 @@ mod test {
             "dst",
             "time",
             Some(vec!["prop1", "prop2"]),
+            None,
+            None,
             layer,
             layer_in_df,
             &graph,
@@ -491,7 +529,7 @@ mod test {
         };
         let graph = Graph::new();
 
-        load_vertices_from_df(&df, "id", "time", Some(vec!["name"]), &graph)
+        load_vertices_from_df(&df, "id", "time", Some(vec!["name"]), None,None, &graph)
             .expect("failed to load vertices from pretend df");
 
         let actual = graph


### PR DESCRIPTION
### What changes were proposed in this pull request?
I have added constant props for vertices and edges in the pandas data loaders. I have also introduced tests for these and the already established layer arguments for edges

### Why are the changes needed?
There are several instances where we have multiple vertex types we wish to label - without these arguments a user is forced to manually add them drastically reducing the point of the automatic pandas loading

### Does this PR introduce any user-facing change? If yes is this documented?
Yes and TBD

### How was this patch tested?
New tests as specified above.

### Are there any further changes required?
Possibly more expansions to this as we see how people use them.
