### PR TITLE
String deduplication

### DIFF
--- a/examples/rust/src/bin/lotr/main.rs
+++ b/examples/rust/src/bin/lotr/main.rs
@@ -59,14 +59,14 @@ fn main() {
                 g.add_vertex(
                     lotr.time,
                     lotr.src_id.clone(),
-                    [("type".to_string(), Prop::Str("Character".to_string()))],
+                    [("type", Prop::str("Character"))],
                 )
                 .expect("Failed to add vertex");
 
                 g.add_vertex(
                     lotr.time,
                     lotr.dst_id.clone(),
-                    [("type".to_string(), Prop::Str("Character".to_string()))],
+                    [("type", Prop::str("Character"))],
                 )
                 .expect("Failed to add vertex");
 
@@ -74,10 +74,7 @@ fn main() {
                     lotr.time,
                     lotr.src_id.clone(),
                     lotr.dst_id.clone(),
-                    [(
-                        "type".to_string(),
-                        Prop::Str("Character Co-occurrence".to_string()),
-                    )],
+                    [("type", Prop::str("Character Co-occurrence"))],
                     None,
                 )
                 .expect("Failed to add edge");

--- a/js-raphtory/src/graph/edge.rs
+++ b/js-raphtory/src/graph/edge.rs
@@ -4,7 +4,7 @@ use raphtory::db::{
     api::view::*,
     graph::{edge::EdgeView, graph::Graph as TGraph},
 };
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/js-raphtory/src/graph/edge.rs
+++ b/js-raphtory/src/graph/edge.rs
@@ -39,7 +39,7 @@ impl Edge {
         let t_props = self.0.properties();
         let obj = js_sys::Map::new();
         for (k, v) in t_props.iter() {
-            obj.set(&k.deref().into(), &JsProp(v).into());
+            obj.set(&k.to_string().into(), &JsProp(v).into());
         }
         obj
     }

--- a/js-raphtory/src/graph/misc.rs
+++ b/js-raphtory/src/graph/misc.rs
@@ -21,7 +21,7 @@ impl From<JsProp> for JsValue {
         match value.0 {
             raphtory::core::Prop::U8(v) => v.into(),
             raphtory::core::Prop::U16(v) => v.into(),
-            raphtory::core::Prop::Str(v) => v.into(),
+            raphtory::core::Prop::Str(v) => v.to_string().into(),
             raphtory::core::Prop::I32(v) => v.into(),
             raphtory::core::Prop::I64(v) => v.into(),
             raphtory::core::Prop::U32(v) => v.into(),
@@ -68,6 +68,6 @@ impl From<JsObjectEntry> for Option<(String, Prop)> {
 
         let key = arr.at(0).as_string().unwrap();
         let value = arr.at(1).as_string().unwrap();
-        Some((key, Prop::Str(value)))
+        Some((key, Prop::str(value)))
     }
 }

--- a/js-raphtory/src/graph/mod.rs
+++ b/js-raphtory/src/graph/mod.rs
@@ -99,7 +99,7 @@ impl Graph {
     #[wasm_bindgen(js_name = addVertex)]
     pub fn add_vertex_js(&self, t: i64, id: JsValue, js_props: Object) -> Result<Vertex, JSError> {
         let rust_props = if js_props.is_string() {
-            vec![("name".to_string(), Prop::Str(js_props.as_string().unwrap()))]
+            vec![("name".to_string(), Prop::str(js_props.as_string().unwrap()))]
         } else if js_props.is_object() {
             Object::entries(&js_props)
                 .iter()

--- a/js-raphtory/src/graph/vertex.rs
+++ b/js-raphtory/src/graph/vertex.rs
@@ -100,7 +100,7 @@ impl Vertex {
     pub fn properties(&self) -> js_sys::Map {
         let obj = js_sys::Map::new();
         for (k, v) in self.0.properties() {
-            obj.set(&k.into(), &JsProp(v).into());
+            obj.set(&k.to_string().into(), &JsProp(v).into());
         }
         obj
     }

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -74,7 +74,7 @@ impl Data {
                 println!("loading graph from {path}");
                 let graph = Graph::load_from_file(&path).expect("Unable to load from graph");
                 graph
-                    .add_constant_properties([("path".to_string(), Prop::Str(path.clone()))])
+                    .add_constant_properties([("path".to_string(), Prop::str(path.clone()))])
                     .expect("Failed to add static property");
                 let maybe_graph_name = graph.properties().get("name");
 

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -202,18 +202,10 @@ mod graphql_test {
         if let Err(err) = graph.add_vertex(0, "gandalf", NO_PROPS) {
             panic!("Could not add vertex! {:?}", err);
         }
-        if let Err(err) = graph.add_vertex(
-            0,
-            "bilbo",
-            [("food".to_string(), Prop::Str("lots".to_string()))],
-        ) {
+        if let Err(err) = graph.add_vertex(0, "bilbo", [("food".to_string(), Prop::str("lots"))]) {
             panic!("Could not add vertex! {:?}", err);
         }
-        if let Err(err) = graph.add_vertex(
-            0,
-            "frodo",
-            [("food".to_string(), Prop::Str("some".to_string()))],
-        ) {
+        if let Err(err) = graph.add_vertex(0, "frodo", [("food".to_string(), Prop::str("some"))]) {
             panic!("Could not add vertex! {:?}", err);
         }
 

--- a/raphtory-graphql/src/model/filters/edge_filter.rs
+++ b/raphtory-graphql/src/model/filters/edge_filter.rs
@@ -43,8 +43,7 @@ impl EdgeFilter {
             return edge
                 .ee
                 .layer_names()
-                .iter()
-                .any(|name| name_filter.contains(name));
+                .any(|name| name_filter.contains(&name));
         }
 
         if let Some(property_has_filter) = &self.property_has {

--- a/raphtory-graphql/src/model/filters/property_filter.rs
+++ b/raphtory-graphql/src/model/filters/property_filter.rs
@@ -62,7 +62,7 @@ fn valid_prop(prop: Prop, value_str: &Option<String>, num_filter: &Option<Number
 
 fn value_neq_str_prop(value: &str, prop: &Prop) -> bool {
     if let Prop::Str(prop_str) = prop {
-        return value != prop_str;
+        return prop_str != value;
     }
 
     false

--- a/raphtory-graphql/src/model/graph/edge.rs
+++ b/raphtory-graphql/src/model/graph/edge.rs
@@ -1,5 +1,6 @@
 use crate::model::graph::node::Node;
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
+use itertools::Itertools;
 use raphtory::db::{
     api::view::{
         internal::{DynamicGraph, IntoDynamic},
@@ -47,7 +48,7 @@ impl Edge {
     }
 
     async fn layers(&self) -> Vec<String> {
-        self.ee.layer_names()
+        self.ee.layer_names().map_into().collect()
     }
 
     async fn history(&self) -> Vec<i64> {

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -46,7 +46,7 @@ impl GraphMeta {
             .properties()
             .constant()
             .into_iter()
-            .map(|(k, v)| Property::new(k, v))
+            .map(|(k, v)| Property::new(k.into(), v))
             .collect()
     }
 
@@ -87,7 +87,7 @@ impl GqlGraph {
     }
 
     async fn layer_names(&self) -> Vec<String> {
-        self.graph.unique_layers()
+        self.graph.unique_layers().map_into().collect()
     }
 
     async fn static_properties(&self) -> Vec<Property> {
@@ -95,7 +95,7 @@ impl GqlGraph {
             .properties()
             .constant()
             .into_iter()
-            .map(|(k, v)| Property::new(k, v))
+            .map(|(k, v)| Property::new(k.into(), v))
             .collect()
     }
 

--- a/raphtory-graphql/src/model/graph/mod.rs
+++ b/raphtory-graphql/src/model/graph/mod.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use raphtory::{
+    core::ArcStr,
     db::{
         api::view::internal::DynamicGraph,
         graph::{edge::EdgeView, vertex::VertexView},
@@ -26,7 +27,7 @@ fn get_expanded_edges(
 
     let mut filtered_fetched_edges = match maybe_layers {
         Some(layers) => {
-            let layer_set: HashSet<String> = layers.into_iter().collect();
+            let layer_set: HashSet<ArcStr> = layers.into_iter().map_into().collect();
             fetched_edges
                 .filter(|e| {
                     e.layer_names()

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -60,7 +60,7 @@ impl Node {
             self.vv
                 .properties()
                 .iter()
-                .map(|(k, v)| Property::new(k.clone(), v))
+                .map(|(k, v)| Property::new(k.into(), v))
                 .collect(),
         )
     }

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -120,7 +120,7 @@ impl Mut {
 
         let subgraph = data.get(&graph_name).ok_or("Graph not found")?;
         let path = subgraph
-            .static_prop(&"path".to_string())
+            .constant_prop(&"path".to_string())
             .expect("Path is missing")
             .to_string();
 
@@ -133,7 +133,7 @@ impl Mut {
             .add_constant_properties(subgraph.properties().constant())
             .expect("Failed to add static properties");
         new_subgraph
-            .add_constant_properties([("uiProps".to_string(), Prop::Str(props))])
+            .add_constant_properties([("uiProps".to_string(), Prop::str(props))])
             .expect("Failed to add static property");
 
         new_subgraph

--- a/raphtory-graphql/src/model/schema/edge_schema.rs
+++ b/raphtory-graphql/src/model/schema/edge_schema.rs
@@ -58,10 +58,8 @@ impl<G: GraphViewOps> EdgeSchema<G> {
 }
 
 fn collect_edge_schema<G: GraphViewOps>(edge: EdgeView<G>) -> SchemaAggregate {
-    let pairs = edge
-        .properties()
+    edge.properties()
         .iter()
-        .map(|(key, value)| (key.to_owned(), HashSet::from([value.to_string()])))
-        .collect_vec();
-    HashMap::from_iter(pairs)
+        .map(|(key, value)| (key.to_string(), HashSet::from([value.to_string()])))
+        .collect()
 }

--- a/raphtory-graphql/src/model/schema/graph_schema.rs
+++ b/raphtory-graphql/src/model/schema/graph_schema.rs
@@ -24,7 +24,6 @@ impl GraphSchema {
 
         let layers = graph
             .unique_layers()
-            .iter()
             .map(|layer_name| graph.layer(layer_name).unwrap().into())
             .collect_vec();
 

--- a/raphtory-graphql/src/model/schema/layer_schema.rs
+++ b/raphtory-graphql/src/model/schema/layer_schema.rs
@@ -21,10 +21,13 @@ impl<G: GraphViewOps> From<LayeredGraph<G>> for LayerSchema<G> {
 impl<G: GraphViewOps> LayerSchema<G> {
     /// Returns the name of the layer with this schema
     async fn name(&self) -> String {
-        match &self.graph.unique_layers()[..] {
-            [layer] => layer.clone(),
-            _ => panic!("Layered graph outputted more than one layer name"),
-        }
+        let mut layers = self.graph.unique_layers();
+        let layer = layers.next().expect("Layered graph has a layer");
+        debug_assert!(
+            layers.next().is_none(),
+            "Layered graph outputted more than one layer name"
+        );
+        layer.into()
     }
     /// Returns the list of edge schemas for this edge layer
     async fn edges(&self) -> Vec<EdgeSchema<LayeredGraph<G>>> {

--- a/raphtory-graphql/src/model/schema/node_schema.rs
+++ b/raphtory-graphql/src/model/schema/node_schema.rs
@@ -48,10 +48,9 @@ impl NodeSchema {
 }
 
 fn collect_vertex_schema(vertex: VertexView<DynamicGraph>) -> SchemaAggregate {
-    let pairs = vertex
+    vertex
         .properties()
         .iter()
-        .map(|(key, value)| (key.to_owned(), HashSet::from([value.to_string()])))
-        .collect_vec();
-    HashMap::from_iter(pairs)
+        .map(|(key, value)| (key.to_string(), HashSet::from([value.to_string()])))
+        .collect()
 }

--- a/raphtory/src/core/entities/graph/tgraph.rs
+++ b/raphtory/src/core/entities/graph/tgraph.rs
@@ -266,7 +266,7 @@ impl<const N: usize> TemporalGraph<N> {
     }
 
     pub(crate) fn vertex_reverse_prop_id(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
-        self.vertex_meta.reverse_prop_id(prop_id, is_static)
+        self.vertex_meta.get_prop_name(prop_id, is_static)
     }
 
     pub(crate) fn edge_temp_prop_ids(&self, e: EID) -> Vec<usize> {
@@ -280,15 +280,15 @@ impl<const N: usize> TemporalGraph<N> {
     }
 
     pub(crate) fn edge_find_prop(&self, prop: &str, is_static: bool) -> Option<usize> {
-        self.edge_meta.find_prop_id(prop, is_static)
+        self.edge_meta.get_prop_id(prop, is_static)
     }
 
     pub(crate) fn vertex_find_prop(&self, prop: &str, is_static: bool) -> Option<usize> {
-        self.vertex_meta.find_prop_id(prop, is_static)
+        self.vertex_meta.get_prop_id(prop, is_static)
     }
 
     pub(crate) fn edge_reverse_prop_id(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
-        self.edge_meta.reverse_prop_id(prop_id, is_static)
+        self.edge_meta.get_prop_name(prop_id, is_static)
     }
 }
 
@@ -390,7 +390,7 @@ impl<const N: usize> TemporalGraph<N> {
             layer.add_constant_prop(prop_id, prop).map_err(|err| {
                 IllegalMutate::from_source(
                     err,
-                    &self.edge_meta.reverse_prop_id(prop_id, true).unwrap(),
+                    &self.edge_meta.get_prop_name(prop_id, true).unwrap(),
                 )
             })?;
         }

--- a/raphtory/src/core/entities/graph/tgraph.rs
+++ b/raphtory/src/core/entities/graph/tgraph.rs
@@ -302,21 +302,15 @@ impl<const N: usize> TemporalGraph<N> {
         match filter {
             None => match layers {
                 LayerIds::All => self.storage.edges.len(),
-                _ => self
-                    .storage
-                    .edges
-                    .read_lock()
-                    .into_par_iter()
-                    .filter(|e| e.has_layer(layers))
-                    .count(),
+                _ => {
+                    let guard = self.storage.edges.read_lock();
+                    guard.par_iter().filter(|e| e.has_layer(layers)).count()
+                }
             },
-            Some(filter) => self
-                .storage
-                .edges
-                .read_lock()
-                .into_par_iter()
-                .filter(|e| filter(e, layers))
-                .count(),
+            Some(filter) => {
+                let guard = self.storage.edges.read_lock();
+                guard.par_iter().filter(|e| filter(e, layers)).count()
+            }
         }
     }
 

--- a/raphtory/src/core/entities/properties/props.rs
+++ b/raphtory/src/core/entities/properties/props.rs
@@ -66,7 +66,7 @@ impl Props {
     pub fn temporal_props(&self, prop_id: usize) -> Box<dyn Iterator<Item = (i64, Prop)> + '_> {
         let o = self.temporal_props.get(prop_id);
         if let Some(t_prop) = o {
-            Box::new(t_prop.iter().map(|(t, p)| (t, p.clone())))
+            Box::new(t_prop.iter())
         } else {
             Box::new(std::iter::empty())
         }
@@ -80,11 +80,7 @@ impl Props {
     ) -> Box<dyn Iterator<Item = (i64, Prop)> + '_> {
         let o = self.temporal_props.get(prop_id);
         if let Some(t_prop) = o {
-            Box::new(
-                t_prop
-                    .iter_window(t_start..t_end)
-                    .map(|(t, p)| (t, p.clone())),
-            )
+            Box::new(t_prop.iter_window(t_start..t_end))
         } else {
             Box::new(std::iter::empty())
         }
@@ -155,7 +151,7 @@ impl Meta {
     }
 
     #[inline]
-    pub fn find_prop_id(&self, name: &str, is_static: bool) -> Option<usize> {
+    pub fn get_prop_id(&self, name: &str, is_static: bool) -> Option<usize> {
         if is_static {
             self.meta_prop_constant.get_id(name)
         } else {
@@ -193,7 +189,7 @@ impl Meta {
         }
     }
 
-    pub fn reverse_prop_id(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
+    pub fn get_prop_name(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
         if is_static {
             self.meta_prop_constant.get_name(prop_id)
         } else {
@@ -315,12 +311,6 @@ impl Deref for PropMapper {
 }
 
 impl PropMapper {
-    pub fn get_or_create_id<Q>(&self, name: &Q) -> usize
-    where
-        Q: Hash + Eq + ?Sized + ToOwned<Owned = String>,
-    {
-        todo!()
-    }
     fn get_or_create_and_validate(&self, prop: &str, dtype: PropType) -> Result<usize, GraphError> {
         let id = self.id_mapper.get_or_create_id(prop);
         let dtype_read = self.dtypes.read_recursive();
@@ -365,6 +355,10 @@ impl PropMapper {
                 Ok(id)
             }
         }
+    }
+
+    pub fn get_dtype(&self, prop_id: usize) -> Option<PropType> {
+        self.dtypes.read_recursive().get(prop_id).copied()
     }
 }
 

--- a/raphtory/src/core/entities/properties/props.rs
+++ b/raphtory/src/core/entities/properties/props.rs
@@ -6,8 +6,9 @@ use crate::core::{
         timeindex::TimeIndexEntry,
     },
     utils::errors::{GraphError, IllegalMutate, MutateGraphError},
-    Prop, PropType,
+    ArcStr, Prop, PropType,
 };
+use lock_api;
 use parking_lot::{RwLock, RwLockReadGuard};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -15,8 +16,14 @@ use std::{
     fmt::Debug,
     hash::Hash,
     ops::Deref,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
+use tantivy::HasLen;
+
+type ArcRwLockReadGuard<T> = lock_api::ArcRwLockReadGuard<parking_lot::RawRwLock, T>;
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct Props {
@@ -104,20 +111,20 @@ impl Props {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Meta {
     meta_prop_temporal: PropMapper,
-    meta_prop_static: PropMapper,
-    meta_layer: DictMapper<String>,
+    meta_prop_constant: PropMapper,
+    meta_layer: DictMapper,
 }
 
 impl Meta {
-    pub fn static_prop_meta(&self) -> &PropMapper {
-        &self.meta_prop_static
+    pub fn constant_prop_meta(&self) -> &PropMapper {
+        &self.meta_prop_constant
     }
 
     pub fn temporal_prop_meta(&self) -> &PropMapper {
         &self.meta_prop_temporal
     }
 
-    pub fn layer_meta(&self) -> &DictMapper<String> {
+    pub fn layer_meta(&self) -> &DictMapper {
         &self.meta_layer
     }
 
@@ -126,7 +133,7 @@ impl Meta {
         meta_layer.get_or_create_id("_default");
         Self {
             meta_prop_temporal: PropMapper::default(),
-            meta_prop_static: PropMapper::default(),
+            meta_prop_constant: PropMapper::default(),
             meta_layer, // layer 0 is the default layer
         }
     }
@@ -139,7 +146,7 @@ impl Meta {
         is_static: bool,
     ) -> Result<usize, GraphError> {
         if is_static {
-            self.meta_prop_static
+            self.meta_prop_constant
                 .get_or_create_and_validate(prop, dtype)
         } else {
             self.meta_prop_temporal
@@ -150,9 +157,9 @@ impl Meta {
     #[inline]
     pub fn find_prop_id(&self, name: &str, is_static: bool) -> Option<usize> {
         if is_static {
-            self.meta_prop_static.get(&name.to_owned())
+            self.meta_prop_constant.get_id(name)
         } else {
-            self.meta_prop_temporal.get(&name.to_owned())
+            self.meta_prop_temporal.get_id(name)
         }
     }
 
@@ -167,7 +174,7 @@ impl Meta {
     }
 
     pub fn get_layer_name_by_id(&self, id: usize) -> Option<String> {
-        self.meta_layer.reverse_lookup(id).map(|v| v.to_string())
+        self.meta_layer.get_name(id).map(|v| v.to_string())
     }
 
     pub fn get_all_layers(&self) -> Vec<usize> {
@@ -178,48 +185,87 @@ impl Meta {
             .collect()
     }
 
-    pub fn get_all_property_names(&self, is_static: bool) -> Vec<String> {
+    pub fn get_all_property_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr> {
         if is_static {
-            self.meta_prop_static
-                .map
-                .iter()
-                .map(|entry| entry.key().clone())
-                .collect()
+            self.meta_prop_constant.get_keys()
         } else {
-            self.meta_prop_temporal
-                .map
-                .iter()
-                .map(|entry| entry.key().clone())
-                .collect()
+            self.meta_prop_temporal.get_keys()
         }
     }
 
-    pub fn reverse_prop_id(&self, prop_id: usize, is_static: bool) -> Option<LockedView<String>> {
+    pub fn reverse_prop_id(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
         if is_static {
-            self.meta_prop_static.reverse_lookup(prop_id)
+            self.meta_prop_constant.get_name(prop_id)
         } else {
-            self.meta_prop_temporal.reverse_lookup(prop_id)
+            self.meta_prop_temporal.get_name(prop_id)
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
-pub struct DictMapper<T: Hash + Eq> {
-    map: FxDashMap<T, usize>,
-    reverse_map: RwLock<Vec<T>>, //FIXME: a boxcar vector would be a great fit if it was serializable...
+pub struct DictMapper {
+    map: FxDashMap<ArcStr, usize>,
+    reverse_map: Arc<RwLock<Vec<ArcStr>>>, //FIXME: a boxcar vector would be a great fit if it was serializable...
 }
 
-impl<T: Hash + Eq + Clone + Debug> DictMapper<T> {
-    pub fn get_or_create_id<Q>(&self, name: &Q) -> usize
+#[derive(Debug)]
+pub struct ArcReadLockedVec<T> {
+    guard: ArcRwLockReadGuard<Vec<T>>,
+}
+
+impl<T> Deref for ArcReadLockedVec<T> {
+    type Target = Vec<T>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.guard.deref()
+    }
+}
+
+impl<T: Clone> IntoIterator for ArcReadLockedVec<T> {
+    type Item = T;
+    type IntoIter = LockedIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let guard = self.guard;
+        let len = guard.len();
+        let pos = 0;
+        LockedIter { guard, pos, len }
+    }
+}
+
+pub struct LockedIter<T> {
+    guard: ArcRwLockReadGuard<Vec<T>>,
+    pos: usize,
+    len: usize,
+}
+
+impl<T: Clone> Iterator for LockedIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos < self.len {
+            let next_val = Some(self.guard[self.pos].clone());
+            self.pos += 1;
+            next_val
+        } else {
+            None
+        }
+    }
+}
+
+impl DictMapper {
+    pub fn get_or_create_id<Q, T>(&self, name: &Q) -> usize
     where
-        T: Borrow<Q>,
+        ArcStr: Borrow<Q>,
         Q: Hash + Eq + ?Sized + ToOwned<Owned = T>,
+        T: Into<ArcStr>,
     {
         if let Some(existing_id) = self.map.get(name) {
             return *existing_id;
         }
 
-        let name = name.to_owned();
+        let name = name.to_owned().into();
         let new_id = self.map.entry(name.clone()).or_insert_with(|| {
             let mut reverse = self.reverse_map.write();
             let id = reverse.len();
@@ -229,17 +275,19 @@ impl<T: Hash + Eq + Clone + Debug> DictMapper<T> {
         *new_id
     }
 
-    pub fn get(&self, name: &T) -> Option<usize> {
+    pub fn get_id(&self, name: &str) -> Option<usize> {
         self.map.get(name).map(|id| *id)
     }
 
-    pub fn reverse_lookup(&self, id: usize) -> Option<LockedView<T>> {
+    pub fn get_name(&self, id: usize) -> Option<ArcStr> {
         let guard = self.reverse_map.read();
-        (id < guard.len()).then(|| RwLockReadGuard::map(guard, |v| &v[id]).into())
+        guard.get(id).map(|v| v.clone())
     }
 
-    pub fn get_keys(&self) -> RwLockReadGuard<Vec<T>> {
-        self.reverse_map.read()
+    pub fn get_keys(&self) -> ArcReadLockedVec<ArcStr> {
+        ArcReadLockedVec {
+            guard: self.reverse_map.read_arc(),
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -253,12 +301,12 @@ impl<T: Hash + Eq + Clone + Debug> DictMapper<T> {
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct PropMapper {
-    id_mapper: DictMapper<String>,
-    dtypes: RwLock<Vec<PropType>>,
+    id_mapper: DictMapper,
+    dtypes: Arc<RwLock<Vec<PropType>>>,
 }
 
 impl Deref for PropMapper {
-    type Target = DictMapper<String>;
+    type Target = DictMapper;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -340,8 +388,9 @@ mod test {
     #[quickcheck]
     fn check_dict_mapper_concurrent_write(write: Vec<String>) -> bool {
         let n = 100;
-        let mapper: DictMapper<String> = DictMapper::default();
+        let mapper: DictMapper = DictMapper::default();
 
+        // create n maps from strings to ids in parallel
         let res: Vec<HashMap<String, usize>> = (0..n)
             .into_par_iter()
             .map(|_| {
@@ -350,14 +399,16 @@ mod test {
                 let mut write_s = write.clone();
                 write_s.shuffle(&mut rng);
                 for s in write_s {
-                    let id = mapper.get_or_create_id(&s);
+                    let id = mapper.get_or_create_id(s.as_str());
                     ids.insert(s, id);
                 }
                 ids
             })
             .collect();
+
+        // check that all maps are the same and that all strings have been assigned an id
         let res_0 = &res[0];
-        res[1..n].iter().all(|v| res_0 == v) && write.iter().all(|v| mapper.get(v).is_some())
+        res[1..n].iter().all(|v| res_0 == v) && write.iter().all(|v| mapper.get_id(v).is_some())
     }
 
     // map 5 strings to 5 ids from 4 threads concurrently 1000 times

--- a/raphtory/src/core/entities/properties/tcell.rs
+++ b/raphtory/src/core/entities/properties/tcell.rs
@@ -6,9 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt::Debug, ops::Range};
 
 #[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
-
 // TCells represent a value in time that can be set at multiple times and keeps a history
-pub enum TCell<A: Clone + Default + Debug + PartialEq> {
+pub enum TCell<A: Clone + Debug + PartialEq> {
     #[default]
     Empty,
     TCell1(TimeIndexEntry, A),
@@ -18,7 +17,7 @@ pub enum TCell<A: Clone + Default + Debug + PartialEq> {
 
 const BTREE_CUTOFF: usize = 128;
 
-impl<A: Clone + Default + Debug + PartialEq> TCell<A> {
+impl<A: Clone + Debug + PartialEq> TCell<A> {
     pub fn new(t: TimeIndexEntry, value: A) -> Self {
         TCell::TCell1(t, value)
     }

--- a/raphtory/src/core/entities/properties/tprop.rs
+++ b/raphtory/src/core/entities/properties/tprop.rs
@@ -6,7 +6,7 @@ use crate::{
         },
         storage::{locked_view::LockedView, timeindex::TimeIndexEntry},
         utils::errors::GraphError,
-        ArcStr, Prop,
+        ArcStr, Prop, PropType,
     },
     db::graph::graph::Graph,
 };
@@ -38,6 +38,26 @@ pub enum TProp {
 }
 
 impl TProp {
+    pub fn dtype(&self) -> PropType {
+        match self {
+            TProp::Empty => PropType::Empty,
+            TProp::Str(_) => PropType::Str,
+            TProp::U8(_) => PropType::U8,
+            TProp::U16(_) => PropType::U16,
+            TProp::I32(_) => PropType::I32,
+            TProp::I64(_) => PropType::I64,
+            TProp::U32(_) => PropType::U32,
+            TProp::U64(_) => PropType::U64,
+            TProp::F32(_) => PropType::F32,
+            TProp::F64(_) => PropType::F64,
+            TProp::Bool(_) => PropType::Bool,
+            TProp::DTime(_) => PropType::DTime,
+            TProp::Graph(_) => PropType::Graph,
+            TProp::List(_) => PropType::List,
+            TProp::Map(_) => PropType::Map,
+        }
+    }
+
     pub(crate) fn from(t: TimeIndexEntry, prop: Prop) -> Self {
         match prop {
             Prop::Str(value) => TProp::Str(TCell::new(t, value)),

--- a/raphtory/src/core/entities/properties/tprop.rs
+++ b/raphtory/src/core/entities/properties/tprop.rs
@@ -6,7 +6,7 @@ use crate::{
         },
         storage::{locked_view::LockedView, timeindex::TimeIndexEntry},
         utils::errors::GraphError,
-        Prop,
+        ArcStr, Prop,
     },
     db::graph::graph::Graph,
 };
@@ -21,7 +21,7 @@ use std::{collections::HashMap, iter, ops::Range, sync::Arc};
 pub enum TProp {
     #[default]
     Empty,
-    Str(TCell<String>),
+    Str(TCell<ArcStr>),
     U8(TCell<u8>),
     U16(TCell<u16>),
     I32(TCell<i32>),
@@ -161,7 +161,7 @@ impl TProp {
             TProp::Empty => Box::new(iter::empty()),
             TProp::Str(cell) => Box::new(
                 cell.iter_t()
-                    .map(|(t, value)| (*t, Prop::Str(value.to_string()))),
+                    .map(|(t, value)| (*t, Prop::Str(value.clone()))),
             ),
             TProp::I32(cell) => Box::new(cell.iter_t().map(|(t, value)| (*t, Prop::I32(*value)))),
             TProp::I64(cell) => Box::new(cell.iter_t().map(|(t, value)| (*t, Prop::I64(*value)))),
@@ -195,7 +195,7 @@ impl TProp {
             TProp::Empty => Box::new(std::iter::empty()),
             TProp::Str(cell) => Box::new(
                 cell.iter_window_t(r)
-                    .map(|(t, value)| (*t, Prop::Str(value.to_string()))),
+                    .map(|(t, value)| (*t, Prop::Str(value.clone()))),
             ),
             TProp::I32(cell) => Box::new(
                 cell.iter_window_t(r)

--- a/raphtory/src/core/entities/vertices/vertex.rs
+++ b/raphtory/src/core/entities/vertices/vertex.rs
@@ -45,7 +45,7 @@ impl<'a, const N: usize> Vertex<'a, N> {
         name: &str,
         window: Option<Range<i64>>,
     ) -> impl Iterator<Item = (i64, Prop)> + 'a {
-        let prop_id = self.graph.vertex_meta.find_prop_id(name, false);
+        let prop_id = self.graph.vertex_meta.get_prop_id(name, false);
         prop_id
             .into_iter()
             .flat_map(move |prop_id| self.node.temporal_properties(prop_id, window.clone()))

--- a/raphtory/src/core/entities/vertices/vertex.rs
+++ b/raphtory/src/core/entities/vertices/vertex.rs
@@ -1,26 +1,23 @@
-use crate::{
-    core::{
-        entities::{
-            edges::{edge::EdgeView, edge_ref::EdgeRef, edge_store::EdgeStore},
-            graph::tgraph::TGraph,
-            properties::{
-                props::{DictMapper, Meta},
-                tprop::TProp,
-            },
-            vertices::{
-                structure::iter::{Paged, PagedIter},
-                vertex_store::VertexStore,
-            },
-            LayerIds, VRef, VID,
+use crate::core::{
+    entities::{
+        edges::{edge::EdgeView, edge_ref::EdgeRef, edge_store::EdgeStore},
+        graph::tgraph::TGraph,
+        properties::{
+            props::{DictMapper, Meta},
+            tprop::TProp,
         },
-        storage::{
-            locked_view::LockedView,
-            timeindex::{TimeIndex, TimeIndexEntry, TimeIndexOps},
-            ArcEntry, Entry,
+        vertices::{
+            structure::iter::{Paged, PagedIter},
+            vertex_store::VertexStore,
         },
-        Direction, Prop,
+        LayerIds, VRef, VID,
     },
-    db::api::properties::internal::CorePropertiesOps,
+    storage::{
+        locked_view::LockedView,
+        timeindex::{TimeIndex, TimeIndexEntry, TimeIndexOps},
+        ArcEntry, Entry,
+    },
+    Direction, Prop,
 };
 use itertools::Itertools;
 use std::{ops::Range, sync::Arc};
@@ -28,24 +25,6 @@ use std::{ops::Range, sync::Arc};
 pub struct Vertex<'a, const N: usize> {
     node: VRef<'a, N>,
     pub graph: &'a TGraph<N>,
-}
-
-impl<'b, const N: usize> CorePropertiesOps for Vertex<'b, N> {
-    fn const_prop_meta(&self) -> &DictMapper<String> {
-        self.graph.vertex_meta.static_prop_meta()
-    }
-
-    fn temporal_prop_meta(&self) -> &DictMapper<String> {
-        self.graph.vertex_meta.temporal_prop_meta()
-    }
-
-    fn temporal_prop(&self, id: usize) -> Option<&TProp> {
-        self.node.props.as_ref().and_then(|p| p.temporal_prop(id))
-    }
-
-    fn const_prop(&self, id: usize) -> Option<&Prop> {
-        self.node.props.as_ref().and_then(|p| p.static_prop(id))
-    }
 }
 
 impl<'a, const N: usize> Vertex<'a, N> {
@@ -122,24 +101,6 @@ impl<'a, const N: usize> IntoIterator for Vertex<'a, N> {
 pub struct ArcVertex {
     e: ArcEntry<VertexStore>,
     meta: Arc<Meta>,
-}
-
-impl CorePropertiesOps for ArcVertex {
-    fn const_prop_meta(&self) -> &DictMapper<String> {
-        self.meta.static_prop_meta()
-    }
-
-    fn temporal_prop_meta(&self) -> &DictMapper<String> {
-        self.meta.temporal_prop_meta()
-    }
-
-    fn temporal_prop(&self, id: usize) -> Option<&TProp> {
-        self.e.temporal_property(id)
-    }
-
-    fn const_prop(&self, id: usize) -> Option<&Prop> {
-        self.e.static_property(id)
-    }
 }
 
 impl ArcVertex {

--- a/raphtory/src/core/entities/vertices/vertex_store.rs
+++ b/raphtory/src/core/entities/vertices/vertex_store.rs
@@ -332,7 +332,7 @@ impl VertexStore {
         self.layers[layer_id].get_page_vec(last, page_size, dir)
     }
 
-    pub(crate) fn static_prop_ids(&self) -> Vec<usize> {
+    pub(crate) fn constant_prop_ids(&self) -> Vec<usize> {
         self.props
             .as_ref()
             .map(|ps| ps.static_prop_ids())

--- a/raphtory/src/core/storage/mod.rs
+++ b/raphtory/src/core/storage/mod.rs
@@ -15,13 +15,13 @@ use serde::{Deserialize, Serialize};
 use std::{
     array,
     fmt::Debug,
+    iter::FusedIterator,
     ops::{Deref, DerefMut},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
 };
-use tantivy::directory::Lock;
 
 type ArcRwLockReadGuard<T> = lock_api::ArcRwLockReadGuard<parking_lot::RawRwLock, T>;
 
@@ -32,8 +32,8 @@ fn resolve<const N: usize>(index: usize) -> (usize, usize) {
     (bucket, offset)
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct LockVec<T: Default> {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LockVec<T> {
     data: Arc<RwLock<Vec<T>>>,
 }
 

--- a/raphtory/src/core/utils/errors.rs
+++ b/raphtory/src/core/utils/errors.rs
@@ -1,6 +1,7 @@
 use crate::core::{
-    storage::lazy_vec::IllegalSet, utils::time::error::ParseTimeError, Prop, PropType,
+    storage::lazy_vec::IllegalSet, utils::time::error::ParseTimeError, ArcStr, Prop, PropType,
 };
+use std::sync::Arc;
 
 #[cfg(feature = "search")]
 use tantivy;
@@ -29,7 +30,7 @@ pub enum GraphError {
     },
 
     #[error("Tried to mutate constant property {name}: old value {old:?}, new value {new:?}")]
-    ConstantPropertyMutationError { name: String, old: Prop, new: Prop },
+    ConstantPropertyMutationError { name: ArcStr, old: Prop, new: Prop },
 
     #[error("Failed to parse time string")]
     ParseTime {

--- a/raphtory/src/core/utils/errors.rs
+++ b/raphtory/src/core/utils/errors.rs
@@ -1,8 +1,6 @@
 use crate::core::{
     storage::lazy_vec::IllegalSet, utils::time::error::ParseTimeError, ArcStr, Prop, PropType,
 };
-use std::sync::Arc;
-
 #[cfg(feature = "search")]
 use tantivy;
 #[cfg(feature = "search")]

--- a/raphtory/src/db/api/mutation/addition_ops.rs
+++ b/raphtory/src/db/api/mutation/addition_ops.rs
@@ -102,8 +102,10 @@ impl<G: InternalAdditionOps + GraphViewOps> AdditionOps for G {
         v: V,
         props: PI,
     ) -> Result<VertexView<G>, GraphError> {
-        let properties = props
-            .collect_properties(|name, dtype| self.resolve_vertex_property(name, dtype, false))?;
+        let properties = props.collect_properties(
+            |name, dtype| self.resolve_vertex_property(name, dtype, false),
+            |prop| self.process_prop_value(prop),
+        )?;
         let ti = TimeIndexEntry::from_input(self, t)?;
         let v_id = self.resolve_vertex(v.id(), v.id_str());
         self.internal_add_vertex(ti, v_id, properties)?;
@@ -123,8 +125,10 @@ impl<G: InternalAdditionOps + GraphViewOps> AdditionOps for G {
         let dst_id = self.resolve_vertex(dst.id(), dst.id_str());
         let layer_id = self.resolve_layer(layer);
 
-        let properties: Vec<(usize, Prop)> = props
-            .collect_properties(|name, dtype| self.resolve_edge_property(name, dtype, false))?;
+        let properties: Vec<(usize, Prop)> = props.collect_properties(
+            |name, dtype| self.resolve_edge_property(name, dtype, false),
+            |prop| self.process_prop_value(prop),
+        )?;
         let eid = self.internal_add_edge(ti, src_id, dst_id, properties, layer_id)?;
         Ok(EdgeView::new(
             self.clone(),

--- a/raphtory/src/db/api/mutation/internal/internal_addition_ops.rs
+++ b/raphtory/src/db/api/mutation/internal/internal_addition_ops.rs
@@ -39,6 +39,8 @@ pub trait InternalAdditionOps {
         is_static: bool,
     ) -> Result<usize, GraphError>;
 
+    fn process_prop_value(&self, prop: Prop) -> Prop;
+
     /// add vertex update
     fn internal_add_vertex(
         &self,
@@ -115,6 +117,11 @@ impl<G: DelegateAdditionOps> InternalAdditionOps for G {
         is_static: bool,
     ) -> Result<usize, GraphError> {
         self.graph().resolve_edge_property(prop, dtype, is_static)
+    }
+
+    #[inline]
+    fn process_prop_value(&self, prop: Prop) -> Prop {
+        self.graph().process_prop_value(prop)
     }
 
     #[inline(always)]

--- a/raphtory/src/db/api/mutation/mod.rs
+++ b/raphtory/src/db/api/mutation/mod.rs
@@ -47,9 +47,10 @@ impl<T: TryIntoTime> TryIntoInputTime for (T, usize) {
 }
 
 pub trait CollectProperties {
-    fn collect_properties<F: Fn(&str, PropType) -> Result<usize, GraphError>>(
+    fn collect_properties<F: Fn(&str, PropType) -> Result<usize, GraphError>, G: Fn(Prop) -> Prop>(
         self,
-        resolver: F,
+        id_resolver: F,
+        value_processor: G,
     ) -> Result<Vec<(usize, Prop)>, GraphError>;
 }
 
@@ -57,9 +58,10 @@ impl<S: AsRef<str>, P: Into<Prop>, PI> CollectProperties for PI
 where
     PI: IntoIterator<Item = (S, P)>,
 {
-    fn collect_properties<F: Fn(&str, PropType) -> Result<usize, GraphError>>(
+    fn collect_properties<F: Fn(&str, PropType) -> Result<usize, GraphError>, G: Fn(Prop) -> Prop>(
         self,
-        resolver: F,
+        id_resolver: F,
+        value_processor: G,
     ) -> Result<Vec<(usize, Prop)>, GraphError>
     where
         PI: IntoIterator<Item = (S, P)>,
@@ -67,8 +69,8 @@ where
         let mut properties: Vec<(usize, Prop)> = Vec::new();
         for (key, value) in self {
             let value: Prop = value.into();
-            let prop_id = resolver(key.as_ref(), value.dtype())?;
-            properties.push((prop_id, value));
+            let prop_id = id_resolver(key.as_ref(), value.dtype())?;
+            properties.push((prop_id, value_processor(value)));
         }
         Ok(properties)
     }

--- a/raphtory/src/db/api/mutation/property_addition_ops.rs
+++ b/raphtory/src/db/api/mutation/property_addition_ops.rs
@@ -28,14 +28,18 @@ impl<G: InternalPropertyAdditionOps + InternalAdditionOps> PropertyAdditionOps f
         props: PI,
     ) -> Result<(), GraphError> {
         let ti = TimeIndexEntry::from_input(self, t)?;
-        let properties: Vec<_> =
-            props.collect_properties(|name, _| Ok(self.resolve_graph_property(name, false)))?;
+        let properties: Vec<_> = props.collect_properties(
+            |name, _| Ok(self.resolve_graph_property(name, false)),
+            |prop| self.process_prop_value(prop),
+        )?;
         self.internal_add_properties(ti, properties)
     }
 
     fn add_constant_properties<PI: CollectProperties>(&self, props: PI) -> Result<(), GraphError> {
-        let properties: Vec<_> =
-            props.collect_properties(|name, _| Ok(self.resolve_graph_property(name, true)))?;
+        let properties: Vec<_> = props.collect_properties(
+            |name, _| Ok(self.resolve_graph_property(name, true)),
+            |prop| self.process_prop_value(prop),
+        )?;
         self.internal_add_static_properties(properties)
     }
 }

--- a/raphtory/src/db/api/properties/constant_props.rs
+++ b/raphtory/src/db/api/properties/constant_props.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{ArcStr, Prop},
     db::api::properties::internal::ConstPropertiesOps,
 };
-use std::{borrow::Borrow, collections::HashMap, iter::Zip, sync::Arc};
+use std::{collections::HashMap, iter::Zip};
 
 pub struct ConstProperties<P: ConstPropertiesOps> {
     pub(crate) props: P,

--- a/raphtory/src/db/api/properties/constant_props.rs
+++ b/raphtory/src/db/api/properties/constant_props.rs
@@ -1,5 +1,8 @@
-use crate::{core::Prop, db::api::properties::internal::ConstPropertiesOps};
-use std::{collections::HashMap, iter::Zip};
+use crate::{
+    core::{ArcStr, Prop},
+    db::api::properties::internal::ConstPropertiesOps,
+};
+use std::{borrow::Borrow, collections::HashMap, iter::Zip, sync::Arc};
 
 pub struct ConstProperties<P: ConstPropertiesOps> {
     pub(crate) props: P,
@@ -9,7 +12,7 @@ impl<P: ConstPropertiesOps> ConstProperties<P> {
     pub(crate) fn new(props: P) -> Self {
         Self { props }
     }
-    pub fn keys(&self) -> Vec<String> {
+    pub fn keys(&self) -> Vec<ArcStr> {
         self.props
             .const_property_keys()
             .map(|v| v.clone())
@@ -20,26 +23,26 @@ impl<P: ConstPropertiesOps> ConstProperties<P> {
         self.props.const_property_values()
     }
 
-    pub fn iter(&self) -> Box<dyn Iterator<Item = (String, Prop)> + '_> {
+    pub fn iter(&self) -> Box<dyn Iterator<Item = (ArcStr, Prop)> + '_> {
         Box::new(self.into_iter())
     }
 
-    pub fn get<Q: AsRef<str>>(&self, key: Q) -> Option<Prop> {
-        self.props.get_const_property(key.as_ref())
+    pub fn get(&self, key: &str) -> Option<Prop> {
+        self.props.get_const_property(key)
     }
 
-    pub fn contains<Q: AsRef<str>>(&self, key: Q) -> bool {
+    pub fn contains(&self, key: &str) -> bool {
         self.get(key).is_some()
     }
 
-    pub fn as_map(&self) -> HashMap<String, Prop> {
+    pub fn as_map(&self) -> HashMap<ArcStr, Prop> {
         self.iter().collect()
     }
 }
 
 impl<P: ConstPropertiesOps> IntoIterator for ConstProperties<P> {
-    type Item = (String, Prop);
-    type IntoIter = Zip<std::vec::IntoIter<String>, std::vec::IntoIter<Prop>>;
+    type Item = (ArcStr, Prop);
+    type IntoIter = Zip<std::vec::IntoIter<ArcStr>, std::vec::IntoIter<Prop>>;
 
     fn into_iter(self) -> Self::IntoIter {
         let keys = self.keys();
@@ -49,8 +52,8 @@ impl<P: ConstPropertiesOps> IntoIterator for ConstProperties<P> {
 }
 
 impl<P: ConstPropertiesOps> IntoIterator for &ConstProperties<P> {
-    type Item = (String, Prop);
-    type IntoIter = Zip<std::vec::IntoIter<String>, std::vec::IntoIter<Prop>>;
+    type Item = (ArcStr, Prop);
+    type IntoIter = Zip<std::vec::IntoIter<ArcStr>, std::vec::IntoIter<Prop>>;
 
     fn into_iter(self) -> Self::IntoIter {
         let keys = self.keys();

--- a/raphtory/src/db/api/properties/internal.rs
+++ b/raphtory/src/db/api/properties/internal.rs
@@ -1,13 +1,8 @@
 use crate::{
-    core::{
-        entities::properties::{props::DictMapper, tprop::TProp},
-        storage::locked_view::LockedView,
-        ArcStr, Prop,
-    },
-    db::api::view::{internal::Base, BoxedIter},
+    core::{ArcStr, Prop},
+    db::api::view::internal::Base,
 };
 use enum_dispatch::enum_dispatch;
-use std::sync::Arc;
 
 pub type Key = String; //Fixme: This should really be the internal usize index but that means more reworking of the low-level api
 

--- a/raphtory/src/db/api/properties/props.rs
+++ b/raphtory/src/db/api/properties/props.rs
@@ -1,10 +1,10 @@
 use crate::{
-    core::{storage::locked_view::LockedView, Prop},
+    core::{storage::locked_view::LockedView, ArcStr, Prop},
     db::api::properties::{
         constant_props::ConstProperties, internal::*, temporal_props::TemporalProperties,
     },
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 /// View of the properties of an entity (graph|vertex|edge)
 #[derive(Clone)]
@@ -34,7 +34,7 @@ impl<P: PropertiesOps + Clone> Properties<P> {
     }
 
     /// Iterate over all property keys
-    pub fn keys(&self) -> impl Iterator<Item = LockedView<String>> + '_ {
+    pub fn keys(&self) -> impl Iterator<Item = ArcStr> + '_ {
         self.props.temporal_property_keys().chain(
             self.props
                 .const_property_keys()
@@ -48,7 +48,7 @@ impl<P: PropertiesOps + Clone> Properties<P> {
     }
 
     /// Iterate over all property key-value pairs
-    pub fn iter(&self) -> impl Iterator<Item = (LockedView<String>, Prop)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = (ArcStr, Prop)> + '_ {
         self.keys().zip(self.values())
     }
 
@@ -63,18 +63,18 @@ impl<P: PropertiesOps + Clone> Properties<P> {
     }
 
     /// Collect properties into vector
-    pub fn as_vec(&self) -> Vec<(String, Prop)> {
+    pub fn as_vec(&self) -> Vec<(ArcStr, Prop)> {
         self.iter().map(|(k, v)| (k.clone(), v)).collect()
     }
 
     /// Collect properties into map
-    pub fn as_map(&self) -> HashMap<String, Prop> {
+    pub fn as_map(&self) -> HashMap<ArcStr, Prop> {
         self.iter().map(|(k, v)| (k.clone(), v)).collect()
     }
 }
 
 impl<P: PropertiesOps + Clone> IntoIterator for Properties<P> {
-    type Item = (String, Prop);
+    type Item = (ArcStr, Prop);
     type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -85,8 +85,8 @@ impl<P: PropertiesOps + Clone> IntoIterator for Properties<P> {
 }
 
 impl<'a, P: PropertiesOps + Clone + 'a> IntoIterator for &'a Properties<P> {
-    type Item = (LockedView<'a, String>, Prop);
-    type IntoIter = Box<dyn Iterator<Item = (LockedView<'a, String>, Prop)> + 'a>;
+    type Item = (ArcStr, Prop);
+    type IntoIter = Box<dyn Iterator<Item = (ArcStr, Prop)> + 'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.iter())

--- a/raphtory/src/db/api/properties/props.rs
+++ b/raphtory/src/db/api/properties/props.rs
@@ -1,10 +1,10 @@
 use crate::{
-    core::{storage::locked_view::LockedView, ArcStr, Prop},
+    core::{ArcStr, Prop},
     db::api::properties::{
         constant_props::ConstProperties, internal::*, temporal_props::TemporalProperties,
     },
 };
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 /// View of the properties of an entity (graph|vertex|edge)
 #[derive(Clone)]

--- a/raphtory/src/db/api/properties/temporal_props.rs
+++ b/raphtory/src/db/api/properties/temporal_props.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{storage::locked_view::LockedView, Prop, PropUnwrap},
+    core::{storage::locked_view::LockedView, ArcStr, Prop, PropUnwrap},
     db::api::properties::internal::{Key, PropertiesOps},
     prelude::Graph,
 };
@@ -59,8 +59,8 @@ pub struct TemporalProperties<P: PropertiesOps + Clone> {
 }
 
 impl<P: PropertiesOps + Clone> IntoIterator for TemporalProperties<P> {
-    type Item = (String, TemporalPropertyView<P>);
-    type IntoIter = Zip<std::vec::IntoIter<String>, std::vec::IntoIter<TemporalPropertyView<P>>>;
+    type Item = (ArcStr, TemporalPropertyView<P>);
+    type IntoIter = Zip<std::vec::IntoIter<ArcStr>, std::vec::IntoIter<TemporalPropertyView<P>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         let keys: Vec<_> = self.keys().map(|k| k.clone()).collect();
@@ -73,7 +73,7 @@ impl<P: PropertiesOps + Clone> TemporalProperties<P> {
     pub(crate) fn new(props: P) -> Self {
         Self { props }
     }
-    pub fn keys(&self) -> impl Iterator<Item = LockedView<String>> + '_ {
+    pub fn keys(&self) -> impl Iterator<Item = ArcStr> + '_ {
         self.props.temporal_property_keys()
     }
 
@@ -87,11 +87,11 @@ impl<P: PropertiesOps + Clone> TemporalProperties<P> {
             .map(|k| TemporalPropertyView::new(self.props.clone(), k))
     }
 
-    pub fn iter_latest(&self) -> impl Iterator<Item = (LockedView<String>, Prop)> + '_ {
+    pub fn iter_latest(&self) -> impl Iterator<Item = (ArcStr, Prop)> + '_ {
         self.iter().flat_map(|(k, v)| v.latest().map(|v| (k, v)))
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (LockedView<String>, TemporalPropertyView<P>)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = (ArcStr, TemporalPropertyView<P>)> + '_ {
         self.keys().zip(self.values())
     }
 
@@ -101,7 +101,7 @@ impl<P: PropertiesOps + Clone> TemporalProperties<P> {
             .map(|k| TemporalPropertyView::new(self.props.clone(), k))
     }
 
-    pub fn collect_properties(self) -> Vec<(String, Prop)> {
+    pub fn collect_properties(self) -> Vec<(ArcStr, Prop)> {
         self.iter()
             .flat_map(|(k, v)| v.latest().map(|v| (k.clone(), v)))
             .collect()
@@ -117,7 +117,7 @@ impl<P: PropertiesOps> PropUnwrap for TemporalPropertyView<P> {
         self.latest().into_u16()
     }
 
-    fn into_str(self) -> Option<String> {
+    fn into_str(self) -> Option<ArcStr> {
         self.latest().into_str()
     }
 

--- a/raphtory/src/db/api/properties/temporal_props.rs
+++ b/raphtory/src/db/api/properties/temporal_props.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{storage::locked_view::LockedView, ArcStr, Prop, PropUnwrap},
+    core::{ArcStr, Prop, PropUnwrap},
     db::api::properties::internal::{Key, PropertiesOps},
     prelude::Graph,
 };

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -12,7 +12,6 @@ use crate::{
         view::{internal::*, *},
     },
 };
-use std::sync::Arc;
 
 pub trait EdgeViewInternalOps<G: GraphViewOps, V: VertexViewOps<Graph = G>> {
     fn graph(&self) -> G;

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -2,6 +2,7 @@ use crate::{
     core::{
         entities::{edges::edge_ref::EdgeRef, VID},
         storage::timeindex::{AsTime, TimeIndexEntry},
+        ArcStr,
     },
     db::api::{
         properties::{
@@ -11,6 +12,7 @@ use crate::{
         view::{internal::*, *},
     },
 };
+use std::sync::Arc;
 
 pub trait EdgeViewInternalOps<G: GraphViewOps, V: VertexViewOps<Graph = G>> {
     fn graph(&self) -> G;
@@ -106,10 +108,10 @@ pub trait EdgeViewOps:
     }
 
     /// Gets the layer name for the edge if it is restricted to a single layer
-    fn layer_name(&self) -> Option<String> {
+    fn layer_name(&self) -> Option<ArcStr> {
         self.eref()
             .layer()
-            .and_then(|l_id| self.graph().get_layer_name(*l_id).map(|name| name.clone()))
+            .and_then(|l_id| self.graph().get_layer_name(*l_id))
     }
 
     /// Gets the TimeIndexEntry if the edge is exploded
@@ -118,7 +120,7 @@ pub trait EdgeViewOps:
     }
 
     /// Gets the name of the layer this edge belongs to
-    fn layer_names(&self) -> Vec<String> {
+    fn layer_names(&self) -> BoxedIter<ArcStr> {
         let layer_ids = self
             .graph()
             .edge_layer_ids(&self.graph().core_edge(self.eref().pid()))
@@ -165,7 +167,7 @@ pub trait EdgeListOps:
     fn time(self) -> Self::IterType<Option<i64>>;
 
     /// Get the layer name for each edge if it is restricted to a single layer
-    fn layer_name(self) -> Self::IterType<Option<String>>;
+    fn layer_name(self) -> Self::IterType<Option<ArcStr>>;
 }
 
 #[cfg(test)]

--- a/raphtory/src/db/api/view/graph.rs
+++ b/raphtory/src/db/api/view/graph.rs
@@ -25,7 +25,6 @@ use crate::{
     prelude::{DeletionOps, NO_PROPS},
 };
 use rustc_hash::FxHashSet;
-use std::sync::Arc;
 
 /// This trait GraphViewOps defines operations for accessing
 /// information about a graph. The trait has associated types

--- a/raphtory/src/db/api/view/internal/core_ops.rs
+++ b/raphtory/src/db/api/view/internal/core_ops.rs
@@ -19,7 +19,6 @@ use crate::{
     db::api::view::{internal::Base, BoxedIter},
 };
 use enum_dispatch::enum_dispatch;
-use std::sync::Arc;
 
 /// Core functions that should (almost-)always be implemented by pointing at the underlying graph.
 #[enum_dispatch]

--- a/raphtory/src/db/api/view/internal/core_ops.rs
+++ b/raphtory/src/db/api/view/internal/core_ops.rs
@@ -3,6 +3,7 @@ use crate::{
         entities::{
             edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
             properties::{
+                graph_props::GraphProps,
                 props::{ArcReadLockedVec, Meta},
                 tprop::{LockedLayeredTProp, TProp},
             },
@@ -29,6 +30,8 @@ pub trait CoreGraphOps {
     fn vertex_meta(&self) -> &Meta;
 
     fn edge_meta(&self) -> &Meta;
+
+    fn graph_meta(&self) -> &GraphProps;
 
     fn get_layer_name(&self, layer_id: usize) -> Option<ArcStr>;
 
@@ -251,6 +254,11 @@ impl<G: DelegateCoreOps + ?Sized> CoreGraphOps for G {
     #[inline]
     fn edge_meta(&self) -> &Meta {
         self.graph().edge_meta()
+    }
+
+    #[inline]
+    fn graph_meta(&self) -> &GraphProps {
+        self.graph().graph_meta()
     }
 
     #[inline]

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -3,7 +3,7 @@ use crate::{
         entities::{
             edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
             properties::{
-                props::Meta,
+                props::{ArcReadLockedVec, Meta},
                 tprop::{LockedLayeredTProp, TProp},
             },
             vertices::{vertex_ref::VertexRef, vertex_store::VertexStore},
@@ -15,7 +15,7 @@ use crate::{
             ArcEntry,
         },
         utils::errors::GraphError,
-        Direction, PropType,
+        ArcStr, Direction, PropType,
     },
     db::{
         api::{
@@ -23,7 +23,7 @@ use crate::{
             properties::internal::{
                 ConstPropertiesOps, Key, TemporalPropertiesOps, TemporalPropertyViewOps,
             },
-            view::internal::*,
+            view::{internal::*, BoxedIter},
         },
         graph::{
             graph::{Graph, InternalGraph},

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -3,6 +3,7 @@ use crate::{
         entities::{
             edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
             properties::{
+                graph_props::GraphProps,
                 props::{ArcReadLockedVec, Meta},
                 tprop::{LockedLayeredTProp, TProp},
             },

--- a/raphtory/src/db/api/view/layer.rs
+++ b/raphtory/src/db/api/view/layer.rs
@@ -1,3 +1,4 @@
+use crate::core::ArcStr;
 use std::sync::Arc;
 
 /// Trait defining layer operations
@@ -15,14 +16,14 @@ pub trait LayerOps {
 pub enum Layer {
     All,
     Default,
-    One(String),
+    One(ArcStr),
     Multiple(Arc<[String]>),
 }
 
 impl<'a, T: ToOwned<Owned = String> + ?Sized> From<Option<&'a T>> for Layer {
     fn from(name: Option<&'a T>) -> Self {
         match name {
-            Some(name) => Layer::One(name.to_owned()),
+            Some(name) => Layer::One(name.to_owned().into()),
             None => Layer::All,
         }
     }
@@ -31,21 +32,27 @@ impl<'a, T: ToOwned<Owned = String> + ?Sized> From<Option<&'a T>> for Layer {
 impl From<Option<String>> for Layer {
     fn from(value: Option<String>) -> Self {
         match value {
-            Some(name) => Layer::One(name),
+            Some(name) => Layer::One(name.into()),
             None => Layer::All,
         }
     }
 }
 
+impl From<ArcStr> for Layer {
+    fn from(value: ArcStr) -> Self {
+        Layer::One(value)
+    }
+}
+
 impl From<String> for Layer {
     fn from(value: String) -> Self {
-        Layer::One(value)
+        Layer::One(value.into())
     }
 }
 
 impl<'a, T: ToOwned<Owned = String> + ?Sized> From<&'a T> for Layer {
     fn from(name: &'a T) -> Self {
-        Layer::One(name.to_owned())
+        Layer::One(name.to_owned().into())
     }
 }
 
@@ -53,7 +60,7 @@ impl<'a, T: ToOwned<Owned = String> + ?Sized> From<Vec<&'a T>> for Layer {
     fn from(names: Vec<&'a T>) -> Self {
         match names.len() {
             0 => Layer::All,
-            1 => Layer::One(names[0].to_owned()),
+            1 => Layer::One(names[0].to_owned().into()),
             _ => Layer::Multiple(
                 names
                     .into_iter()
@@ -69,7 +76,7 @@ impl From<Vec<String>> for Layer {
     fn from(names: Vec<String>) -> Self {
         match names.len() {
             0 => Layer::All,
-            1 => Layer::One(names[0].clone()),
+            1 => Layer::One(names.into_iter().next().expect("exists").into()),
             _ => Layer::Multiple(names.into()),
         }
     }

--- a/raphtory/src/db/graph/edge.rs
+++ b/raphtory/src/db/graph/edge.rs
@@ -9,7 +9,7 @@ use super::views::layer_graph::LayeredGraph;
 use crate::{
     core::{
         entities::{edges::edge_ref::EdgeRef, VID},
-        storage::{locked_view::LockedView, timeindex::TimeIndexEntry},
+        storage::timeindex::TimeIndexEntry,
         utils::{errors::GraphError, time::IntoTime},
         ArcStr,
     },
@@ -34,7 +34,6 @@ use crate::{
 use std::{
     fmt::{Debug, Formatter},
     iter,
-    sync::Arc,
 };
 
 /// A view of an edge in the graph.
@@ -409,7 +408,7 @@ mod test_edge {
         prelude::*,
     };
     use itertools::Itertools;
-    use std::{collections::HashMap, sync::Arc};
+    use std::collections::HashMap;
 
     #[test]
     fn test_properties() {

--- a/raphtory/src/db/graph/edge.rs
+++ b/raphtory/src/db/graph/edge.rs
@@ -115,9 +115,10 @@ impl<G: GraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps> EdgeVi
         props: C,
         layer: Option<&str>,
     ) -> Result<(), GraphError> {
-        let properties: Vec<(usize, Prop)> = props.collect_properties(|name, dtype| {
-            self.graph.resolve_edge_property(name, dtype, true)
-        })?;
+        let properties: Vec<(usize, Prop)> = props.collect_properties(
+            |name, dtype| self.graph.resolve_edge_property(name, dtype, true),
+            |prop| self.graph.process_prop_value(prop),
+        )?;
         let input_layer_id = self.resolve_layer(layer)?;
 
         self.graph.internal_add_constant_edge_properties(
@@ -135,9 +136,10 @@ impl<G: GraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps> EdgeVi
     ) -> Result<(), GraphError> {
         let t = TimeIndexEntry::from_input(&self.graph, time)?;
         let layer_id = self.resolve_layer(layer)?;
-        let properties: Vec<(usize, Prop)> = props.collect_properties(|name, dtype| {
-            self.graph.resolve_edge_property(name, dtype, false)
-        })?;
+        let properties: Vec<(usize, Prop)> = props.collect_properties(
+            |name, dtype| self.graph.resolve_edge_property(name, dtype, false),
+            |prop| self.graph.process_prop_value(prop),
+        )?;
 
         self.graph
             .internal_add_edge(t, self.edge.src(), self.edge.dst(), properties, layer_id)?;

--- a/raphtory/src/db/graph/vertex.rs
+++ b/raphtory/src/db/graph/vertex.rs
@@ -3,7 +3,7 @@
 use crate::{
     core::{
         entities::{vertices::vertex_ref::VertexRef, VID},
-        storage::{locked_view::LockedView, timeindex::TimeIndexEntry},
+        storage::timeindex::TimeIndexEntry,
         utils::{errors::GraphError, time::IntoTime},
         ArcStr, Direction,
     },
@@ -29,7 +29,6 @@ use crate::{
     },
     prelude::*,
 };
-use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct VertexView<G: GraphViewOps> {

--- a/raphtory/src/db/graph/vertex.rs
+++ b/raphtory/src/db/graph/vertex.rs
@@ -306,9 +306,10 @@ impl<G: GraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps> Vertex
         &self,
         props: C,
     ) -> Result<(), GraphError> {
-        let properties: Vec<(usize, Prop)> = props.collect_properties(|name, dtype| {
-            self.graph.resolve_vertex_property(name, dtype, true)
-        })?;
+        let properties: Vec<(usize, Prop)> = props.collect_properties(
+            |name, dtype| self.graph.resolve_vertex_property(name, dtype, true),
+            |prop| self.graph.process_prop_value(prop),
+        )?;
         self.graph
             .internal_add_constant_vertex_properties(self.vertex, properties)
     }
@@ -319,9 +320,10 @@ impl<G: GraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps> Vertex
         props: C,
     ) -> Result<(), GraphError> {
         let t = TimeIndexEntry::from_input(&self.graph, time)?;
-        let properties: Vec<(usize, Prop)> = props.collect_properties(|name, dtype| {
-            self.graph.resolve_vertex_property(name, dtype, false)
-        })?;
+        let properties: Vec<(usize, Prop)> = props.collect_properties(
+            |name, dtype| self.graph.resolve_vertex_property(name, dtype, false),
+            |prop| self.graph.process_prop_value(prop),
+        )?;
         self.graph.internal_add_vertex(t, self.vertex, properties)
     }
 }

--- a/raphtory/src/db/graph/vertex.rs
+++ b/raphtory/src/db/graph/vertex.rs
@@ -547,4 +547,16 @@ mod vertex_test {
         v1.add_constant_properties([("test", "test")]).unwrap();
         assert_eq!(v1.properties().get("test"), Some("test".into()))
     }
+
+    #[test]
+    fn test_string_deduplication() {
+        let g = Graph::new();
+        let v1 = g
+            .add_vertex(0, 1, [("test1", "test"), ("test2", "test")])
+            .unwrap();
+        let s1 = v1.properties().get("test1").unwrap_str();
+        let s2 = v1.properties().get("test2").unwrap_str();
+
+        assert_eq!(s1.as_ptr(), s2.as_ptr())
+    }
 }

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -46,7 +46,7 @@ use crate::{
         },
         storage::locked_view::LockedView,
         utils::time::IntoTime,
-        Direction, Prop,
+        ArcStr, Direction, Prop,
     },
     db::api::{
         properties::internal::{
@@ -142,9 +142,7 @@ impl<G: GraphViewOps> TemporalPropertyViewOps for WindowedGraph<G> {
 }
 
 impl<G: GraphViewOps> TemporalPropertiesOps for WindowedGraph<G> {
-    fn temporal_property_keys<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = LockedView<'a, String>> + 'a> {
+    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
         Box::new(
             self.graph
                 .temporal_property_keys()

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -44,7 +44,6 @@ use crate::{
             vertices::vertex_ref::VertexRef,
             LayerIds, EID, VID,
         },
-        storage::locked_view::LockedView,
         utils::time::IntoTime,
         ArcStr, Direction, Prop,
     },

--- a/raphtory/src/db/internal/addition.rs
+++ b/raphtory/src/db/internal/addition.rs
@@ -58,6 +58,14 @@ impl<const N: usize> InternalAdditionOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
+    fn process_prop_value(&self, prop: Prop) -> Prop {
+        match prop {
+            Prop::Str(value) => Prop::Str(self.inner().resolve_str(value)),
+            _ => prop,
+        }
+    }
+
+    #[inline]
     fn internal_add_vertex(
         &self,
         t: TimeIndexEntry,

--- a/raphtory/src/db/internal/core_ops.rs
+++ b/raphtory/src/db/internal/core_ops.rs
@@ -21,7 +21,7 @@ use crate::{
     prelude::Prop,
 };
 use itertools::Itertools;
-use std::{collections::HashMap, iter, sync::Arc};
+use std::{collections::HashMap, iter};
 
 impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     #[inline]

--- a/raphtory/src/db/internal/core_ops.rs
+++ b/raphtory/src/db/internal/core_ops.rs
@@ -4,6 +4,7 @@ use crate::{
             edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
             graph::tgraph::InnerTemporalGraph,
             properties::{
+                graph_props::GraphProps,
                 props::{ArcReadLockedVec, Meta},
                 tprop::{LockedLayeredTProp, TProp},
             },
@@ -37,6 +38,11 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     #[inline]
     fn edge_meta(&self) -> &Meta {
         &self.inner().edge_meta
+    }
+
+    #[inline]
+    fn graph_meta(&self) -> &GraphProps {
+        &self.inner().graph_props
     }
 
     #[inline]

--- a/raphtory/src/db/internal/core_ops.rs
+++ b/raphtory/src/db/internal/core_ops.rs
@@ -4,7 +4,7 @@ use crate::{
             edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
             graph::tgraph::InnerTemporalGraph,
             properties::{
-                props::Meta,
+                props::{ArcReadLockedVec, Meta},
                 tprop::{LockedLayeredTProp, TProp},
             },
             vertices::{vertex_ref::VertexRef, vertex_store::VertexStore},
@@ -15,12 +15,13 @@ use crate::{
             timeindex::{LockedLayeredIndex, TimeIndex, TimeIndexEntry},
             ArcEntry,
         },
+        ArcStr,
     },
-    db::api::view::internal::CoreGraphOps,
+    db::api::view::{internal::CoreGraphOps, BoxedIter},
     prelude::Prop,
 };
 use itertools::Itertools;
-use std::{collections::HashMap, iter};
+use std::{collections::HashMap, iter, sync::Arc};
 
 impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     #[inline]
@@ -39,8 +40,8 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn get_layer_name(&self, layer_id: usize) -> Option<LockedView<String>> {
-        self.inner().edge_meta.layer_meta().reverse_lookup(layer_id)
+    fn get_layer_name(&self, layer_id: usize) -> Option<ArcStr> {
+        self.inner().edge_meta.layer_meta().get_name(layer_id)
     }
 
     #[inline]
@@ -49,7 +50,7 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn get_layer_names_from_ids(&self, layer_ids: LayerIds) -> Vec<String> {
+    fn get_layer_names_from_ids(&self, layer_ids: LayerIds) -> BoxedIter<ArcStr> {
         self.inner().layer_names(layer_ids)
     }
 
@@ -94,26 +95,18 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn static_prop_names(&self) -> Vec<String> {
-        self.inner()
-            .constant_property_names()
-            .iter()
-            .cloned()
-            .collect()
+    fn constant_prop_names(&self) -> ArcReadLockedVec<ArcStr> {
+        self.inner().constant_property_names()
     }
 
     #[inline]
-    fn static_prop(&self, name: &str) -> Option<Prop> {
+    fn constant_prop(&self, name: &str) -> Option<Prop> {
         self.inner().get_constant_prop(name)
     }
 
     #[inline]
-    fn temporal_prop_names(&self) -> Vec<String> {
-        self.inner()
-            .temporal_property_names()
-            .iter()
-            .cloned()
-            .collect()
+    fn temporal_prop_names(&self) -> ArcReadLockedVec<ArcStr> {
+        self.inner().temporal_property_names()
     }
 
     #[inline]
@@ -122,7 +115,7 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn static_vertex_prop(&self, v: VID, name: &str) -> Option<Prop> {
+    fn constant_vertex_prop(&self, v: VID, name: &str) -> Option<Prop> {
         let entry = self.inner().node_entry(v);
         let node = entry.value();
         let prop_id = self.inner().vertex_find_prop(name, true)?;
@@ -130,15 +123,10 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn static_vertex_prop_names<'a>(
-        &'a self,
-        v: VID,
-    ) -> Box<dyn Iterator<Item = LockedView<'a, String>> + 'a> {
-        let ids = self.inner().node_entry(v).static_prop_ids();
-        Box::new(
-            ids.into_iter()
-                .flat_map(|prop_id| self.inner().vertex_reverse_prop_id(prop_id, true)),
-        )
+    fn constant_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr> {
+        let keys = self.inner().vertex_meta.constant_prop_meta().get_keys();
+        let ids = self.inner().node_entry(v).constant_prop_ids();
+        Box::new(ids.into_iter().map(move |prop_id| keys[prop_id].clone()))
     }
 
     #[inline]
@@ -150,29 +138,27 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn temporal_vertex_prop_names<'a>(
-        &'a self,
-        v: VID,
-    ) -> Box<dyn Iterator<Item = LockedView<'a, String>> + 'a> {
+    fn temporal_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr> {
+        let keys = self.inner().vertex_meta.temporal_prop_meta().get_keys();
         Box::new(
             self.inner()
                 .vertex_temp_prop_ids(v)
                 .into_iter()
-                .flat_map(|id| self.inner().vertex_reverse_prop_id(id, false)),
+                .map(move |id| keys[id].clone()),
         )
     }
 
     #[inline]
-    fn all_vertex_prop_names(&self, is_static: bool) -> Vec<String> {
+    fn all_vertex_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr> {
         self.inner().get_all_vertex_property_names(is_static)
     }
 
     #[inline]
-    fn all_edge_prop_names(&self, is_static: bool) -> Vec<String> {
+    fn all_edge_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr> {
         self.inner().get_all_edge_property_names(is_static)
     }
 
-    fn static_edge_prop(&self, e: EdgeRef, name: &str, layer_ids: LayerIds) -> Option<Prop> {
+    fn constant_edge_prop(&self, e: EdgeRef, name: &str, layer_ids: LayerIds) -> Option<Prop> {
         let layer_ids = layer_ids.constrain_from_edge(e);
         let entry = self.inner().edge_entry(e.pid());
         let prop_id = self.inner().edge_find_prop(name, true)?;
@@ -225,13 +211,10 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
         }
     }
 
-    fn static_edge_prop_names<'a>(
-        &'a self,
-        e: EdgeRef,
-        layer_ids: LayerIds,
-    ) -> Box<dyn Iterator<Item = LockedView<'a, String>> + 'a> {
+    fn constant_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr> {
         let layer_ids = layer_ids.constrain_from_edge(e);
         let entry = self.inner().edge_entry(e.pid());
+        let reverse_map = self.inner().edge_meta.constant_prop_meta().get_keys();
         match layer_ids {
             LayerIds::None => Box::new(iter::empty()),
             LayerIds::All => Box::new(
@@ -240,13 +223,13 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
                     .map(|l| l.static_prop_ids())
                     .kmerge()
                     .dedup()
-                    .flat_map(|id| self.inner().edge_reverse_prop_id(id, true)),
+                    .map(move |id| reverse_map[id].clone()),
             ),
             LayerIds::One(id) => match entry.layer(id) {
                 Some(l) => Box::new(
                     l.static_prop_ids()
                         .into_iter()
-                        .flat_map(|id| self.inner().edge_reverse_prop_id(id, true)),
+                        .map(move |id| reverse_map[id].clone()),
                 ),
                 None => Box::new(iter::empty()),
             },
@@ -255,7 +238,7 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
                     .flat_map(|id| entry.layer(*id).map(|l| l.static_prop_ids()))
                     .kmerge()
                     .dedup()
-                    .flat_map(|id| self.inner().edge_reverse_prop_id(id, true)),
+                    .map(move |id| reverse_map[id].clone()),
             ),
         }
     }
@@ -273,33 +256,30 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
         edge.temporal_property(layer_ids, prop_id)
     }
 
-    fn temporal_edge_prop_names<'a>(
-        &'a self,
-        e: EdgeRef,
-        layer_ids: LayerIds,
-    ) -> Box<dyn Iterator<Item = LockedView<'a, String>> + 'a> {
+    fn temporal_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr> {
         let layer_ids = layer_ids.constrain_from_edge(e);
         let entry = self.inner().edge_entry(e.pid());
+        let reverse_map = self.inner().edge_meta.temporal_prop_meta().get_keys();
         match layer_ids {
             LayerIds::None => Box::new(iter::empty()),
             LayerIds::All => Box::new(
                 entry
                     .temp_prop_ids(None)
                     .into_iter()
-                    .flat_map(|id| self.inner().edge_reverse_prop_id(id, false)),
+                    .map(move |id| reverse_map[id].clone()),
             ),
             LayerIds::One(id) => Box::new(
                 entry
                     .temp_prop_ids(Some(id))
                     .into_iter()
-                    .flat_map(|id| self.inner().edge_reverse_prop_id(id, false)),
+                    .map(move |id| reverse_map[id].clone()),
             ),
             LayerIds::Multiple(ids) => Box::new(
                 ids.iter()
                     .map(|id| entry.temp_prop_ids(Some(*id)))
                     .kmerge()
                     .dedup()
-                    .flat_map(|id| self.inner().edge_reverse_prop_id(id, false)),
+                    .map(move |id| reverse_map[id].clone()),
             ),
         }
     }
@@ -327,7 +307,10 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
 
 #[cfg(test)]
 mod test_edges {
-    use crate::{core::IntoPropMap, prelude::*};
+    use crate::{
+        core::{ArcStr, IntoPropMap},
+        prelude::*,
+    };
     use std::collections::HashMap;
 
     #[test]
@@ -356,10 +339,10 @@ mod test_edges {
             e_all.properties().constant().as_map(),
             HashMap::from([
                 (
-                    "layer".to_owned(),
+                    ArcStr::from("layer"),
                     [("layer1", 1), ("layer2", 2), ("layer3", 3)].into_prop_map()
                 ),
-                ("layer1".to_owned(), [("layer1", "1")].into_prop_map())
+                (ArcStr::from("layer1"), [("layer1", "1")].into_prop_map())
             ])
         );
         assert_eq!(

--- a/raphtory/src/db/internal/prop_add.rs
+++ b/raphtory/src/db/internal/prop_add.rs
@@ -31,7 +31,7 @@ impl<const N: usize> InternalPropertyAdditionOps for InnerTemporalGraph<N> {
             node.add_constant_prop(prop_id, value).map_err(|err| {
                 let name = self
                     .vertex_meta()
-                    .reverse_prop_id(prop_id, true)
+                    .get_prop_name(prop_id, true)
                     .expect("name exists")
                     .to_owned();
                 GraphError::ConstantPropertyMutationError {
@@ -60,7 +60,7 @@ impl<const N: usize> InternalPropertyAdditionOps for InnerTemporalGraph<N> {
                 .map_err(|err| {
                     let name = self
                         .edge_meta()
-                        .reverse_prop_id(prop_id, true)
+                        .get_prop_name(prop_id, true)
                         .expect("name exists")
                         .to_owned();
                     GraphError::ConstantPropertyMutationError {

--- a/raphtory/src/db/internal/static_properties.rs
+++ b/raphtory/src/db/internal/static_properties.rs
@@ -1,15 +1,15 @@
 use crate::{
-    core::{entities::graph::tgraph::InnerTemporalGraph, storage::locked_view::LockedView, Prop},
-    db::api::properties::internal::ConstPropertiesOps,
+    core::{
+        entities::graph::tgraph::InnerTemporalGraph, storage::locked_view::LockedView, ArcStr, Prop,
+    },
+    db::api::{properties::internal::ConstPropertiesOps, view::BoxedIter},
 };
 use parking_lot::RwLockReadGuard;
+use std::sync::Arc;
 
 impl<const N: usize> ConstPropertiesOps for InnerTemporalGraph<N> {
-    fn const_property_keys<'a>(&'a self) -> Box<dyn Iterator<Item = LockedView<'a, String>> + 'a> {
-        let guarded = self.inner().constant_property_names();
-        Box::new((0..guarded.len()).map(move |i| {
-            RwLockReadGuard::map(RwLockReadGuard::rwlock(&guarded).read(), |v| &v[i]).into()
-        }))
+    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
+        Box::new(self.inner().constant_property_names().into_iter())
     }
 
     fn get_const_property(&self, key: &str) -> Option<Prop> {

--- a/raphtory/src/db/internal/static_properties.rs
+++ b/raphtory/src/db/internal/static_properties.rs
@@ -1,11 +1,7 @@
 use crate::{
-    core::{
-        entities::graph::tgraph::InnerTemporalGraph, storage::locked_view::LockedView, ArcStr, Prop,
-    },
-    db::api::{properties::internal::ConstPropertiesOps, view::BoxedIter},
+    core::{entities::graph::tgraph::InnerTemporalGraph, ArcStr, Prop},
+    db::api::properties::internal::ConstPropertiesOps,
 };
-use parking_lot::RwLockReadGuard;
-use std::sync::Arc;
 
 impl<const N: usize> ConstPropertiesOps for InnerTemporalGraph<N> {
     fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {

--- a/raphtory/src/db/internal/temporal_properties.rs
+++ b/raphtory/src/db/internal/temporal_properties.rs
@@ -1,14 +1,7 @@
 use crate::{
-    core::{
-        entities::graph::tgraph::InnerTemporalGraph, storage::locked_view::LockedView, ArcStr, Prop,
-    },
-    db::api::{
-        properties::internal::{Key, TemporalPropertiesOps, TemporalPropertyViewOps},
-        view::BoxedIter,
-    },
+    core::{entities::graph::tgraph::InnerTemporalGraph, ArcStr, Prop},
+    db::api::properties::internal::{Key, TemporalPropertiesOps, TemporalPropertyViewOps},
 };
-use parking_lot::RwLockReadGuard;
-use std::sync::Arc;
 
 impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
     fn temporal_value(&self, id: &Key) -> Option<Prop> {

--- a/raphtory/src/db/internal/temporal_properties.rs
+++ b/raphtory/src/db/internal/temporal_properties.rs
@@ -1,8 +1,14 @@
 use crate::{
-    core::{entities::graph::tgraph::InnerTemporalGraph, storage::locked_view::LockedView, Prop},
-    db::api::properties::internal::{Key, TemporalPropertiesOps, TemporalPropertyViewOps},
+    core::{
+        entities::graph::tgraph::InnerTemporalGraph, storage::locked_view::LockedView, ArcStr, Prop,
+    },
+    db::api::{
+        properties::internal::{Key, TemporalPropertiesOps, TemporalPropertyViewOps},
+        view::BoxedIter,
+    },
 };
 use parking_lot::RwLockReadGuard;
+use std::sync::Arc;
 
 impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
     fn temporal_value(&self, id: &Key) -> Option<Prop> {
@@ -33,17 +39,9 @@ impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
 }
 
 impl<const N: usize> TemporalPropertiesOps for InnerTemporalGraph<N> {
-    fn temporal_property_keys<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = LockedView<'a, String>> + 'a> {
+    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
         // TODO: Is this actually worth doing? the advantage is that there is definitely no writes during the iteration as we keep the guard alive...
-        let guarded = self.inner().temporal_property_names();
-        Box::new((0..guarded.len()).map(move |i| {
-            RwLockReadGuard::map(RwLockReadGuard::rwlock(&guarded).read_recursive(), |v| {
-                &v[i]
-            })
-            .into()
-        }))
+        Box::new(self.inner().temporal_property_names().into_iter())
     }
 
     fn get_temporal_property(&self, key: &str) -> Option<Key> {

--- a/raphtory/src/db/task/edge/eval_edge.rs
+++ b/raphtory/src/db/task/edge/eval_edge.rs
@@ -3,7 +3,7 @@ use crate::{
         entities::{edges::edge_ref::EdgeRef, LayerIds, VID},
         state::compute_state::ComputeState,
         storage::locked_view::LockedView,
-        Prop,
+        ArcStr, Prop,
     },
     db::{
         api::{
@@ -19,7 +19,7 @@ use crate::{
         },
     },
 };
-use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc};
+use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc, sync::Arc};
 
 pub struct EvalEdgeView<'a, G: GraphViewOps, CS: ComputeState, S> {
     ss: usize,
@@ -85,14 +85,14 @@ impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static>
 impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> ConstPropertiesOps
     for EvalEdgeView<'a, G, CS, S>
 {
-    fn const_property_keys<'b>(&'b self) -> Box<dyn Iterator<Item = LockedView<'b, String>> + 'b> {
+    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
         self.graph
-            .static_edge_prop_names(self.ev, self.graph.layer_ids())
+            .constant_edge_prop_names(self.ev, self.graph.layer_ids())
     }
 
     fn get_const_property(&self, key: &str) -> Option<Prop> {
         self.graph
-            .static_edge_prop(self.ev, key, self.graph.layer_ids())
+            .constant_edge_prop(self.ev, key, self.graph.layer_ids())
     }
 }
 
@@ -132,9 +132,7 @@ impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> TemporalPropertyViewOps
 impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> TemporalPropertiesOps
     for EvalEdgeView<'a, G, CS, S>
 {
-    fn temporal_property_keys<'b>(
-        &'b self,
-    ) -> Box<dyn Iterator<Item = LockedView<'b, String>> + 'b> {
+    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
         self.graph
             .temporal_edge_prop_names(self.ev, self.graph.layer_ids())
     }
@@ -230,8 +228,8 @@ impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> EdgeListOps
         Box::new(self.map(|e| e.time()))
     }
 
-    fn layer_name(self) -> Self::IterType<Option<String>> {
-        Box::new(self.map(|e| e.layer_name()))
+    fn layer_name(self) -> Self::IterType<Option<ArcStr>> {
+        Box::new(self.map(|e| e.layer_name().map(|v| v.clone())))
     }
 }
 

--- a/raphtory/src/db/task/edge/eval_edge.rs
+++ b/raphtory/src/db/task/edge/eval_edge.rs
@@ -2,7 +2,6 @@ use crate::{
     core::{
         entities::{edges::edge_ref::EdgeRef, LayerIds, VID},
         state::compute_state::ComputeState,
-        storage::locked_view::LockedView,
         ArcStr, Prop,
     },
     db::{
@@ -19,7 +18,7 @@ use crate::{
         },
     },
 };
-use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc, sync::Arc};
+use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc};
 
 pub struct EvalEdgeView<'a, G: GraphViewOps, CS: ComputeState, S> {
     ss: usize,

--- a/raphtory/src/db/task/edge/window_eval_edge.rs
+++ b/raphtory/src/db/task/edge/window_eval_edge.rs
@@ -2,7 +2,6 @@ use crate::{
     core::{
         entities::{edges::edge_ref::EdgeRef, LayerIds, VID},
         state::compute_state::ComputeState,
-        storage::locked_view::LockedView,
         ArcStr, Prop,
     },
     db::{
@@ -20,7 +19,7 @@ use crate::{
         },
     },
 };
-use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc, sync::Arc};
+use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc};
 
 pub struct WindowEvalEdgeView<'a, G: GraphViewOps, CS: ComputeState, S: 'static> {
     ss: usize,

--- a/raphtory/src/db/task/edge/window_eval_edge.rs
+++ b/raphtory/src/db/task/edge/window_eval_edge.rs
@@ -3,7 +3,7 @@ use crate::{
         entities::{edges::edge_ref::EdgeRef, LayerIds, VID},
         state::compute_state::ComputeState,
         storage::locked_view::LockedView,
-        Prop,
+        ArcStr, Prop,
     },
     db::{
         api::{
@@ -20,7 +20,7 @@ use crate::{
         },
     },
 };
-use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc};
+use std::{cell::RefCell, iter, marker::PhantomData, rc::Rc, sync::Arc};
 
 pub struct WindowEvalEdgeView<'a, G: GraphViewOps, CS: ComputeState, S: 'static> {
     ss: usize,
@@ -108,13 +108,13 @@ impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static>
 impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> ConstPropertiesOps
     for WindowEvalEdgeView<'a, G, CS, S>
 {
-    fn const_property_keys<'b>(&'b self) -> Box<dyn Iterator<Item = LockedView<'b, String>> + 'b> {
-        Box::new(self.g.static_edge_prop_names(self.ev, self.g.layer_ids()))
+    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
+        Box::new(self.g.constant_edge_prop_names(self.ev, self.g.layer_ids()))
     }
 
     fn get_const_property(&self, key: &str) -> Option<Prop> {
         self.graph()
-            .static_edge_prop(self.ev, key, self.g.layer_ids())
+            .constant_edge_prop(self.ev, key, self.g.layer_ids())
     }
 }
 
@@ -182,9 +182,7 @@ impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> TemporalPropertyViewOps
 impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> TemporalPropertiesOps
     for WindowEvalEdgeView<'a, G, CS, S>
 {
-    fn temporal_property_keys<'b>(
-        &'b self,
-    ) -> Box<dyn Iterator<Item = LockedView<'b, String>> + 'b> {
+    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
         Box::new(
             self.g
                 .temporal_edge_prop_names(self.ev, self.g.layer_ids())
@@ -374,7 +372,7 @@ impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> EdgeListOps
         Box::new(self.map(|e| e.time()))
     }
 
-    fn layer_name(self) -> Self::IterType<Option<String>> {
-        Box::new(self.map(|e| e.layer_name()))
+    fn layer_name(self) -> Self::IterType<Option<ArcStr>> {
+        Box::new(self.map(|e| e.layer_name().map(|v| v.clone())))
     }
 }

--- a/raphtory/src/graph_loader/example/reddit_hyperlinks.rs
+++ b/raphtory/src/graph_loader/example/reddit_hyperlinks.rs
@@ -113,7 +113,7 @@ pub fn reddit_graph(timeout: u64, test_file: bool) -> Graph {
                                 .collect();
                             let edge_properties = [
                                 ("post_label".to_string(), Prop::I32(post_label)),
-                                ("post_id".to_string(), Prop::Str(post_id)),
+                                ("post_id".to_string(), Prop::str(post_id)),
                                 ("word_count".to_string(), Prop::F64(post_properties[7])),
                                 ("long_words".to_string(), Prop::F64(post_properties[9])),
                                 ("sentences".to_string(), Prop::F64(post_properties[13])),

--- a/raphtory/src/graph_loader/mod.rs
+++ b/raphtory/src/graph_loader/mod.rs
@@ -52,14 +52,14 @@
 //!     g.add_vertex(
 //!         lotr.time,
 //!         lotr.src_id.clone(),
-//!         [("type".to_string(), Prop::Str("Character".to_string()))],
+//!         [("type", Prop::str("Character"))],
 //!     )
 //!     .expect("Failed to add vertex");
 //!
 //!     g.add_vertex(
 //!         lotr.time,
 //!         lotr.dst_id.clone(),
-//!         [("type".to_string(), Prop::Str("Character".to_string()))],
+//!         [("type", Prop::str("Character"))],
 //!     )
 //!     .expect("Failed to add vertex");
 //!
@@ -68,8 +68,8 @@
 //!         lotr.src_id.clone(),
 //!         lotr.dst_id.clone(),
 //!         [(
-//!             "type".to_string(),
-//!             Prop::Str("Character Co-occurrence".to_string()),
+//!             "type",
+//!             Prop::str("Character Co-occurrence"),
 //!         )],
 //!         None,
 //!     )
@@ -216,26 +216,15 @@ mod graph_loader_test {
                     let src_id = hashing::calculate_hash(&src);
                     let dst_id = hashing::calculate_hash(&dst);
 
-                    g.add_vertex(
-                        t,
-                        src_id,
-                        [("name".to_string(), Prop::Str("Character".to_string()))],
-                    )
-                    .unwrap();
-                    g.add_vertex(
-                        t,
-                        dst_id,
-                        [("name".to_string(), Prop::Str("Character".to_string()))],
-                    )
-                    .unwrap();
+                    g.add_vertex(t, src_id, [("name", Prop::str("Character"))])
+                        .unwrap();
+                    g.add_vertex(t, dst_id, [("name", Prop::str("Character"))])
+                        .unwrap();
                     g.add_edge(
                         t,
                         src_id,
                         dst_id,
-                        [(
-                            "name".to_string(),
-                            Prop::Str("Character Co-occurrence".to_string()),
-                        )],
+                        [("name", Prop::str("Character Co-occurrence"))],
                         None,
                     )
                     .unwrap();

--- a/raphtory/src/graph_loader/source/csv_loader.rs
+++ b/raphtory/src/graph_loader/source/csv_loader.rs
@@ -32,14 +32,14 @@
 //!          g.add_vertex(
 //!              time,
 //!              src_id,
-//!              [("name".to_string(), Prop::Str("Character".to_string()))],
+//!              [("name", Prop::str("Character"))],
 //!          )
 //!          .map_err(|err| println!("{:?}", err))
 //!          .ok();
 //!          g.add_vertex(
 //!              time,
 //!              dst_id,
-//!              [("name".to_string(), Prop::Str("Character".to_string()))],
+//!              [("name", Prop::str("Character"))],
 //!          )
 //!          .map_err(|err| println!("{:?}", err))
 //!          .ok();
@@ -48,8 +48,8 @@
 //!              src_id,
 //!              dst_id,
 //!              [(
-//!                  "name".to_string(),
-//!                  Prop::Str("Character Co-occurrence".to_string()),
+//!                  "name",
+//!                  Prop::str("Character Co-occurrence"),
 //!              )],
 //!              None,
 //!          ).expect("Failed to add edge");
@@ -520,28 +520,17 @@ mod csv_loader_test {
                 let dst_id = calculate_hash(&lotr.dst_id);
                 let time = lotr.time;
 
-                g.add_vertex(
-                    time,
-                    src_id,
-                    [("name".to_string(), Prop::Str("Character".to_string()))],
-                )
-                .map_err(|err| println!("{:?}", err))
-                .ok();
-                g.add_vertex(
-                    time,
-                    dst_id,
-                    [("name".to_string(), Prop::Str("Character".to_string()))],
-                )
-                .map_err(|err| println!("{:?}", err))
-                .ok();
+                g.add_vertex(time, src_id, [("name", Prop::str("Character"))])
+                    .map_err(|err| println!("{:?}", err))
+                    .ok();
+                g.add_vertex(time, dst_id, [("name", Prop::str("Character"))])
+                    .map_err(|err| println!("{:?}", err))
+                    .ok();
                 g.add_edge(
                     time,
                     src_id,
                     dst_id,
-                    [(
-                        "name".to_string(),
-                        Prop::Str("Character Co-occurrence".to_string()),
-                    )],
+                    [("name", Prop::str("Character Co-occurrence"))],
                     None,
                 )
                 .unwrap();
@@ -565,28 +554,17 @@ mod csv_loader_test {
                     .unwrap();
                 let time = lotr.get(2).map(|s| s.parse::<i64>().unwrap()).unwrap();
 
-                g.add_vertex(
-                    time,
-                    src_id,
-                    [("name".to_string(), Prop::Str("Character".to_string()))],
-                )
-                .map_err(|err| println!("{:?}", err))
-                .ok();
-                g.add_vertex(
-                    time,
-                    dst_id,
-                    [("name".to_string(), Prop::Str("Character".to_string()))],
-                )
-                .map_err(|err| println!("{:?}", err))
-                .ok();
+                g.add_vertex(time, src_id, [("name", Prop::str("Character"))])
+                    .map_err(|err| println!("{:?}", err))
+                    .ok();
+                g.add_vertex(time, dst_id, [("name", Prop::str("Character"))])
+                    .map_err(|err| println!("{:?}", err))
+                    .ok();
                 g.add_edge(
                     time,
                     src_id,
                     dst_id,
-                    [(
-                        "name".to_string(),
-                        Prop::Str("Character Co-occurrence".to_string()),
-                    )],
+                    [("name", Prop::str("Character Co-occurrence"))],
                     None,
                 )
                 .unwrap();

--- a/raphtory/src/lib.rs
+++ b/raphtory/src/lib.rs
@@ -36,25 +36,25 @@
 //! graph.add_vertex(
 //!   1,
 //!   "Gandalf",
-//!   [("type".to_string(), Prop::Str("Character".to_string()))],
-//! );
+//!   [("type", Prop::str("Character"))],
+//! ).unwrap();
 //!
 //! graph.add_vertex(
 //!   2,
 //!   "Frodo",
-//!   [("type".to_string(), Prop::Str("Character".to_string()))],
-//! );
+//!   [("type", Prop::str("Character"))],
+//! ).unwrap();
 //!
 //! graph.add_edge(
 //!   3,
 //!   "Gandalf",
 //!   "Frodo",
 //!   [(
-//!       "meeting".to_string(),
-//!       Prop::Str("Character Co-occurrence".to_string()),
+//!       "meeting",
+//!       Prop::str("Character Co-occurrence"),
 //!   )],
 //!   None,
-//! );
+//! ).unwrap();
 //!
 //! // Get the in-degree, out-degree and degree of Gandalf
 //! println!("Number of vertices {:?}", graph.count_vertices());

--- a/raphtory/src/python/graph/views/graph_view.rs
+++ b/raphtory/src/python/graph/views/graph_view.rs
@@ -4,6 +4,7 @@ use crate::{
     core::{
         entities::vertices::vertex_ref::VertexRef,
         utils::{errors::GraphError, time::error::ParseTimeError},
+        ArcStr,
     },
     db::{
         api::{
@@ -103,8 +104,8 @@ impl<G: GraphViewOps + IntoDynamic> IntoPy<PyObject> for VertexSubgraph<G> {
 impl PyGraphView {
     /// Return all the layer ids in the graph
     #[getter]
-    pub fn unique_layers(&self) -> Vec<String> {
-        self.graph.unique_layers()
+    pub fn unique_layers(&self) -> Vec<ArcStr> {
+        self.graph.unique_layers().collect()
     }
 
     //******  Metrics APIs ******//

--- a/raphtory/src/python/types/repr.rs
+++ b/raphtory/src/python/types/repr.rs
@@ -1,4 +1,4 @@
-use crate::core::storage::locked_view::LockedView;
+use crate::core::{storage::locked_view::LockedView, ArcStr};
 use chrono::NaiveDateTime;
 use itertools::Itertools;
 use std::{collections::HashMap, ops::Deref};
@@ -89,6 +89,18 @@ impl Repr for f64 {
 }
 
 impl Repr for String {
+    fn repr(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Repr for ArcStr {
+    fn repr(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Repr for &ArcStr {
     fn repr(&self) -> String {
         self.to_string()
     }

--- a/raphtory/src/python/types/wrappers/prop.rs
+++ b/raphtory/src/python/types/wrappers/prop.rs
@@ -43,8 +43,8 @@ impl<'source> FromPyObject<'source> for Prop {
         if let Ok(d) = ob.extract() {
             return Ok(Prop::DTime(d));
         }
-        if let Ok(s) = ob.extract() {
-            return Ok(Prop::Str(s));
+        if let Ok(s) = ob.extract::<String>() {
+            return Ok(Prop::Str(s.into()));
         }
         if let Ok(g) = ob.extract() {
             return Ok(Prop::Graph(g));

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -692,7 +692,7 @@ impl<G: GraphViewOps + InternalAdditionOps> InternalAdditionOps for IndexedGraph
             let prop_name = self
                 .graph
                 .vertex_meta()
-                .reverse_prop_id(*prop_id, false)
+                .get_prop_name(*prop_id, false)
                 .expect("property id should be valid");
             if let Ok(field) = self.vertex_index.schema().get_field(&prop_name) {
                 if let Prop::Str(s) = prop {

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -667,6 +667,11 @@ impl<G: GraphViewOps + InternalAdditionOps> InternalAdditionOps for IndexedGraph
         self.graph.resolve_edge_property(prop, dtype, is_static)
     }
 
+    #[inline]
+    fn process_prop_value(&self, prop: Prop) -> Prop {
+        self.graph.process_prop_value(prop)
+    }
+
     fn internal_add_vertex(
         &self,
         t: TimeIndexEntry,

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         entities::{vertices::vertex_ref::VertexRef, EID, VID},
         storage::timeindex::{AsTime, TimeIndexEntry},
         utils::errors::GraphError,
-        PropType,
+        ArcStr, PropType,
     },
     db::{
         api::{
@@ -188,7 +188,7 @@ impl<G: GraphViewOps> IndexedGraph<G> {
             if prop_names_set.is_empty() {
                 break;
             }
-            let mut found_props = HashSet::from(["name".to_string()]);
+            let mut found_props: HashSet<ArcStr> = HashSet::default();
 
             for prop in prop_names_set.iter() {
                 // load temporal props
@@ -202,14 +202,13 @@ impl<G: GraphViewOps> IndexedGraph<G> {
                         continue;
                     }
                     Self::set_schema_field_from_prop(&mut schema, prop, prop_value);
-                    found_props.insert(prop.to_string());
+                    found_props.insert(prop.clone());
                 }
                 // load static props
                 if let Some(prop_value) = vertex.properties().constant().get(prop) {
-                    let name = if prop == "_id" { fields::NAME } else { prop };
-                    if !found_props.contains(name) {
-                        Self::set_schema_field_from_prop(&mut schema, name, prop_value);
-                        found_props.insert(prop.to_string());
+                    if !found_props.contains(prop) {
+                        Self::set_schema_field_from_prop(&mut schema, prop, prop_value);
+                        found_props.insert(prop.clone());
                     }
                 }
             }
@@ -239,7 +238,7 @@ impl<G: GraphViewOps> IndexedGraph<G> {
             if prop_names_set.is_empty() {
                 break;
             }
-            let mut found_props = HashSet::new();
+            let mut found_props: HashSet<ArcStr> = HashSet::new();
 
             for prop in prop_names_set.iter() {
                 // load temporal props
@@ -253,14 +252,13 @@ impl<G: GraphViewOps> IndexedGraph<G> {
                         continue;
                     }
                     Self::set_schema_field_from_prop(&mut schema, prop, prop_value);
-                    found_props.insert(prop.to_string());
+                    found_props.insert(prop.clone());
                 }
                 // load static props
                 if let Some(prop_value) = edge.properties().constant().get(prop) {
-                    let name = if prop == "_id" { fields::NAME } else { prop };
-                    if !found_props.contains(name) {
-                        Self::set_schema_field_from_prop(&mut schema, name, prop_value);
-                        found_props.insert(prop.to_string());
+                    if !found_props.contains(prop) {
+                        Self::set_schema_field_from_prop(&mut schema, prop, prop_value);
+                        found_props.insert(prop.clone());
                     }
                 }
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Store all strings as immutable Arc<str> to make cloning of properties cheap
- Implement a per-graph string pool to avoid storing duplicate string values and instead only store pointers to the same underlying string

### Why are the changes needed?

- memory optimisation

### Does this PR introduce any user-facing change? If yes is this documented?

no, changes are completely transparent to the user-facing apis
### How was this patch tested?

existing tests still work and added a test to check the deduplication is effective



