### PR TITLE
Add method to return TimeIndexEntry for exploded edge

### DIFF
--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -204,4 +204,36 @@ mod test_edge_view {
         assert_eq!(prop_values, expected_prop_values);
         assert_eq!(actual_layers, expected_layers);
     }
+
+    #[test]
+    fn test_sorting_by_secondary_index() {
+        let g = Graph::new();
+        g.add_edge(0, 2, 3, NO_PROPS, None).unwrap();
+        g.add_edge(0, 1, 2, NO_PROPS, None).unwrap();
+        g.add_edge(0, 1, 2, [("second", true)], None).unwrap();
+        g.add_edge(0, 2, 3, [("second", true)], None).unwrap();
+
+        let mut exploded_edges: Vec<_> = g.edges().explode().collect();
+        exploded_edges.sort_by(|a, b| a.time_and_index().cmp(&b.time_and_index()));
+
+        let res: Vec<_> = exploded_edges
+            .into_iter()
+            .map(|e| {
+                (
+                    e.src().id(),
+                    e.dst().id(),
+                    e.properties().get("second").into_bool(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            res,
+            vec![
+                (2, 3, None),
+                (1, 2, None),
+                (1, 2, Some(true)),
+                (2, 3, Some(true))
+            ]
+        )
+    }
 }

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{
         entities::{edges::edge_ref::EdgeRef, VID},
-        storage::timeindex::AsTime,
+        storage::timeindex::{AsTime, TimeIndexEntry},
     },
     db::api::{
         properties::{
@@ -103,6 +103,11 @@ pub trait EdgeViewOps:
     /// Gets the time stamp of the edge if it is exploded
     fn time(&self) -> Option<i64> {
         self.eref().time().map(|ti| *ti.t())
+    }
+
+    /// Gets the TimeIndexEntry if the edge is exploded
+    fn time_and_index(&self) -> Option<TimeIndexEntry> {
+        self.eref().time()
     }
 
     /// Gets the name of the layer this edge belongs to

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -214,7 +214,7 @@ mod test_edge_view {
         g.add_edge(0, 2, 3, [("second", true)], None).unwrap();
 
         let mut exploded_edges: Vec<_> = g.edges().explode().collect();
-        exploded_edges.sort_by(|a, b| a.time_and_index().cmp(&b.time_and_index()));
+        exploded_edges.sort_by_key(|a| a.time_and_index());
 
         let res: Vec<_> = exploded_edges
             .into_iter()


### PR DESCRIPTION
### What changes were proposed in this pull request?

adds an extra method to EdgeViews that allows one to return the TimeIndexEntry which includes the secondary index created during ingestion

### Why are the changes needed?

makes it possible to sort exploded edges by insertion/secondary index order

### Does this PR introduce any user-facing change? If yes is this documented?

New method has a docstring

### How was this patch tested?

added test for the sorting

### Issues

### Are there any further changes required?


