### PR TITLE
Support for writing external pyo3-based algorithm extensions

### DIFF
--- a/.github/workflows/test_python_workflow.yml
+++ b/.github/workflows/test_python_workflow.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           python -m pip install -q pytest networkx numpy seaborn pandas nbmake pytest-xdist matplotlib pyvis
           python -m pip install target/wheels/raphtory-*.whl
+          python -m pip install -e examples/custom_python_extension
       - name: Install Python dependencies (Windows)
         if: "contains(matrix.os, 'Windows')"
         run: |
@@ -80,6 +81,10 @@ jobs:
           Get-ChildItem -Path $folder_path -Recurse -Include *.whl | ForEach-Object {
             python -m pip install "$($_.FullName)"
           }
+          python -m pip install -e examples/custom_python_extension
       - name: Run Python tests
         run: |
-          cd python/tests && pytest --nbmake --nbmake-timeout=1200 .    
+          cd python/tests && pytest --nbmake --nbmake-timeout=1200 .
+      - name: Run Python extension tests
+        run: |
+          cd examples/custom_python_extension/test && pytest .

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,11 @@ examples/py/enron/emails.csv
 /docs/lib/
 /docs/build/
 docs/source/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+.pytest_cache/
+*.py[cod]
+
+# C extensions
+*.so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_python_extension"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
+ "pyo3-build-config",
+ "raphtory",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
 	"raphtory",
 	"raphtory-benchmark",
 	"examples/rust",
+	"examples/custom_python_extension",
 	"python",
 	"js-raphtory",
 	"raphtory-graphql",

--- a/examples/custom_python_extension/Cargo.toml
+++ b/examples/custom_python_extension/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "custom_python_extension"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+raphtory = {path = "../../raphtory", features = ["python"]}
+pyo3 = "0.19.2"
+
+[lib]
+crate-type = ["cdylib"]
+
+
+[build-dependencies]
+pyo3-build-config = "0.19.2"

--- a/examples/custom_python_extension/build.rs
+++ b/examples/custom_python_extension/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}

--- a/examples/custom_python_extension/pyproject.toml
+++ b/examples/custom_python_extension/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["maturin>=0.13,<0.14"]
+build-backend = "maturin"
+
+[project]
+name = "custom_python_extension"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+    "raphtory"
+]
+
+
+[project.urls]
+homepage = "https://github.com/pometry/raphtory"
+documentation = "https://docs.raphtory.com/"
+repository = "https://github.com/pometry/raphtory"
+twitter = "https://twitter.com/raphtory/"
+slack = "https://join.slack.com/t/raphtory/shared_invite/zt-xbebws9j-VgPIFRleJFJBwmpf81tvxA"
+youtube = "https://www.youtube.com/@pometry8546/videos"
+
+[project.optional-dependencies]
+export = ["pyvis >= 0.3.2", "networkx >= 2.6.3", "matplotlib >= 3.4.3", "seaborn >= 0.11.2"]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+python-source = "python"

--- a/examples/custom_python_extension/python/custom_python_extension/__init__.py
+++ b/examples/custom_python_extension/python/custom_python_extension/__init__.py
@@ -1,0 +1,1 @@
+from .custom_python_extension import *

--- a/examples/custom_python_extension/src/lib.rs
+++ b/examples/custom_python_extension/src/lib.rs
@@ -1,0 +1,17 @@
+use pyo3::prelude::*;
+use raphtory::{db::api::view::internal::DynamicGraph, prelude::GraphViewOps};
+
+fn custom_algorithm<G: GraphViewOps>(graph: &G) -> usize {
+    graph.num_vertices()
+}
+
+#[pyfunction(name = "custom_algorithm")]
+fn py_custom_algorithm(graph: DynamicGraph) -> usize {
+    custom_algorithm(&graph)
+}
+
+#[pymodule]
+fn custom_python_extension(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(py_custom_algorithm, m)?)?;
+    Ok(())
+}

--- a/examples/custom_python_extension/test/test_custom_algorithm.py
+++ b/examples/custom_python_extension/test/test_custom_algorithm.py
@@ -1,5 +1,6 @@
 from raphtory import Graph
 from custom_python_extension import custom_algorithm
+from pytest import raises
 
 
 def test_custom_algorithm():
@@ -7,3 +8,9 @@ def test_custom_algorithm():
     for v in range(10):
         g.add_vertex(0, v)
     assert custom_algorithm(g) == 10
+
+
+def test_error_for_wrong_type():
+    """ calling with the wrong type should still raise a type error (unless it defines a bincode method)"""
+    with raises(TypeError):
+        custom_algorithm(1)

--- a/examples/custom_python_extension/test/test_custom_algorithm.py
+++ b/examples/custom_python_extension/test/test_custom_algorithm.py
@@ -1,0 +1,9 @@
+from raphtory import Graph
+from custom_python_extension import custom_algorithm
+
+
+def test_custom_algorithm():
+    g = Graph()
+    for v in range(10):
+        g.add_vertex(0, v)
+    assert custom_algorithm(g) == 10

--- a/python/tests/test_graph_conversions.py
+++ b/python/tests/test_graph_conversions.py
@@ -2,15 +2,18 @@ from raphtory import Graph
 from raphtory import export
 import pandas as pd
 import json
+from pathlib import Path
+
+base_dir = Path(__file__).parent
 
 
 def build_graph():
-    edges_df = pd.read_csv("data/network_traffic_edges.csv")
+    edges_df = pd.read_csv(base_dir / "data/network_traffic_edges.csv")
     edges_df["timestamp"] = pd.to_datetime(edges_df["timestamp"]).astype(
         "datetime64[ms, UTC]"
     )
 
-    vertices_df = pd.read_csv("data/network_traffic_vertices.csv")
+    vertices_df = pd.read_csv(base_dir / "data/network_traffic_vertices.csv")
     vertices_df["timestamp"] = pd.to_datetime(vertices_df["timestamp"]).astype(
         "datetime64[ms, UTC]"
     )
@@ -951,56 +954,56 @@ def test_to_df():
     g = build_graph()
 
     compare_df(
-        export.to_edge_df(g), pd.read_json("expected/dataframe_output/edge_df_all.json")
+        export.to_edge_df(g), pd.read_json(base_dir / "expected/dataframe_output/edge_df_all.json")
     )
 
     compare_df(
         export.to_edge_df(g, include_edge_properties=False),
-        pd.read_json("expected/dataframe_output/edge_df_no_props.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_no_props.json"),
     )
 
     compare_df(
         export.to_edge_df(g, include_update_history=False),
-        pd.read_json("expected/dataframe_output/edge_df_no_hist.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_no_hist.json"),
     )
 
     compare_df(
         export.to_edge_df(g, include_property_histories=False),
-        pd.read_json("expected/dataframe_output/edge_df_no_prop_hist.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_no_prop_hist.json"),
     )
 
     compare_df(
         export.to_edge_df(g, explode_edges=True),
-        pd.read_json("expected/dataframe_output/edge_df_exploded.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_exploded.json"),
     )
     compare_df(
         export.to_edge_df(g, explode_edges=True, include_edge_properties=False),
-        pd.read_json("expected/dataframe_output/edge_df_exploded_no_props.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_exploded_no_props.json"),
     )
 
     compare_df(
         export.to_edge_df(g, explode_edges=True, include_update_history=False),
-        pd.read_json("expected/dataframe_output/edge_df_exploded_no_hist.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_exploded_no_hist.json"),
     )
 
     compare_df(
         export.to_edge_df(g, explode_edges=True, include_property_histories=False),
-        pd.read_json("expected/dataframe_output/edge_df_exploded_no_prop_hist.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_exploded_no_prop_hist.json"),
     )
 
     compare_df(
         export.to_vertex_df(g),
-        pd.read_json("expected/dataframe_output/vertex_df_all.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/vertex_df_all.json"),
     )
     compare_df(
         export.to_vertex_df(g, include_vertex_properties=False),
-        pd.read_json("expected/dataframe_output/vertex_df_no_props.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/vertex_df_no_props.json"),
     )
     compare_df(
         export.to_vertex_df(g, include_update_history=False),
-        pd.read_json("expected/dataframe_output/vertex_df_no_hist.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/vertex_df_no_hist.json"),
     )
     compare_df(
         export.to_vertex_df(g, include_property_histories=False),
-        pd.read_json("expected/dataframe_output/vertex_df_no_prop_hist.json"),
+        pd.read_json(base_dir / "expected/dataframe_output/vertex_df_no_prop_hist.json"),
     )

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -76,6 +76,16 @@ impl MaterializedGraph {
         let mut writer = std::io::BufWriter::new(f);
         Ok(bincode::serialize_into(&mut writer, self)?)
     }
+
+    pub fn bincode(&self) -> Result<Vec<u8>, GraphError> {
+        let encoded = bincode::serialize(self)?;
+        Ok(encoded)
+    }
+
+    pub fn from_bincode(b: &[u8]) -> Result<Self, GraphError> {
+        let g = bincode::deserialize(b)?;
+        Ok(g)
+    }
 }
 
 #[enum_dispatch]

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     python::graph::pandas::{load_edges_props_from_df, load_vertex_props_from_df},
 };
-use pyo3::types::IntoPyDict;
+use pyo3::types::{IntoPyDict, PyBytes};
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
@@ -38,7 +38,7 @@ use super::pandas::{
 #[derive(Clone)]
 #[pyclass(name="Graph", extends=PyGraphView)]
 pub struct PyGraph {
-    pub(crate) graph: Graph,
+    pub graph: Graph,
 }
 
 impl Debug for PyGraph {
@@ -246,6 +246,12 @@ impl PyGraph {
     /// None
     pub fn save_to_file(&self, path: &str) -> Result<(), GraphError> {
         self.graph.save_to_file(Path::new(path))
+    }
+
+    /// Get bincode encoded graph
+    pub fn bincode<'py>(&'py self, py: Python<'py>) -> Result<&'py PyBytes, GraphError> {
+        let bytes = MaterializedGraph::from(self.graph.clone()).bincode()?;
+        Ok(PyBytes::new(py, &bytes))
     }
 
     #[staticmethod]

--- a/raphtory/src/python/graph/graph_with_deletions.rs
+++ b/raphtory/src/python/graph/graph_with_deletions.rs
@@ -8,7 +8,10 @@
 use crate::{
     core::{entities::vertices::vertex_ref::VertexRef, utils::errors::GraphError, Prop},
     db::{
-        api::mutation::{AdditionOps, PropertyAdditionOps},
+        api::{
+            mutation::{AdditionOps, PropertyAdditionOps},
+            view::internal::MaterializedGraph,
+        },
         graph::{edge::EdgeView, vertex::VertexView, views::deletion_graph::GraphWithDeletions},
     },
     prelude::{DeletionOps, GraphViewOps},
@@ -17,7 +20,7 @@ use crate::{
         utils::{PyInputVertex, PyTime},
     },
 };
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PyBytes};
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
@@ -232,5 +235,11 @@ impl PyGraphWithDeletions {
     /// None
     pub fn save_to_file(&self, path: &str) -> Result<(), GraphError> {
         self.graph.save_to_file(Path::new(path))
+    }
+
+    /// Get bincode encoded graph
+    pub fn bincode<'py>(&'py self, py: Python<'py>) -> Result<&'py PyBytes, GraphError> {
+        let bytes = MaterializedGraph::from(self.graph.clone()).bincode()?;
+        Ok(PyBytes::new(py, &bytes))
     }
 }

--- a/raphtory/src/python/graph/views/graph_view.rs
+++ b/raphtory/src/python/graph/views/graph_view.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 use chrono::prelude::*;
 use itertools::Itertools;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PyBytes};
 use std::ops::Deref;
 
 impl IntoPy<PyObject> for MaterializedGraph {
@@ -50,8 +50,23 @@ impl IntoPy<PyObject> for DynamicGraph {
     }
 }
 
+impl<'source> FromPyObject<'source> for DynamicGraph {
+    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+        ob.extract::<PyRef<PyGraphView>>()
+            .map(|g| g.graph.clone())
+            .or_else(|_| {
+                println!("attempting bincode roundtrip due to crate boundary");
+                let res = ob.call_method0("bincode")?;
+                let b = res.extract::<&[u8]>()?;
+                let g = MaterializedGraph::from_bincode(b)?;
+                Ok(g.into_dynamic())
+            })
+    }
+}
 /// Graph view is a read-only version of a graph at a certain point in time.
+
 #[pyclass(name = "GraphView", frozen, subclass)]
+#[repr(C)]
 pub struct PyGraphView {
     pub graph: DynamicGraph,
 }
@@ -376,6 +391,12 @@ impl PyGraphView {
     ///    GraphView - Returns a graph clone
     fn materialize(&self) -> Result<MaterializedGraph, GraphError> {
         self.graph.materialize()
+    }
+
+    /// Get bincode encoded graph
+    pub fn bincode<'py>(&'py self, py: Python<'py>) -> Result<&'py PyBytes, GraphError> {
+        let bytes = self.graph.materialize()?.bincode()?;
+        Ok(PyBytes::new(py, &bytes))
     }
 
     /// Displays the graph

--- a/raphtory/src/python/graph/views/graph_view.rs
+++ b/raphtory/src/python/graph/views/graph_view.rs
@@ -54,9 +54,9 @@ impl<'source> FromPyObject<'source> for DynamicGraph {
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
         ob.extract::<PyRef<PyGraphView>>()
             .map(|g| g.graph.clone())
-            .or_else(|_| {
-                println!("attempting bincode roundtrip due to crate boundary");
-                let res = ob.call_method0("bincode")?;
+            .or_else(|err| {
+                let res = ob.call_method0("bincode").map_err(|_| err)?; // return original error as probably more helpful
+                                                                        // assume we have a graph at this point, the res probably should not fail
                 let b = res.extract::<&[u8]>()?;
                 let g = MaterializedGraph::from_bincode(b)?;
                 Ok(g.into_dynamic())


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Make it possible to pass a python raphtory graph across crate boundary using a bincode roundtrip
- Add methods to get bincode without saving to file

### Why are the changes needed?

Trying to use a python graph created by a different python extension built against raphtory fails with a type error without this change

### Does this PR introduce any user-facing change? If yes is this documented?

adds `bincode` methods 

### How was this patch tested?

added a dummy extension example with tests

### Are there any further changes required?

Maybe there is a better way to do this without requiring serialising and deserialising the graph?

