### PR TITLE
refactor and clean up the AlgorithmResult struct

### DIFF
--- a/raphtory-graphql/src/model/algorithm.rs
+++ b/raphtory-graphql/src/model/algorithm.rs
@@ -96,6 +96,13 @@ impl From<(String, f64)> for Pagerank {
     }
 }
 
+impl From<(String, OrderedFloat<f64>)> for Pagerank {
+    fn from((name, rank): (String, OrderedFloat<f64>)) -> Self {
+        let rank = rank.into_inner();
+        Self { name, rank }
+    }
+}
+
 impl From<(&String, &OrderedFloat<f64>)> for Pagerank {
     fn from((name, rank): (&String, &OrderedFloat<f64>)) -> Self {
         Self {

--- a/raphtory/src/algorithms/balance.rs
+++ b/raphtory/src/algorithms/balance.rs
@@ -131,7 +131,6 @@ mod sum_weight_test {
         core::{Direction, Prop},
         db::{api::mutation::AdditionOps, graph::graph::Graph},
     };
-    use ordered_float::OrderedFloat;
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/raphtory/src/algorithms/balance.rs
+++ b/raphtory/src/algorithms/balance.rs
@@ -162,31 +162,31 @@ mod sum_weight_test {
 
         let res = balance(&graph, "value_dec".to_string(), Direction::BOTH, None);
         let expected = vec![
-            ("1".to_string(), (-26.0)),
-            ("2".to_string(), (7.0)),
-            ("3".to_string(), (12.0)),
-            ("4".to_string(), (5.0)),
-            ("5".to_string(), (2.0)),
+            ("1".to_string(), -26.0),
+            ("2".to_string(), 7.0),
+            ("3".to_string(), 12.0),
+            ("4".to_string(), 5.0),
+            ("5".to_string(), 2.0),
         ];
         assert_eq!(res.sort_by_key(false), expected);
 
         let res = balance(&graph, "value_dec".to_string(), Direction::IN, None);
         let expected = vec![
-            ("1".to_string(), (6.0)),
-            ("2".to_string(), (12.0)),
-            ("3".to_string(), (15.0)),
-            ("4".to_string(), (20.0)),
-            ("5".to_string(), (2.0)),
+            ("1".to_string(), 6.0),
+            ("2".to_string(), 12.0),
+            ("3".to_string(), 15.0),
+            ("4".to_string(), 20.0),
+            ("5".to_string(), 2.0),
         ];
         assert_eq!(res.sort_by_key(false), expected);
 
         let res = balance(&graph, "value_dec".to_string(), Direction::OUT, None);
         let expected = vec![
-            ("1".to_string(), (-32.0)),
-            ("2".to_string(), (-5.0)),
-            ("3".to_string(), (-3.0)),
-            ("4".to_string(), (-15.0)),
-            ("5".to_string(), (0.0)),
+            ("1".to_string(), -32.0),
+            ("2".to_string(), -5.0),
+            ("3".to_string(), -3.0),
+            ("4".to_string(), -15.0),
+            ("5".to_string(), 0.0),
         ];
         assert_eq!(res.sort_by_key(false), expected);
     }

--- a/raphtory/src/algorithms/balance.rs
+++ b/raphtory/src/algorithms/balance.rs
@@ -102,7 +102,7 @@ pub fn balance<G: GraphViewOps>(
     name: String,
     direction: Direction,
     threads: Option<usize>,
-) -> AlgorithmResult<String, OrderedFloat<f64>> {
+) -> AlgorithmResult<String, f64, OrderedFloat<f64>> {
     let mut ctx: Context<G, ComputeStateVec> = graph.into();
     let min = sum(0);
     ctx.agg(min);
@@ -112,7 +112,7 @@ pub fn balance<G: GraphViewOps>(
         Step::Done
     });
     let mut runner: TaskRunner<G, _> = TaskRunner::new(ctx);
-    AlgorithmResult::new_with_float(runner.run(
+    AlgorithmResult::new(runner.run(
         vec![],
         vec![Job::new(step1)],
         None,
@@ -163,31 +163,31 @@ mod sum_weight_test {
 
         let res = balance(&graph, "value_dec".to_string(), Direction::BOTH, None);
         let expected = vec![
-            ("1".to_string(), OrderedFloat(-26.0)),
-            ("2".to_string(), OrderedFloat(7.0)),
-            ("3".to_string(), OrderedFloat(12.0)),
-            ("4".to_string(), OrderedFloat(5.0)),
-            ("5".to_string(), OrderedFloat(2.0)),
+            ("1".to_string(), (-26.0)),
+            ("2".to_string(), (7.0)),
+            ("3".to_string(), (12.0)),
+            ("4".to_string(), (5.0)),
+            ("5".to_string(), (2.0)),
         ];
         assert_eq!(res.sort_by_key(false), expected);
 
         let res = balance(&graph, "value_dec".to_string(), Direction::IN, None);
         let expected = vec![
-            ("1".to_string(), OrderedFloat(6.0)),
-            ("2".to_string(), OrderedFloat(12.0)),
-            ("3".to_string(), OrderedFloat(15.0)),
-            ("4".to_string(), OrderedFloat(20.0)),
-            ("5".to_string(), OrderedFloat(2.0)),
+            ("1".to_string(), (6.0)),
+            ("2".to_string(), (12.0)),
+            ("3".to_string(), (15.0)),
+            ("4".to_string(), (20.0)),
+            ("5".to_string(), (2.0)),
         ];
         assert_eq!(res.sort_by_key(false), expected);
 
         let res = balance(&graph, "value_dec".to_string(), Direction::OUT, None);
         let expected = vec![
-            ("1".to_string(), OrderedFloat(-32.0)),
-            ("2".to_string(), OrderedFloat(-5.0)),
-            ("3".to_string(), OrderedFloat(-3.0)),
-            ("4".to_string(), OrderedFloat(-15.0)),
-            ("5".to_string(), OrderedFloat(0.0)),
+            ("1".to_string(), (-32.0)),
+            ("2".to_string(), (-5.0)),
+            ("3".to_string(), (-3.0)),
+            ("4".to_string(), (-15.0)),
+            ("5".to_string(), (0.0)),
         ];
         assert_eq!(res.sort_by_key(false), expected);
     }

--- a/raphtory/src/algorithms/hits.rs
+++ b/raphtory/src/algorithms/hits.rs
@@ -18,6 +18,7 @@ use crate::{
     },
 };
 use num_traits::abs;
+use ordered_float::OrderedFloat;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -50,7 +51,7 @@ pub fn hits<G: GraphViewOps>(
     g: &G,
     iter_count: usize,
     threads: Option<usize>,
-) -> AlgorithmResult<String, (f32, f32)> {
+) -> AlgorithmResult<String, (f32, f32), (OrderedFloat<f32>, OrderedFloat<f32>)> {
     let mut ctx: Context<G, ComputeStateVec> = g.into();
 
     let recv_hub_score = sum::<f32>(2);
@@ -209,7 +210,7 @@ mod hits_tests {
             (8, 1),
         ]);
 
-        let results: AlgorithmResult<String, (f32, f32)> = hits(&graph, 20, None);
+        let results = hits(&graph, 20, None);
 
         // NetworkX results
         // >>> G = nx.DiGraph()

--- a/raphtory/src/algorithms/pagerank.rs
+++ b/raphtory/src/algorithms/pagerank.rs
@@ -58,7 +58,7 @@ pub fn unweighted_page_rank<G: GraphViewOps>(
     threads: Option<usize>,
     tol: Option<f64>,
     use_l2_norm: bool,
-) -> AlgorithmResult<String, OrderedFloat<f64>> {
+) -> AlgorithmResult<String, f64, OrderedFloat<f64>> {
     let n = g.num_vertices();
     let total_edges = g.num_edges();
 
@@ -185,7 +185,7 @@ pub fn unweighted_page_rank<G: GraphViewOps>(
         .map(|(k, v)| (g.vertex_name(k), v))
         .collect();
 
-    AlgorithmResult::new_with_float(res)
+    AlgorithmResult::new(res)
 }
 
 #[cfg(test)]
@@ -217,29 +217,12 @@ mod page_rank_tests {
     fn test_page_rank() {
         let graph = load_graph();
 
-        let results: AlgorithmResult<String, OrderedFloat<f64>> =
-            unweighted_page_rank(&graph, 1000, Some(1), None, true);
+        let results = unweighted_page_rank(&graph, 1000, Some(1), None, true);
 
-        assert_eq_f64(
-            Some(&results.get(&"1".to_string()).unwrap().0),
-            Some(&0.38694),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"2".to_string()).unwrap().0),
-            Some(&0.20195),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"4".to_string()).unwrap().0),
-            Some(&0.20195),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"3".to_string()).unwrap().0),
-            Some(&0.20916),
-            5,
-        );
+        assert_eq_f64(results.get("1"), Some(&0.38694), 5);
+        assert_eq_f64(results.get("2"), Some(&0.20195), 5);
+        assert_eq_f64(results.get("4"), Some(&0.20195), 5);
+        assert_eq_f64(results.get("3"), Some(&0.20916), 5);
     }
 
     #[test]
@@ -276,64 +259,19 @@ mod page_rank_tests {
             graph.add_edge(t, src, dst, NO_PROPS, None).unwrap();
         }
 
-        let results: AlgorithmResult<String, OrderedFloat<f64>> =
-            unweighted_page_rank(&graph, 1000, Some(4), None, true);
+        let results = unweighted_page_rank(&graph, 1000, Some(4), None, true);
 
-        assert_eq_f64(
-            Some(&results.get(&"10".to_string()).unwrap().0),
-            Some(&0.072082),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"8".to_string()).unwrap().0),
-            Some(&0.136473),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"3".to_string()).unwrap().0),
-            Some(&0.15484),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"6".to_string()).unwrap().0),
-            Some(&0.07208),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"11".to_string()).unwrap().0),
-            Some(&0.06186),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"2".to_string()).unwrap().0),
-            Some(&0.03557),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"1".to_string()).unwrap().0),
-            Some(&0.11284),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"4".to_string()).unwrap().0),
-            Some(&0.07944),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"7".to_string()).unwrap().0),
-            Some(&0.01638),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"9".to_string()).unwrap().0),
-            Some(&0.06186),
-            5,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"5".to_string()).unwrap().0),
-            Some(&0.19658),
-            5,
-        );
+        assert_eq_f64(results.get("10"), Some(&0.072082), 5);
+        assert_eq_f64(results.get("8"), Some(&0.136473), 5);
+        assert_eq_f64(results.get("3"), Some(&0.15484), 5);
+        assert_eq_f64(results.get("6"), Some(&0.07208), 5);
+        assert_eq_f64(results.get("11"), Some(&0.06186), 5);
+        assert_eq_f64(results.get("2"), Some(&0.03557), 5);
+        assert_eq_f64(results.get("1"), Some(&0.11284), 5);
+        assert_eq_f64(results.get("4"), Some(&0.07944), 5);
+        assert_eq_f64(results.get("7"), Some(&0.01638), 5);
+        assert_eq_f64(results.get("9"), Some(&0.06186), 5);
+        assert_eq_f64(results.get("5"), Some(&0.19658), 5);
     }
 
     #[test]
@@ -346,19 +284,10 @@ mod page_rank_tests {
             graph.add_edge(t as i64, src, dst, NO_PROPS, None).unwrap();
         }
 
-        let results: AlgorithmResult<String, OrderedFloat<f64>> =
-            unweighted_page_rank(&graph, 1000, Some(4), None, false);
+        let results = unweighted_page_rank(&graph, 1000, Some(4), None, false);
 
-        assert_eq_f64(
-            Some(&results.get(&"1".to_string()).unwrap().0),
-            Some(&0.5),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"2".to_string()).unwrap().0),
-            Some(&0.5),
-            3,
-        );
+        assert_eq_f64(results.get("1"), Some(&0.5), 3);
+        assert_eq_f64(results.get("2"), Some(&0.5), 3);
     }
 
     #[test]
@@ -371,24 +300,11 @@ mod page_rank_tests {
             graph.add_edge(t as i64, src, dst, NO_PROPS, None).unwrap();
         }
 
-        let results: AlgorithmResult<String, OrderedFloat<f64>> =
-            unweighted_page_rank(&graph, 10, Some(4), None, false);
+        let results = unweighted_page_rank(&graph, 10, Some(4), None, false);
 
-        assert_eq_f64(
-            Some(&results.get(&"1".to_string()).unwrap().0),
-            Some(&0.303),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"2".to_string()).unwrap().0),
-            Some(&0.393),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"3".to_string()).unwrap().0),
-            Some(&0.303),
-            3,
-        );
+        assert_eq_f64(results.get("1"), Some(&0.303), 3);
+        assert_eq_f64(results.get("2"), Some(&0.393), 3);
+        assert_eq_f64(results.get("3"), Some(&0.303), 3);
     }
 
     #[test]
@@ -420,64 +336,19 @@ mod page_rank_tests {
             graph.add_edge(t, src, dst, NO_PROPS, None).unwrap();
         }
 
-        let results: AlgorithmResult<String, OrderedFloat<f64>> =
-            unweighted_page_rank(&graph, 1000, Some(4), None, true);
+        let results = unweighted_page_rank(&graph, 1000, Some(4), None, true);
 
-        assert_eq_f64(
-            Some(&results.get(&"1".to_string()).unwrap().0),
-            Some(&0.055),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"2".to_string()).unwrap().0),
-            Some(&0.079),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"3".to_string()).unwrap().0),
-            Some(&0.113),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"4".to_string()).unwrap().0),
-            Some(&0.055),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"5".to_string()).unwrap().0),
-            Some(&0.070),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"6".to_string()).unwrap().0),
-            Some(&0.083),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"7".to_string()).unwrap().0),
-            Some(&0.093),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"8".to_string()).unwrap().0),
-            Some(&0.102),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"9".to_string()).unwrap().0),
-            Some(&0.110),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"10".to_string()).unwrap().0),
-            Some(&0.117),
-            3,
-        );
-        assert_eq_f64(
-            Some(&results.get(&"11".to_string()).unwrap().0),
-            Some(&0.122),
-            3,
-        );
+        assert_eq_f64(results.get("1"), Some(&0.055), 3);
+        assert_eq_f64(results.get("2"), Some(&0.079), 3);
+        assert_eq_f64(results.get("3"), Some(&0.113), 3);
+        assert_eq_f64(results.get("4"), Some(&0.055), 3);
+        assert_eq_f64(results.get("5"), Some(&0.070), 3);
+        assert_eq_f64(results.get("6"), Some(&0.083), 3);
+        assert_eq_f64(results.get("7"), Some(&0.093), 3);
+        assert_eq_f64(results.get("8"), Some(&0.102), 3);
+        assert_eq_f64(results.get("9"), Some(&0.110), 3);
+        assert_eq_f64(results.get("10"), Some(&0.117), 3);
+        assert_eq_f64(results.get("11"), Some(&0.122), 3);
     }
 
     fn assert_eq_f64<T: Borrow<f64> + PartialEq + std::fmt::Debug>(

--- a/raphtory/src/algorithms/reciprocity.rs
+++ b/raphtory/src/algorithms/reciprocity.rs
@@ -116,7 +116,7 @@ pub fn global_reciprocity<G: GraphViewOps>(g: &G, threads: Option<usize>) -> f64
 pub fn all_local_reciprocity<G: GraphViewOps>(
     g: &G,
     threads: Option<usize>,
-) -> AlgorithmResult<String, OrderedFloat<f64>> {
+) -> AlgorithmResult<String, f64, OrderedFloat<f64>> {
     let mut ctx: Context<G, ComputeStateVec> = g.into();
 
     let min = sum(0);
@@ -135,7 +135,7 @@ pub fn all_local_reciprocity<G: GraphViewOps>(
 
     let mut runner: TaskRunner<G, _> = TaskRunner::new(ctx);
 
-    AlgorithmResult::new_with_float(runner.run(
+    AlgorithmResult::new(runner.run(
         vec![],
         vec![Job::new(step1)],
         None,
@@ -187,9 +187,6 @@ mod reciprocity_test {
         hash_map_result.insert("5".to_string(), 0.0);
 
         let res = all_local_reciprocity(&graph, None);
-        assert_eq!(
-            res.get(&"1".to_string()).unwrap().0,
-            *hash_map_result.get("1").unwrap()
-        );
+        assert_eq!(res.get("1"), hash_map_result.get("1"));
     }
 }

--- a/raphtory/src/python/graph/algorithm_result.rs
+++ b/raphtory/src/python/graph/algorithm_result.rs
@@ -3,22 +3,35 @@ use pyo3::prelude::*;
 
 /// Create a macro for py_algorithm_result
 macro_rules! py_algorithm_result {
-    ($name:ident, $rustKey:ty, $rustValue:ty) => {
+    ($name:ident, $rustKey:ty, $rustValue:ty, $rustSortValue:ty) => {
         #[pyclass]
         pub struct $name(
-            $crate::algorithms::algorithm_result::AlgorithmResult<$rustKey, $rustValue>,
+            $crate::algorithms::algorithm_result::AlgorithmResult<
+                $rustKey,
+                $rustValue,
+                $rustSortValue,
+            >,
         );
 
         impl pyo3::IntoPy<pyo3::PyObject>
-            for $crate::algorithms::algorithm_result::AlgorithmResult<$rustKey, $rustValue>
+            for $crate::algorithms::algorithm_result::AlgorithmResult<
+                $rustKey,
+                $rustValue,
+                $rustSortValue,
+            >
         {
             fn into_py(self, py: Python<'_>) -> pyo3::PyObject {
                 $name(self).into_py(py)
             }
         }
     };
+
+    ($name:ident, $rustKey:ty, $rustValue:ty) => {
+        py_algorithm_result!($name, $rustKey, $rustValue, $rustValue);
+    };
 }
 
+#[macro_export]
 macro_rules! py_algorithm_result_base {
     ($name:ident, $rustKey:ty, $rustValue:ty) => {
         #[pymethods]
@@ -63,6 +76,7 @@ macro_rules! py_algorithm_result_base {
     };
 }
 
+#[macro_export]
 macro_rules! py_algorithm_result_partial_ord {
     ($name:ident, $rustKey:ty, $rustValue:ty) => {
         #[pymethods]
@@ -123,6 +137,7 @@ macro_rules! py_algorithm_result_partial_ord {
     };
 }
 
+#[macro_export]
 macro_rules! py_algorithm_result_ord_hash_eq {
     ($name:ident, $rustKey:ty, $rustValue:ty) => {
         #[pymethods]
@@ -144,7 +159,12 @@ macro_rules! py_algorithm_result_ord_hash_eq {
 py_algorithm_result!(AlgorithmResultStrU64, String, u64);
 py_algorithm_result_ord_hash_eq!(AlgorithmResultStrU64, String, u64);
 
-py_algorithm_result!(AlgorithmResultStrTupleF32F32, String, (f32, f32));
+py_algorithm_result!(
+    AlgorithmResultStrTupleF32F32,
+    String,
+    (f32, f32),
+    (OrderedFloat<f32>, OrderedFloat<f32>)
+);
 py_algorithm_result_partial_ord!(AlgorithmResultStrTupleF32F32, String, (f32, f32));
 
 py_algorithm_result!(AlgorithmResultStrVecI64Str, String, Vec<(i64, String)>);
@@ -153,131 +173,5 @@ py_algorithm_result_ord_hash_eq!(AlgorithmResultStrVecI64Str, String, Vec<(i64, 
 py_algorithm_result!(AlgorithmResultU64VecUsize, u64, Vec<usize>);
 py_algorithm_result_ord_hash_eq!(AlgorithmResultU64VecUsize, u64, Vec<usize>);
 
-py_algorithm_result!(AlgorithmResultStrF64, String, OrderedFloat<f64>);
-
-#[pymethods]
-impl AlgorithmResultStrF64 {
-    /// Returns all results as a dict
-    fn get_all(&self) -> std::collections::HashMap<String, f64> {
-        self.0
-            .get_all()
-            .into_iter()
-            .map(|(key, of)| (key.clone(), of.into_inner()))
-            .collect()
-    }
-
-    /// Returns the value corresponding to the provided key
-    ///
-    /// # Arguments
-    ///
-    /// * `key`: The key of type `H` for which the value is to be retrieved.
-    fn get(&self, key: String) -> Option<f64> {
-        self.0.get(&key).map(|x| x.0)
-    }
-
-    /// Sorts the `AlgorithmResult` by its values in ascending or descending order.
-    ///
-    /// # Arguments
-    ///
-    /// * `reverse`: If `true`, sorts the result in descending order; otherwise, sorts in ascending order.
-    ///
-    /// # Returns
-    ///
-    /// A sorted vector of tuples containing keys of type `H` and values of type `Y`.
-    #[pyo3(signature = (reverse=true))]
-    fn sort_by_value(&self, reverse: bool) -> Vec<(String, f64)> {
-        self.0
-            .sort_by_value(reverse)
-            .into_iter()
-            .map(|(key, ordered_float)| (key, ordered_float.into_inner()))
-            .collect()
-    }
-
-    /// Sorts the `AlgorithmResult` by its keys in ascending or descending order.
-    ///
-    /// # Arguments
-    ///
-    /// * `reverse`: If `true`, sorts the result in descending order; otherwise, sorts in ascending order.
-    ///
-    /// # Returns
-    ///
-    /// A sorted vector of tuples containing keys of type `H` and values of type `Y`.
-    #[pyo3(signature = (reverse=true))]
-    fn sort_by_key(&self, reverse: bool) -> Vec<(String, f64)> {
-        self.0
-            .sort_by_key(reverse)
-            .into_iter()
-            .map(|(key, ordered_float)| (key, ordered_float.into_inner()))
-            .collect()
-    }
-
-    /// Retrieves the top-k elements from the `AlgorithmResult` based on its values.
-    ///
-    /// # Arguments
-    ///
-    /// * `k`: The number of elements to retrieve.
-    /// * `percentage`: If `true`, the `k` parameter is treated as a percentage of total elements.
-    /// * `reverse`: If `true`, retrieves the elements in descending order; otherwise, in ascending order.
-    ///
-    /// # Returns
-    ///
-    /// An `Option` containing a vector of tuples with keys of type `H` and values of type `Y`.
-    /// If `percentage` is `true`, the returned vector contains the top `k` percentage of elements.
-    /// If `percentage` is `false`, the returned vector contains the top `k` elements.
-    /// Returns `None` if the result is empty or if `k` is 0.
-    #[pyo3(signature = (k, percentage=false, reverse=true))]
-    fn top_k(&self, k: usize, percentage: bool, reverse: bool) -> Vec<(String, f64)> {
-        self.0
-            .top_k(k, percentage, reverse)
-            .into_iter()
-            .map(|vec| (vec.0, vec.1.into_inner()))
-            .collect()
-    }
-
-    /// Creates a dataframe from the result
-    ///
-    /// # Returns
-    ///
-    /// A `pandas.DataFrame` containing the result
-    #[pyo3(signature = ())]
-    fn to_df(&self) -> PyResult<PyObject> {
-        let hashmap: std::collections::HashMap<String, f64> = self
-            .0
-            .get_all()
-            .clone()
-            .into_iter()
-            .map(|(k, v)| (k, v.into()))
-            .collect();
-        let mut keys = Vec::new();
-        let mut values = Vec::new();
-        Python::with_gil(|py| {
-            for (key, value) in hashmap.iter() {
-                keys.push(key.to_object(py));
-                values.push(value.to_object(py));
-            }
-            let dict = pyo3::types::PyDict::new(py);
-            dict.set_item("Key", pyo3::types::PyList::new(py, keys.as_slice()))?;
-            dict.set_item("Value", pyo3::types::PyList::new(py, values.as_slice()))?;
-            let pandas = PyModule::import(py, "pandas")?;
-            let df: &PyAny = pandas.getattr("DataFrame")?.call1((dict,))?;
-            Ok(df.to_object(py))
-        })
-    }
-
-    /// Groups the `AlgorithmResult` by its values.
-    ///
-    /// # Returns
-    ///
-    /// A `HashMap` where keys are unique values from the `AlgorithmResult` and values are vectors
-    /// containing keys of type `H` that share the same value.
-    fn group_by(&self) -> std::collections::HashMap<String, Vec<String>> {
-        let ordered_map = self.0.group_by();
-        let mut f64_map: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
-        for (ordered_float, strings) in ordered_map {
-            let f64_value = ordered_float.into_inner();
-            f64_map.insert(f64_value.to_string().parse().unwrap(), strings);
-        }
-        f64_map
-    }
-}
+py_algorithm_result!(AlgorithmResultStrF64, String, f64, OrderedFloat<f64>);
+py_algorithm_result_partial_ord!(AlgorithmResultStrF64, String, f64);

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -92,7 +92,7 @@ pub fn pagerank(
     g: &PyGraphView,
     iter_count: usize,
     max_diff: Option<f64>,
-) -> AlgorithmResult<String, OrderedFloat<f64>> {
+) -> AlgorithmResult<String, f64, OrderedFloat<f64>> {
     unweighted_page_rank(&g.graph, iter_count, None, max_diff, true)
 }
 
@@ -242,7 +242,7 @@ pub fn global_reciprocity(g: &PyGraphView) -> f64 {
 ///     AlgorithmResult : AlgorithmResult with string keys and float values mapping each vertex name to its reciprocity value.
 ///
 #[pyfunction]
-pub fn all_local_reciprocity(g: &PyGraphView) -> AlgorithmResult<String, OrderedFloat<f64>> {
+pub fn all_local_reciprocity(g: &PyGraphView) -> AlgorithmResult<String, f64, OrderedFloat<f64>> {
     all_local_reciprocity_rs(&g.graph, None)
 }
 
@@ -369,7 +369,7 @@ pub fn hits(
     g: &PyGraphView,
     iter_count: usize,
     threads: Option<usize>,
-) -> AlgorithmResult<String, (f32, f32)> {
+) -> AlgorithmResult<String, (f32, f32), (OrderedFloat<f32>, OrderedFloat<f32>)> {
     hits_rs(&g.graph, iter_count, threads)
 }
 
@@ -396,6 +396,6 @@ pub fn balance(
     name: String,
     direction: PyDirection,
     threads: Option<usize>,
-) -> AlgorithmResult<String, OrderedFloat<f64>> {
+) -> AlgorithmResult<String, f64, OrderedFloat<f64>> {
     balance_rs(&g.graph, name.clone(), direction.into(), threads)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rework of the AlgorithmResult api's. Added methods that take closures (for types that or not ordered or overriding default ordering) and managed to make floats less annoying

### Why are the changes needed?


### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


