### PR TITLE
Changing property type now returns an error instead of silently ignoring the value

### DIFF
--- a/raphtory/src/core/entities/edges/edge_store.rs
+++ b/raphtory/src/core/entities/edges/edge_store.rs
@@ -9,7 +9,7 @@ use crate::core::{
         locked_view::LockedView,
         timeindex::{TimeIndex, TimeIndexEntry},
     },
-    utils::errors::MutateGraphError,
+    utils::errors::{GraphError, MutateGraphError},
     Prop,
 };
 use itertools::Itertools;
@@ -37,9 +37,14 @@ impl EdgeLayer {
         self.props.as_ref()
     }
 
-    pub fn add_prop(&mut self, t: TimeIndexEntry, prop_id: usize, prop: Prop) {
+    pub fn add_prop(
+        &mut self,
+        t: TimeIndexEntry,
+        prop_id: usize,
+        prop: Prop,
+    ) -> Result<(), GraphError> {
         let props = self.props.get_or_insert_with(|| Props::new());
-        props.add_prop(t, prop_id, prop);
+        props.add_prop(t, prop_id, prop)
     }
 
     pub fn add_static_prop(

--- a/raphtory/src/core/entities/properties/graph_props.rs
+++ b/raphtory/src/core/entities/properties/graph_props.rs
@@ -4,6 +4,7 @@ use crate::core::{
         properties::{props::DictMapper, tprop::TProp},
     },
     storage::{locked_view::LockedView, timeindex::TimeIndexEntry},
+    utils::errors::GraphError,
     Prop,
 };
 use parking_lot::RwLockReadGuard;
@@ -34,13 +35,18 @@ impl GraphProps {
         (*prop_entry) = Some(prop);
     }
 
-    pub(crate) fn add_prop(&self, t: TimeIndexEntry, name: &str, prop: Prop) {
+    pub(crate) fn add_prop(
+        &self,
+        t: TimeIndexEntry,
+        name: &str,
+        prop: Prop,
+    ) -> Result<(), GraphError> {
         let prop_id = self.temporal_mapper.get_or_create_id(name.to_owned());
         let mut prop_entry = self
             .temporal_props
             .entry(prop_id)
             .or_insert(TProp::default());
-        (*prop_entry).set(t, prop);
+        (*prop_entry).set(t, prop)
     }
 
     pub(crate) fn get_static(&self, name: &str) -> Option<Prop> {

--- a/raphtory/src/core/entities/properties/props.rs
+++ b/raphtory/src/core/entities/properties/props.rs
@@ -5,7 +5,7 @@ use crate::core::{
         locked_view::LockedView,
         timeindex::TimeIndexEntry,
     },
-    utils::errors::{IllegalMutate, MutateGraphError},
+    utils::errors::{GraphError, IllegalMutate, MutateGraphError},
     Prop,
 };
 use parking_lot::{RwLock, RwLockReadGuard};
@@ -38,7 +38,12 @@ impl Props {
         }
     }
 
-    pub fn add_prop(&mut self, t: TimeIndexEntry, prop_id: usize, prop: Prop) {
+    pub fn add_prop(
+        &mut self,
+        t: TimeIndexEntry,
+        prop_id: usize,
+        prop: Prop,
+    ) -> Result<(), GraphError> {
         self.temporal_props.update(prop_id, |p| p.set(t, prop))
     }
 

--- a/raphtory/src/core/entities/properties/tprop.rs
+++ b/raphtory/src/core/entities/properties/tprop.rs
@@ -57,7 +57,6 @@ impl TProp {
         if matches!(self, TProp::Empty) {
             *self = TProp::from(t, prop);
         } else {
-            // TODO: we should bubble up the result if we change the type of the property
             match (self, prop) {
                 (TProp::Empty, prop) => {}
 

--- a/raphtory/src/db/api/view/graph.rs
+++ b/raphtory/src/db/api/view/graph.rs
@@ -290,4 +290,19 @@ mod test_materialize {
             .temporal()
             .contains("layer1"));
     }
+
+    #[test]
+    fn changing_property_type_errors() {
+        let g = Graph::new();
+        let props_0 = [("test", Prop::U64(1))];
+        let props_1 = [("test", Prop::F64(0.1))];
+        g.add_properties(0, props_0.clone()).unwrap();
+        assert!(g.add_properties(1, props_1.clone()).is_err());
+
+        g.add_vertex(0, 1, props_0.clone()).unwrap();
+        assert!(g.add_vertex(1, 1, props_1.clone()).is_err());
+
+        g.add_edge(0, 1, 2, props_0.clone(), None).unwrap();
+        assert!(g.add_edge(1, 1, 2, props_1.clone(), None).is_err());
+    }
 }


### PR DESCRIPTION
### How was this patch tested?

Added a test for all temporal property additions

### Issues
fixes #951 



