### PR TITLE
Fix input argument for subgraph in python

### DIFF
--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -1332,6 +1332,12 @@ def test_subgraph():
     subgraph = g.subgraph([vertex1])
     assert subgraph.vertices.collect() == [vertex1]
 
+    subgraph_from_str = g.subgraph(["1"])
+    assert subgraph_from_str.vertices.collect() == [vertex1]
+
+    subgraph_from_int = g.subgraph([1])
+    assert subgraph_from_int.vertices.collect() == [vertex1]
+
     mg = subgraph.materialize()
     assert mg.vertices.collect()[0].properties['type'] == 'wallet'
     assert mg.vertices.collect()[0].name() == '1'

--- a/raphtory/src/python/graph/views/graph_view.rs
+++ b/raphtory/src/python/graph/views/graph_view.rs
@@ -357,7 +357,7 @@ impl PyGraphView {
     ///
     /// Returns:
     ///    GraphView - Returns the subgraph
-    fn subgraph(&self, vertices: Vec<PyVertex>) -> VertexSubgraph<DynamicGraph> {
+    fn subgraph(&self, vertices: Vec<VertexRef>) -> VertexSubgraph<DynamicGraph> {
         self.graph.subgraph(vertices)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make sure subgraph method takes ids and names as input so one doesn't have to get the vertex objects first

### How was this patch tested?

added the different input types to the subgraph test
### Issues

fixes #1216 



