### PR TITLE
roundtrip support for sending and receiving graphs using base64-encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -368,7 +368,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1188,7 +1188,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1306,7 +1306,7 @@ checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2083,7 +2083,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2318,7 +2318,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2349,7 +2349,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2631,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2",
 ]
@@ -2814,6 +2814,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-poem",
  "async-stream",
+ "base64 0.21.2",
  "bincode",
  "dotenv",
  "dynamic-graphql",
@@ -2829,6 +2830,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -3220,7 +3222,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3409,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3621,22 +3623,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3761,7 +3763,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3865,7 +3867,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -4126,7 +4128,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -4160,7 +4162,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/raphtory-graphql/Cargo.toml
+++ b/raphtory-graphql/Cargo.toml
@@ -15,6 +15,8 @@ homepage.workspace = true
 [dependencies]
 raphtory = { path = "../raphtory", version = "0.5.2" }
 bincode = "1"
+base64 = "0.21.2"
+thiserror = "1.0.44"
 dotenv = "0.15.0"
 itertools = "0.10"
 serde = {version = "1.0.147", features = ["derive"]}

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -473,7 +473,7 @@ mod graphql_test {
 
         let receive_graph = r#"
         query {
-            graphAsBase64(name: "test")
+            receiveGraph(name: "test")
         }
         "#;
 
@@ -481,7 +481,7 @@ mod graphql_test {
         let res = schema.execute(req).await;
         assert_eq!(res.errors.len(), 0);
         let res_json = res.data.into_json().unwrap();
-        let graph_encoded = res_json.get("graphAsBase64").unwrap().as_str().unwrap();
+        let graph_encoded = res_json.get("receiveGraph").unwrap().as_str().unwrap();
         let graph_roundtrip = url_decode_graph(graph_encoded).unwrap().into_dynamic();
         assert_eq!(g, graph_roundtrip);
     }

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -1,4 +1,6 @@
 pub use crate::{model::algorithm::Algorithm, server::RaphtoryServer};
+use base64::{prelude::BASE64_URL_SAFE_NO_PAD, DecodeError, Engine};
+use raphtory::{core::utils::errors::GraphError, db::api::view::internal::MaterializedGraph};
 
 mod model;
 mod observability;
@@ -6,6 +8,30 @@ mod routes;
 pub mod server;
 
 mod data;
+#[derive(thiserror::Error, Debug)]
+pub enum UrlDecodeError {
+    #[error("Bincode operation failed")]
+    BincodeError {
+        #[from]
+        source: Box<bincode::ErrorKind>,
+    },
+    #[error("Base64 decoding failed")]
+    DecodeError {
+        #[from]
+        source: DecodeError,
+    },
+}
+
+pub fn url_encode_graph<G: Into<MaterializedGraph>>(graph: G) -> Result<String, GraphError> {
+    let g: MaterializedGraph = graph.into();
+    Ok(BASE64_URL_SAFE_NO_PAD.encode(bincode::serialize(&g)?))
+}
+
+pub fn url_decode_graph<T: AsRef<[u8]>>(graph: T) -> Result<MaterializedGraph, UrlDecodeError> {
+    Ok(bincode::deserialize(
+        &BASE64_URL_SAFE_NO_PAD.decode(graph)?,
+    )?)
+}
 
 #[cfg(test)]
 mod graphql_test {
@@ -392,5 +418,58 @@ mod graphql_test {
         assert_eq!(res.errors.len(), 0);
         let res_json = res.data.into_json().unwrap();
         assert_eq!(res_json, json!({"uploadGraph": {"nodes": [{"id": 1}]}}))
+    }
+
+    #[tokio::test]
+    async fn test_graph_send_receive_base64() {
+        let g = Graph::new();
+        g.add_vertex(0, 1, NO_PROPS).unwrap();
+
+        let graph_str = url_encode_graph(g.clone()).unwrap();
+
+        let data = Data::default();
+        let schema = App::create_schema().data(data).finish().unwrap();
+
+        let query = r#"
+        mutation($graph: String!) {
+            sendGraph(name: "test", graph: $graph) 
+        }
+        "#;
+        let req = Request::new(query).variables(Variables::from_json(json!({"graph": graph_str})));
+
+        let res = schema.execute(req).await;
+        assert_eq!(res.errors.len(), 0);
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"sendGraph": "test"}));
+
+        let list_nodes = r#"
+        query {
+            graph(name: "test") {
+                nodes {
+                    id
+                }
+            }
+        }
+        "#;
+
+        let req = Request::new(list_nodes);
+        let res = schema.execute(req).await;
+        assert_eq!(res.errors.len(), 0);
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
+
+        let receive_graph = r#"
+        query {
+            graphAsBase64(name: "test")
+        }
+        "#;
+
+        let req = Request::new(receive_graph);
+        let res = schema.execute(req).await;
+        assert_eq!(res.errors.len(), 0);
+        let res_json = res.data.into_json().unwrap();
+        let graph_encoded = res_json.get("graphAsBase64").unwrap().as_str().unwrap();
+        let graph_roundtrip = url_decode_graph(graph_encoded).unwrap().into_dynamic();
+        assert_eq!(g, graph_roundtrip);
     }
 }

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -402,11 +402,7 @@ mod graphql_test {
 
         let query = r##"
         mutation($file: Upload!) {
-            uploadGraph(name: "test", graph: $file) {
-            nodes {
-              id
-            }
-          }
+            uploadGraph(name: "test", graph: $file)
         }
         "##;
 
@@ -418,7 +414,23 @@ mod graphql_test {
         println!("{:?}", res);
         assert_eq!(res.errors.len(), 0);
         let res_json = res.data.into_json().unwrap();
-        assert_eq!(res_json, json!({"uploadGraph": {"nodes": [{"id": 1}]}}))
+        assert_eq!(res_json, json!({"uploadGraph": "test"}));
+
+        let list_nodes = r#"
+        query {
+            graph(name: "test") {
+                nodes {
+                    id
+                }
+            }
+        }
+        "#;
+
+        let req = Request::new(list_nodes);
+        let res = schema.execute(req).await;
+        assert_eq!(res.errors.len(), 0);
+        let res_json = res.data.into_json().unwrap();
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
     }
 
     #[tokio::test]

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -415,6 +415,7 @@ mod graphql_test {
             dynamic_graphql::Request::new(query).variables(Variables::from_json(variables));
         req.set_upload("variables.file", upload_val);
         let res = schema.execute(req).await;
+        println!("{:?}", res);
         assert_eq!(res.errors.len(), 0);
         let res_json = res.data.into_json().unwrap();
         assert_eq!(res_json, json!({"uploadGraph": {"nodes": [{"id": 1}]}}))

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -65,7 +65,7 @@ impl QueryRoot {
             .collect_vec()
     }
 
-    async fn graph_as_base64<'a>(ctx: &Context<'a>, name: &str) -> Result<String> {
+    async fn receive_graph<'a>(ctx: &Context<'a>, name: &str) -> Result<String> {
         let data = ctx.data_unchecked::<Data>();
         let g = data
             .graphs

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -1,10 +1,17 @@
-use std::{collections::HashMap, io::BufReader, ops::Deref};
+use std::{
+    collections::HashMap,
+    error::Error,
+    fmt::{Display, Formatter},
+    io::BufReader,
+    ops::Deref,
+};
 
 use crate::{
     data::Data,
     model::graph::graph::{GqlGraph, GraphMeta},
 };
 use async_graphql::Context;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use dynamic_graphql::{
     App, Mutation, MutationFields, MutationRoot, ResolvedObject, ResolvedObjectFields, Result,
     Upload,
@@ -12,6 +19,7 @@ use dynamic_graphql::{
 use itertools::Itertools;
 use raphtory::{
     db::api::view::internal::{DynamicGraph, IntoDynamic, MaterializedGraph},
+    prelude::GraphViewOps,
     search::IndexedGraph,
 };
 
@@ -19,6 +27,17 @@ pub(crate) mod algorithm;
 pub(crate) mod filters;
 pub(crate) mod graph;
 pub(crate) mod schema;
+
+#[derive(Debug)]
+pub struct MissingGraph;
+
+impl Display for MissingGraph {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Graph does not exist")
+    }
+}
+
+impl Error for MissingGraph {}
 
 #[derive(ResolvedObject)]
 #[graphql(root)]
@@ -45,6 +64,19 @@ impl QueryRoot {
             .map(|(name, g)| GraphMeta::new(name.clone(), g.deref().clone().into_dynamic()))
             .collect_vec()
     }
+
+    async fn graph_as_base64<'a>(ctx: &Context<'a>, name: &str) -> Result<String> {
+        let data = ctx.data_unchecked::<Data>();
+        let g = data
+            .graphs
+            .read()
+            .get(name)
+            .cloned()
+            .ok_or(MissingGraph)?
+            .materialize()?;
+        let bincode = bincode::serialize(&g)?;
+        Ok(URL_SAFE_NO_PAD.encode(bincode))
+    }
 }
 
 #[derive(MutationRoot)]
@@ -56,6 +88,9 @@ pub(crate) struct Mut(MutRoot);
 #[MutationFields]
 impl Mut {
     /// Load graphs from a directory of bincode files (existing graphs with the same name are overwritten)
+    ///
+    /// # Returns:
+    ///   list of names for newly added graphs
     async fn load_graphs_from_path<'a>(ctx: &Context<'a>, path: String) -> Vec<String> {
         let new_graphs = Data::load_from_file(&path);
         let keys: Vec<_> = new_graphs.keys().cloned().collect();
@@ -65,6 +100,9 @@ impl Mut {
     }
 
     /// Load new graphs from a directory of bincode files (existing graphs will not been overwritten)
+    ///
+    /// # Returns:
+    ///   list of names for newly added graphs
     async fn load_new_graphs_from_path<'a>(ctx: &Context<'a>, path: String) -> Vec<String> {
         let mut data = ctx.data_unchecked::<Data>().graphs.write();
         let new_graphs: HashMap<_, _> = Data::load_from_file(&path)
@@ -76,14 +114,28 @@ impl Mut {
         keys
     }
 
-    /// Use GQL multipart upload to send new graphs to server (Graphs should be of type MaterializedGraph)
-    async fn upload_graph<'a>(ctx: &Context<'a>, name: String, graph: Upload) -> Result<GqlGraph> {
+    /// Use GQL multipart upload to send new graphs to server
+    ///
+    /// # Returns:
+    ///    name of the new graph
+    async fn upload_graph<'a>(ctx: &Context<'a>, name: String, graph: Upload) -> Result<String> {
         let g: MaterializedGraph =
             bincode::deserialize_from(BufReader::new(graph.value(ctx)?.content))?;
         let gi: IndexedGraph<DynamicGraph> = g.into_dynamic().into();
         let mut data = ctx.data_unchecked::<Data>().graphs.write();
-        data.insert(name, gi.clone());
-        Ok(GqlGraph::from(gi))
+        data.insert(name.clone(), gi.clone());
+        Ok(name)
+    }
+
+    /// Send graph bincode as base64 encoded string
+    ///
+    /// # Returns:
+    ///    name of the new graph
+    async fn send_graph<'a>(ctx: &Context<'a>, name: String, graph: String) -> Result<String> {
+        let g: MaterializedGraph = bincode::deserialize(&URL_SAFE_NO_PAD.decode(graph)?)?;
+        let mut data = ctx.data_unchecked::<Data>().graphs.write();
+        data.insert(name.clone(), g.into_dynamic().into());
+        Ok(name)
     }
 }
 

--- a/raphtory/src/db/api/view/internal/mod.rs
+++ b/raphtory/src/db/api/view/internal/mod.rs
@@ -21,7 +21,10 @@ pub use graph_window_ops::GraphWindowOps;
 pub use inherit::Base;
 pub use into_dynamic::IntoDynamic;
 pub use materialize::*;
-use std::sync::Arc;
+use std::{
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
 pub use time_semantics::*;
 
 /// Marker trait to indicate that an object is a valid graph view
@@ -80,6 +83,17 @@ impl From<Arc<dyn BoxableGraphView>> for DynamicGraph {
 
 #[derive(Clone)]
 pub struct DynamicGraph(pub(crate) Arc<dyn BoxableGraphView>);
+
+impl Debug for DynamicGraph {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DynamicGraph(num_vertices={}, num_edges={})",
+            self.num_vertices(),
+            self.num_edges()
+        )
+    }
+}
 
 impl DynamicGraph {
     pub fn new<G: GraphViewOps>(graph: G) -> Self {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Sending and receiving of graphs for GraphQL server without saving and uploading files

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

more methods available on the GraphQL server with docstrings

### How was this patch tested?

added test for roundtrip of a graph

### Issues

### Are there any further changes required?


