### PR TITLE
Make GraphQL server mutable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "ordered-float 3.7.0",
+ "parking_lot",
  "poem",
  "raphtory",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,6 +2827,7 @@ dependencies = [
  "raphtory",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-opentelemetry",

--- a/raphtory-graphql/Cargo.toml
+++ b/raphtory-graphql/Cargo.toml
@@ -26,7 +26,7 @@ tokio = {version = "1.18.2", features = ["full"]}
 async-graphql = {version = "5.0.5", features = ["dynamic-schema"]}
 dynamic-graphql = "0.7.3"
 async-graphql-poem = "5.0.5"
-
+parking_lot = { version = "0.12" , features = ["serde", "arc_lock", "send_guard"] }
 futures-util = "0.3.0"
 async-stream = "0.3.0"
 

--- a/raphtory-graphql/Cargo.toml
+++ b/raphtory-graphql/Cargo.toml
@@ -41,4 +41,5 @@ ordered-float = "3.7.0"
 
 [dev-dependencies]
 serde_json = "1.0"
+tempfile = "3.6.0"
 

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -10,6 +10,7 @@ use std::{
 };
 use walkdir::WalkDir;
 
+#[derive(Default)]
 pub(crate) struct Data {
     pub(crate) graphs: RwLock<HashMap<String, IndexedGraph<DynamicGraph>>>,
 }

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -1,3 +1,4 @@
+use parking_lot::RwLock;
 use raphtory::{
     db::api::view::internal::{DynamicGraph, IntoDynamic},
     prelude::{Graph, GraphViewOps},
@@ -10,17 +11,17 @@ use std::{
 use walkdir::WalkDir;
 
 pub(crate) struct Data {
-    pub(crate) graphs: HashMap<String, IndexedGraph<DynamicGraph>>,
+    pub(crate) graphs: RwLock<HashMap<String, IndexedGraph<DynamicGraph>>>,
 }
 
 impl Data {
     pub fn from_map(graphs: HashMap<String, DynamicGraph>) -> Self {
-        let graphs = Self::convert_graphs(graphs);
+        let graphs = RwLock::new(Self::convert_graphs(graphs));
         Self { graphs }
     }
 
     pub fn from_directory(directory_path: &str) -> Self {
-        let graphs = Self::load_from_file(directory_path);
+        let graphs = RwLock::new(Self::load_from_file(directory_path));
         Self { graphs }
     }
 
@@ -28,12 +29,10 @@ impl Data {
         graphs: HashMap<String, DynamicGraph>,
         directory_path: &str,
     ) -> Self {
-        let graphs = Self::convert_graphs(graphs);
-        let mut graphs_from_files = Self::load_from_file(directory_path);
-        graphs_from_files.extend(graphs);
-        Self {
-            graphs: graphs_from_files,
-        }
+        let mut graphs = Self::convert_graphs(graphs);
+        graphs.extend(Self::load_from_file(directory_path));
+        let graphs = RwLock::new(graphs);
+        Self { graphs }
     }
 
     fn convert_graphs(
@@ -50,7 +49,7 @@ impl Data {
             .collect()
     }
 
-    fn load_from_file(path: &str) -> HashMap<String, IndexedGraph<DynamicGraph>> {
+    pub fn load_from_file(path: &str) -> HashMap<String, IndexedGraph<DynamicGraph>> {
         let mut valid_paths = HashSet::<String>::new();
 
         for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -256,6 +256,7 @@ mod graphql_test {
         let test_dir = tempdir().unwrap();
         let g0 = Graph::new();
         let test_dir_path = test_dir.path().display();
+        println!("test path: {}", test_dir_path);
         let f0 = &test_dir.path().join("g0");
         let f1 = &test_dir.path().join("g1");
         g0.save_to_file(f0).unwrap();

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -255,7 +255,7 @@ mod graphql_test {
     async fn test_mutation() {
         let test_dir = tempdir().unwrap();
         let g0 = Graph::new();
-        let test_dir_path = test_dir.path().to_str().unwrap();
+        let test_dir_path = test_dir.path().to_str().unwrap().replace(r#"\"#, r#"\\"#);
         println!("test path: {}", test_dir_path);
         let f0 = &test_dir.path().join("g0");
         let f1 = &test_dir.path().join("g1");

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -255,7 +255,7 @@ mod graphql_test {
     async fn test_mutation() {
         let test_dir = tempdir().unwrap();
         let g0 = Graph::new();
-        let test_dir_path = test_dir.path().display();
+        let test_dir_path = test_dir.path().to_str().unwrap();
         println!("test path: {}", test_dir_path);
         let f0 = &test_dir.path().join("g0");
         let f1 = &test_dir.path().join("g1");
@@ -304,9 +304,11 @@ mod graphql_test {
             test_dir_path
         );
 
+        println!("{}", load_all);
         // only g0 which is empty
         let req = Request::new(load_all);
         let res = schema.execute(req).await;
+        println!("response: {:?}", res);
         let res_json = res.data.into_json().unwrap();
         assert_eq!(res_json, json!({"loadGraphsFromPath": ["g0"]}));
 

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -256,7 +256,6 @@ mod graphql_test {
         let test_dir = tempdir().unwrap();
         let g0 = Graph::new();
         let test_dir_path = test_dir.path().to_str().unwrap().replace(r#"\"#, r#"\\"#);
-        println!("test path: {}", test_dir_path);
         let f0 = &test_dir.path().join("g0");
         let f1 = &test_dir.path().join("g1");
         g0.save_to_file(f0).unwrap();
@@ -304,11 +303,9 @@ mod graphql_test {
             test_dir_path
         );
 
-        println!("{}", load_all);
         // only g0 which is empty
         let req = Request::new(load_all);
         let res = schema.execute(req).await;
-        println!("response: {:?}", res);
         let res_json = res.data.into_json().unwrap();
         assert_eq!(res_json, json!({"loadGraphsFromPath": ["g0"]}));
 

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -10,9 +10,12 @@ mod data;
 #[cfg(test)]
 mod graphql_test {
     use super::*;
-    use dynamic_graphql::{dynamic::DynamicRequestExt, App, FieldValue};
+    use crate::{data::Data, model::App};
+    use dynamic_graphql::Request;
     use raphtory::{db::api::view::internal::IntoDynamic, prelude::*};
+    use serde_json::json;
     use std::collections::HashMap;
+    use tempfile::tempdir;
 
     #[tokio::test]
     async fn search_for_gandalf_query() {
@@ -24,11 +27,8 @@ mod graphql_test {
             .add_vertex(0, "Frodo", [("kind".to_string(), Prop::str("Hobbit"))])
             .expect("Could not add vertex!");
 
-        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic().into())]);
-        let data = data::Data { graphs };
-
-        #[derive(App)]
-        struct App(model::QueryRoot);
+        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic())]);
+        let data = data::Data::from_map(graphs);
         let schema = App::create_schema().data(data).finish().unwrap();
 
         let query = r#"
@@ -40,16 +40,13 @@ mod graphql_test {
           }
         }
         "#;
-
-        let root = model::QueryRoot;
-        let req = dynamic_graphql::Request::new(query).root_value(FieldValue::owned_any(root));
-
+        let req = Request::new(query);
         let res = schema.execute(req).await;
         let data = res.data.into_json().unwrap();
 
         assert_eq!(
             data,
-            serde_json::json!({
+            json!({
                 "graph": {
                     "search": [
                         {
@@ -68,11 +65,9 @@ mod graphql_test {
             .add_vertex(0, 11, NO_PROPS)
             .expect("Could not add vertex!");
 
-        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic().into())]);
-        let data = data::Data { graphs };
+        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic())]);
+        let data = data::Data::from_map(graphs);
 
-        #[derive(App)]
-        struct App(model::QueryRoot);
         let schema = App::create_schema().data(data).finish().unwrap();
 
         let query = r#"
@@ -84,10 +79,7 @@ mod graphql_test {
           }
         }
         "#;
-
-        let root = model::QueryRoot;
-        let req = dynamic_graphql::Request::new(query).root_value(FieldValue::owned_any(root));
-
+        let req = Request::new(query);
         let res = schema.execute(req).await;
         let data = res.data.into_json().unwrap();
 
@@ -118,11 +110,9 @@ mod graphql_test {
             panic!("Could not add vertex! {:?}", err);
         }
 
-        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic().into())]);
-        let data = data::Data { graphs };
+        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic())]);
+        let data = Data::from_map(graphs);
 
-        #[derive(App)]
-        struct App(model::QueryRoot);
         let schema = App::create_schema().data(data).finish().unwrap();
 
         let gandalf_query = r#"
@@ -135,16 +125,13 @@ mod graphql_test {
         }
         "#;
 
-        let root = model::QueryRoot;
-        let req =
-            dynamic_graphql::Request::new(gandalf_query).root_value(FieldValue::owned_any(root));
-
+        let req = Request::new(gandalf_query);
         let res = schema.execute(req).await;
         let data = res.data.into_json().unwrap();
 
         assert_eq!(
             data,
-            serde_json::json!({
+            json!({
                 "graph": {
                     "nodes": [
                         {
@@ -165,16 +152,13 @@ mod graphql_test {
         }
         "#;
 
-        let root = model::QueryRoot;
-        let req = dynamic_graphql::Request::new(not_gandalf_query)
-            .root_value(FieldValue::owned_any(root));
-
+        let req = Request::new(not_gandalf_query);
         let res = schema.execute(req).await;
         let data = res.data.into_json().unwrap();
 
         assert_eq!(
             data,
-            serde_json::json!({
+            json!({
                 "graph": {
                     "nodes": [
                         { "name": "bilbo" },
@@ -206,11 +190,9 @@ mod graphql_test {
             panic!("Could not add vertex! {:?}", err);
         }
 
-        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic().into())]);
-        let data = data::Data { graphs };
+        let graphs = HashMap::from([("lotr".to_string(), graph.into_dynamic())]);
+        let data = data::Data::from_map(graphs);
 
-        #[derive(App)]
-        struct App(model::QueryRoot);
         let schema = App::create_schema().data(data).finish().unwrap();
 
         let prop_has_key_filter = r#"
@@ -225,16 +207,13 @@ mod graphql_test {
         }
         "#;
 
-        let root = model::QueryRoot;
-        let req = dynamic_graphql::Request::new(prop_has_key_filter)
-            .root_value(FieldValue::owned_any(root));
-
+        let req = Request::new(prop_has_key_filter);
         let res = schema.execute(req).await;
         let data = res.data.into_json().unwrap();
 
         assert_eq!(
             data,
-            serde_json::json!({
+            json!({
                 "graph": {
                     "nodes": [
                         { "name": "bilbo" },
@@ -256,16 +235,13 @@ mod graphql_test {
         }
         "#;
 
-        let root = model::QueryRoot;
-        let req = dynamic_graphql::Request::new(prop_has_value_filter)
-            .root_value(FieldValue::owned_any(root));
-
+        let req = Request::new(prop_has_value_filter);
         let res = schema.execute(req).await;
         let data = res.data.into_json().unwrap();
 
         assert_eq!(
             data,
-            serde_json::json!({
+            json!({
                 "graph": {
                     "nodes": [
                         { "name": "bilbo" },
@@ -273,5 +249,110 @@ mod graphql_test {
                 }
             }),
         );
+    }
+
+    #[tokio::test]
+    async fn test_mutation() {
+        let test_dir = tempdir().unwrap();
+        let g0 = Graph::new();
+        let test_dir_path = test_dir.path().display();
+        let f0 = &test_dir.path().join("g0");
+        let f1 = &test_dir.path().join("g1");
+        g0.save_to_file(f0).unwrap();
+
+        let g1 = Graph::new();
+        g1.add_vertex(0, 1, NO_PROPS).unwrap();
+
+        let g2 = Graph::new();
+        g2.add_vertex(0, 2, NO_PROPS).unwrap();
+
+        let data = Data::default();
+        let schema = App::create_schema().data(data).finish().unwrap();
+
+        let list_graphs = r#"
+        {
+          graphs {
+            name
+          }
+        }"#;
+
+        let list_nodes = |name: &str| {
+            format!(
+                r#"{{
+                  graph(name: "{}") {{
+                    nodes {{
+                      id
+                    }}
+                  }}
+                }}"#,
+                name
+            )
+        };
+
+        let load_all = &format!(
+            r#"mutation {{
+              loadGraphsFromPath(path: "{}")
+            }}"#,
+            test_dir_path
+        );
+
+        let load_new = &format!(
+            r#"mutation {{
+              loadNewGraphsFromPath(path: "{}")
+            }}"#,
+            test_dir_path
+        );
+
+        // only g0 which is empty
+        let req = Request::new(load_all);
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"loadGraphsFromPath": ["g0"]}));
+
+        let req = Request::new(list_graphs);
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graphs": [{"name": "g0"}]}));
+
+        let req = Request::new(list_nodes("g0"));
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graph": {"nodes": []}}));
+
+        // add g1 to folder and replace g0 with g2 and load new graphs
+        g1.save_to_file(f1).unwrap();
+        g2.save_to_file(f0).unwrap();
+        let req = Request::new(load_new);
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"loadNewGraphsFromPath": ["g1"]}));
+
+        // g0 is still empty
+        let req = Request::new(list_nodes("g0"));
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graph": {"nodes": []}}));
+
+        // g1 has node 1
+        let req = Request::new(list_nodes("g1"));
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
+
+        // reload all graphs from folder
+        let req = Request::new(load_all);
+        let res = schema.execute(req).await;
+
+        // g0 now has node 2
+        let req = Request::new(list_nodes("g0"));
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 2}]}}));
+
+        // g1 still has node 1
+        let req = Request::new(list_nodes("g1"));
+        let res = schema.execute(req).await;
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
     }
 }

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     model::graph::graph::{GqlGraph, GraphMeta},
 };
 use async_graphql::Context;
-use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
+use dynamic_graphql::{
+    Mutation, MutationFields, MutationRoot, ResolvedObject, ResolvedObjectFields,
+};
 use itertools::Itertools;
 use raphtory::db::api::view::internal::IntoDynamic;
 
@@ -26,15 +28,33 @@ impl QueryRoot {
     /// Returns a view including all events between `t_start` (inclusive) and `t_end` (exclusive)
     async fn graph<'a>(ctx: &Context<'a>, name: &str) -> Option<GqlGraph> {
         let data = ctx.data_unchecked::<Data>();
-        let g = data.graphs.get(name)?;
-        Some(GqlGraph::new(g.clone()))
+        let g = data.graphs.read().get(name).cloned()?;
+        Some(GqlGraph::new(g))
     }
 
     async fn graphs<'a>(ctx: &Context<'a>) -> Vec<GraphMeta> {
         let data = ctx.data_unchecked::<Data>();
         data.graphs
+            .read()
             .iter()
             .map(|(name, g)| GraphMeta::new(name.clone(), g.deref().clone().into_dynamic()))
             .collect_vec()
+    }
+}
+
+#[derive(MutationRoot)]
+pub(crate) struct MutRoot;
+
+#[derive(Mutation)]
+pub(crate) struct Mut(MutRoot);
+
+#[MutationFields]
+impl Mut {
+    async fn load_graphs_from_path<'a>(ctx: &Context<'a>, path: String) -> Vec<String> {
+        let new_graphs = Data::load_from_file(&path);
+        let keys: Vec<_> = new_graphs.keys().cloned().collect();
+        let mut data = ctx.data_unchecked::<Data>().graphs.write();
+        data.extend(new_graphs);
+        keys
     }
 }

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -50,6 +50,7 @@ pub(crate) struct Mut(MutRoot);
 
 #[MutationFields]
 impl Mut {
+    /// Load new graphs from a directory of bincode files (existing graphs with the same name are overwritten)
     async fn load_graphs_from_path<'a>(ctx: &Context<'a>, path: String) -> Vec<String> {
         let new_graphs = Data::load_from_file(&path);
         let keys: Vec<_> = new_graphs.keys().cloned().collect();

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use async_graphql::Context;
 use dynamic_graphql::{
-    Mutation, MutationFields, MutationRoot, ResolvedObject, ResolvedObjectFields,
+    App, Mutation, MutationFields, MutationRoot, ResolvedObject, ResolvedObjectFields,
 };
 use itertools::Itertools;
 use raphtory::db::api::view::internal::IntoDynamic;
@@ -71,3 +71,6 @@ impl Mut {
         keys
     }
 }
+
+#[derive(App)]
+pub(crate) struct App(QueryRoot, MutRoot, Mut);

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -2,12 +2,11 @@
 
 use crate::{
     data::Data,
-    model::{algorithm::Algorithm, Mut, MutRoot, QueryRoot},
+    model::{algorithm::Algorithm, App},
     observability::tracing::create_tracer_from_env,
     routes::{graphql_playground, health},
 };
 use async_graphql_poem::GraphQL;
-use dynamic_graphql::App;
 use poem::{get, listener::TcpListener, middleware::Cors, EndpointExt, Route, Server};
 use raphtory::db::api::view::internal::DynamicGraph;
 use std::collections::HashMap;
@@ -61,9 +60,6 @@ impl RaphtoryServer {
             None => registry.with(env_filter).try_init(),
         }
         .unwrap_or(());
-
-        #[derive(App)]
-        struct App(QueryRoot, MutRoot, Mut);
 
         // it is important that this runs after algorithms have been pushed to PLUGIN_ALGOS static variable
         let schema_builder = App::create_schema();

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     data::Data,
-    model::{algorithm::Algorithm, QueryRoot},
+    model::{algorithm::Algorithm, Mut, MutRoot, QueryRoot},
     observability::tracing::create_tracer_from_env,
     routes::{graphql_playground, health},
 };
@@ -63,7 +63,7 @@ impl RaphtoryServer {
         .unwrap_or(());
 
         #[derive(App)]
-        struct App(QueryRoot);
+        struct App(QueryRoot, MutRoot, Mut);
 
         // it is important that this runs after algorithms have been pushed to PLUGIN_ALGOS static variable
         let schema_builder = App::create_schema();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add mutation to the GraphQLServer that allows reading new graphs from directory. Creates the foundation for implementing #1140 

### Why are the changes needed?

No longer need to restart the server to load new data

### Does this PR introduce any user-facing change? If yes is this documented?

yes, new method has docstring.

### How was this patch tested?

manually, we should add some actual tests
### Issues



### Are there any further changes required?


