### PR TITLE
feat(graphql): Extend property filtering to edges in graphql

### DIFF
--- a/raphtory-graphql/src/model/filters/edgefilter.rs
+++ b/raphtory-graphql/src/model/filters/edgefilter.rs
@@ -5,11 +5,14 @@ use crate::model::{
 use dynamic_graphql::InputObject;
 use raphtory::db::api::view::{EdgeViewOps, VertexViewOps};
 
+use super::property::PropertyHasFilter;
+
 #[derive(InputObject, Clone)]
 pub struct EdgeFilter {
     node_names: Option<StringVecFilter>,
     src: Option<StringFilter>,
     dst: Option<StringFilter>,
+    property_has: Option<PropertyHasFilter>,
     pub(crate) layer_names: Option<StringVecFilter>,
 }
 
@@ -41,6 +44,12 @@ impl EdgeFilter {
                 .layer_names()
                 .iter()
                 .any(|name| name_filter.contains(name));
+        }
+
+        if let Some(property_has_filter) = &self.property_has {
+            if !property_has_filter.matches_edge_properties(&edge) {
+                return false;
+            }
         }
 
         true

--- a/raphtory-graphql/src/model/filters/nodefilter.rs
+++ b/raphtory-graphql/src/model/filters/nodefilter.rs
@@ -68,7 +68,7 @@ impl NodeFilter {
         }
 
         if let Some(property_has_filter) = &self.property_has {
-            if !property_has_filter.matches(&node) {
+            if !property_has_filter.matches_node_properties(&node) {
                 return false;
             }
         }

--- a/raphtory-graphql/src/model/filters/primitives.rs
+++ b/raphtory-graphql/src/model/filters/primitives.rs
@@ -26,7 +26,7 @@ impl StringFilter {
     }
 }
 
-#[derive(InputObject)]
+#[derive(InputObject, Clone)]
 pub(crate) struct NumberFilter {
     gt: Option<usize>,
     lt: Option<usize>,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add property filtering to EdgeFilter for GraphQL.

### Why are the changes needed?

Allows users to filter edges using the PropertyHasFilter

### Does this PR introduce any user-facing change? If yes is this documented?

Yes. Users can now use the PropertyHasFilter in the EdgeFilter in GraphQL. It shows up automatically in the GraphQL schema, but I'm not sure if there's somewhere else that needs to be updated.

### How was this patch tested?

Manually :P.  TBD

### Issues
Does not resolve, but contributes to:
https://github.com/Pometry/Raphtory/issues/1038

### Are there any further changes required?

1. Note sure I like doing `matches_node_properties` and `matches_edge_properties` but I don't know enough about rust to do it with traits yet.

