### PR TITLE
Feature/properties use internal ids

### DIFF
--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -75,7 +75,7 @@ impl Node {
         self.vv
             .properties()
             .temporal()
-            .get(name)
+            .get(&name)
             .into_iter()
             .flat_map(|p| {
                 p.iter()

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -211,7 +211,9 @@ impl Mut {
 
         let subgraph = data.get(&graph_name).ok_or("Graph not found")?;
         let mut path = subgraph
-            .constant_prop(&"path".to_string())
+            .properties()
+            .constant()
+            .get("path")
             .ok_or("Path is missing")?
             .to_string();
 

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use async_graphql::Context;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use chrono::{NaiveDateTime, Utc};
+use chrono::Utc;
 use dynamic_graphql::{
     App, Mutation, MutationFields, MutationRoot, ResolvedObject, ResolvedObjectFields, Result,
     Upload,
@@ -12,7 +12,7 @@ use dynamic_graphql::{
 use itertools::Itertools;
 use raphtory::{
     core::{ArcStr, Prop},
-    db::api::view::internal::{CoreGraphOps, DynamicGraph, IntoDynamic, MaterializedGraph},
+    db::api::view::internal::{IntoDynamic, MaterializedGraph},
     prelude::{Graph, GraphViewOps, PropertyAdditionOps, VertexViewOps},
     search::IndexedGraph,
 };
@@ -20,10 +20,8 @@ use std::{
     collections::HashMap,
     error::Error,
     fmt::{Display, Formatter},
-    fs,
     io::BufReader,
     ops::Deref,
-    time::UNIX_EPOCH,
 };
 use uuid::Uuid;
 
@@ -157,7 +155,9 @@ impl Mut {
 
             let subgraph = data.get(&graph_name).ok_or("Graph not found")?;
             let path = subgraph
-                .constant_prop(&"path".to_string())
+                .properties()
+                .constant()
+                .get("path")
                 .ok_or("Path is missing")?
                 .to_string();
 
@@ -169,21 +169,16 @@ impl Mut {
             let static_props_without_name: Vec<(ArcStr, Prop)> = subgraph
                 .properties()
                 .into_iter()
-                .filter(|(a, b)| a != "name")
+                .filter(|(a, _)| a != "name")
                 .collect_vec();
 
             new_subgraph.add_constant_properties(static_props_without_name)?;
-            new_subgraph.add_constant_properties([(
-                "name".to_string(),
-                Prop::Str(new_graph_name.clone().into()),
-            )])?;
+            new_subgraph
+                .add_constant_properties([("name", Prop::Str(new_graph_name.clone().into()))])?;
 
             let dt = Utc::now();
             let timestamp: i64 = dt.timestamp();
-            new_subgraph.add_constant_properties([(
-                "lastUpdated".to_string(),
-                Prop::I64(timestamp * 1000),
-            )])?;
+            new_subgraph.add_constant_properties([("lastUpdated", Prop::I64(timestamp * 1000))])?;
 
             new_subgraph.save_to_file(path)?;
 
@@ -192,7 +187,7 @@ impl Mut {
                 .ok_or("Graph with deletions not supported")?
                 .into();
 
-            data.insert(new_graph_name.clone(), gi.clone());
+            data.insert(new_graph_name, gi);
             data.remove(&graph_name);
         }
 
@@ -226,7 +221,7 @@ impl Mut {
                     let joined_string = elements
                         .iter()
                         .take(size - 1)
-                        .map(|s| *s)
+                        .copied()
                         .collect::<Vec<_>>()
                         .join(delimiter);
                     Ok(joined_string)
@@ -242,10 +237,7 @@ impl Mut {
 
         let new_subgraph = parent_graph.subgraph(graph_nodes).materialize()?;
 
-        new_subgraph.add_constant_properties([(
-            "name".to_string(),
-            Prop::Str(new_graph_name.clone().into()),
-        )])?;
+        new_subgraph.add_constant_properties([("name", Prop::str(new_graph_name.clone()))])?;
 
         // parent_graph_name == graph_name, means its a graph created from UI
         if parent_graph_name.ne(&graph_name) {
@@ -254,14 +246,14 @@ impl Mut {
                 let static_props: Vec<(ArcStr, Prop)> = subgraph
                     .properties()
                     .into_iter()
-                    .filter(|(a, b)| a != "name" && a != "creationTime" && a != "uiProps")
+                    .filter(|(a, _)| a != "name" && a != "creationTime" && a != "uiProps")
                     .collect_vec();
                 new_subgraph.add_constant_properties(static_props)?;
             } else {
                 let static_props: Vec<(ArcStr, Prop)> = subgraph
                     .properties()
                     .into_iter()
-                    .filter(|(a, b)| a != "name" && a != "lastUpdated" && a != "uiProps")
+                    .filter(|(a, _)| a != "name" && a != "lastUpdated" && a != "uiProps")
                     .collect_vec();
                 new_subgraph.add_constant_properties(static_props)?;
             }
@@ -271,15 +263,12 @@ impl Mut {
         let timestamp: i64 = dt.timestamp();
 
         if parent_graph_name.eq(&graph_name) || graph_name.ne(&new_graph_name) {
-            new_subgraph.add_constant_properties([(
-                "creationTime".to_string(),
-                Prop::I64(timestamp * 1000),
-            )])?;
+            new_subgraph
+                .add_constant_properties([("creationTime", Prop::I64(timestamp * 1000))])?;
         }
 
-        new_subgraph
-            .add_constant_properties([("lastUpdated".to_string(), Prop::I64(timestamp * 1000))])?;
-        new_subgraph.add_constant_properties([("uiProps".to_string(), Prop::Str(props.into()))])?;
+        new_subgraph.add_constant_properties([("lastUpdated", Prop::I64(timestamp * 1000))])?;
+        new_subgraph.add_constant_properties([("uiProps", Prop::Str(props.into()))])?;
 
         new_subgraph.save_to_file(path)?;
 
@@ -288,7 +277,7 @@ impl Mut {
             .ok_or("Graph with deletions not supported")?
             .into();
 
-        data.insert(new_graph_name, gi.clone());
+        data.insert(new_graph_name, gi);
 
         Ok(true)
     }
@@ -320,7 +309,7 @@ impl Mut {
             .ok_or("Graph with deletions not supported")?
             .into();
         let mut data = ctx.data_unchecked::<Data>().graphs.write();
-        data.insert(name.clone(), gi.clone());
+        data.insert(name.clone(), gi);
         Ok(name)
     }
 
@@ -351,7 +340,9 @@ impl Mut {
         let subgraph = data.get(&graph_name).ok_or("Graph not found")?;
 
         let path = subgraph
-            .constant_prop(&"path".to_string())
+            .properties()
+            .constant()
+            .get("path")
             .ok_or("Path is missing")?
             .to_string();
 
@@ -363,11 +354,10 @@ impl Mut {
         let static_props_without_isactive: Vec<(ArcStr, Prop)> = subgraph
             .properties()
             .into_iter()
-            .filter(|(a, b)| a != "isArchive")
+            .filter(|(a, _)| a != "isArchive")
             .collect_vec();
         new_subgraph.add_constant_properties(static_props_without_isactive)?;
-        new_subgraph
-            .add_constant_properties([("isArchive".to_string(), Prop::U8(is_archive.clone()))])?;
+        new_subgraph.add_constant_properties([("isArchive", Prop::U8(is_archive))])?;
         new_subgraph.save_to_file(path)?;
 
         let gi: IndexedGraph<Graph> = new_subgraph
@@ -375,7 +365,7 @@ impl Mut {
             .ok_or("Graph with deletions not supported")?
             .into();
 
-        data.insert(graph_name, gi.clone());
+        data.insert(graph_name, gi);
 
         Ok(true)
     }

--- a/raphtory/src/core/entities/edges/edge.rs
+++ b/raphtory/src/core/entities/edges/edge.rs
@@ -133,7 +133,7 @@ impl<'a, const N: usize> EdgeView<'a, N> {
     ) -> Option<LockedLayeredTProp<'a>> {
         match self.edge_id {
             ERef::ERef(entry) => {
-                if entry.has_temporal_prop(layer_ids.clone(), prop_id) {
+                if entry.has_temporal_prop(&layer_ids, prop_id) {
                     match layer_ids {
                         LayerIds::None => None,
                         LayerIds::All => {

--- a/raphtory/src/core/entities/edges/edge_store.rs
+++ b/raphtory/src/core/entities/edges/edge_store.rs
@@ -1,16 +1,19 @@
-use crate::core::{
-    entities::{
-        edges::edge_ref::EdgeRef,
-        properties::{props::Props, tprop::TProp},
-        LayerIds, EID, VID,
+use crate::{
+    core::{
+        entities::{
+            edges::edge_ref::EdgeRef,
+            properties::{props::Props, tprop::TProp},
+            LayerIds, EID, VID,
+        },
+        storage::{
+            lazy_vec::IllegalSet,
+            locked_view::LockedView,
+            timeindex::{TimeIndex, TimeIndexEntry, TimeIndexOps},
+        },
+        utils::errors::{GraphError, MutateGraphError},
+        Prop,
     },
-    storage::{
-        lazy_vec::IllegalSet,
-        locked_view::LockedView,
-        timeindex::{TimeIndex, TimeIndexEntry},
-    },
-    utils::errors::{GraphError, MutateGraphError},
-    Prop,
+    prelude::TimeOps,
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -56,15 +59,15 @@ impl EdgeLayer {
         props.add_constant_prop(prop_id, prop)
     }
 
-    pub(crate) fn static_prop_ids(&self) -> Vec<usize> {
+    pub(crate) fn const_prop_ids(&self) -> impl Iterator<Item = usize> + '_ {
         self.props
             .as_ref()
-            .map(|props| props.static_prop_ids())
-            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|props| props.const_prop_ids())
     }
 
-    pub(crate) fn static_property(&self, prop_id: usize) -> Option<&Prop> {
-        self.props.as_ref().and_then(|ps| ps.static_prop(prop_id))
+    pub(crate) fn const_prop(&self, prop_id: usize) -> Option<&Prop> {
+        self.props.as_ref().and_then(|ps| ps.const_prop(prop_id))
     }
 
     pub(crate) fn temporal_property(&self, prop_id: usize) -> Option<&TProp> {
@@ -245,7 +248,23 @@ impl EdgeStore {
         }
     }
 
-    pub fn has_temporal_prop(&self, layer_ids: LayerIds, prop_id: usize) -> bool {
+    pub fn last_deletion_before(&self, layer_ids: &LayerIds, t: i64) -> Option<i64> {
+        match layer_ids {
+            LayerIds::None => None,
+            LayerIds::All => self
+                .deletions()
+                .iter()
+                .flat_map(|dels| dels.range(i64::MIN..t).last_t())
+                .max(),
+            LayerIds::One(id) => self.deletions[*id].range(i64::MIN..t).last_t(),
+            LayerIds::Multiple(ids) => ids
+                .iter()
+                .flat_map(|id| self.deletions[*id].range(i64::MIN..t).last_t())
+                .max(),
+        }
+    }
+
+    pub fn has_temporal_prop(&self, layer_ids: &LayerIds, prop_id: usize) -> bool {
         match layer_ids {
             LayerIds::None => false,
             LayerIds::All => self.layer_ids_iter().any(|id| {
@@ -254,12 +273,49 @@ impl EdgeStore {
                     .is_some()
             }),
             LayerIds::One(id) => self
-                .layer(id)
+                .layer(*id)
                 .and_then(|layer| layer.temporal_property(prop_id))
                 .is_some(),
             LayerIds::Multiple(ids) => ids.iter().any(|id| {
                 self.layer(*id)
                     .and_then(|layer| layer.temporal_property(prop_id))
+                    .is_some()
+            }),
+        }
+    }
+
+    pub fn has_temporal_prop_window(
+        &self,
+        layer_ids: LayerIds,
+        prop_id: usize,
+        w: Range<i64>,
+    ) -> bool {
+        match layer_ids {
+            LayerIds::None => false,
+            LayerIds::All => self.layer_ids_iter().any(|id| {
+                self.layer(id)
+                    .and_then(|layer| {
+                        layer
+                            .temporal_property(prop_id)
+                            .filter(|p| p.iter_window(w.clone()).next().is_some())
+                    })
+                    .is_some()
+            }),
+            LayerIds::One(id) => self
+                .layer(id)
+                .and_then(|layer| {
+                    layer
+                        .temporal_property(prop_id)
+                        .filter(|p| p.iter_window(w.clone()).next().is_some())
+                })
+                .is_some(),
+            LayerIds::Multiple(ids) => ids.iter().any(|id| {
+                self.layer(*id)
+                    .and_then(|layer| {
+                        layer
+                            .temporal_property(prop_id)
+                            .filter(|p| p.iter_window(w.clone()).next().is_some())
+                    })
                     .is_some()
             }),
         }
@@ -314,29 +370,25 @@ impl EdgeStore {
         }
     }
 
-    pub(crate) fn temp_prop_ids(&self, layer_id: Option<usize>) -> Vec<usize> {
+    pub(crate) fn temp_prop_ids(
+        &self,
+        layer_id: Option<usize>,
+    ) -> Box<dyn Iterator<Item = usize> + '_> {
         if let Some(layer_id) = layer_id {
-            self.layers
-                .get(layer_id)
-                .map(|layer| {
-                    layer
-                        .props()
-                        .map(|props| props.temporal_prop_ids())
-                        .unwrap_or_default()
-                })
-                .unwrap_or_default()
+            Box::new(self.layers.get(layer_id).into_iter().flat_map(|layer| {
+                layer
+                    .props()
+                    .into_iter()
+                    .flat_map(|props| props.temporal_prop_ids())
+            }))
         } else {
-            self.layers
-                .iter()
-                .map(|layer| {
-                    layer
-                        .props()
-                        .map(|prop| prop.temporal_prop_ids())
-                        .unwrap_or_default()
-                })
-                .kmerge()
-                .dedup()
-                .collect()
+            Box::new(
+                self.layers
+                    .iter()
+                    .flat_map(|layer| layer.props().map(|prop| prop.temporal_prop_ids()))
+                    .kmerge()
+                    .dedup(),
+            )
         }
     }
 }

--- a/raphtory/src/core/entities/graph/tgraph.rs
+++ b/raphtory/src/core/entities/graph/tgraph.rs
@@ -132,12 +132,7 @@ impl<const N: usize> TemporalGraph<N> {
             LayerIds::None => Box::new(iter::empty()),
             LayerIds::All => Box::new(self.edge_meta.layer_meta().get_keys().into_iter()),
             LayerIds::One(id) => {
-                let name = self
-                    .edge_meta
-                    .layer_meta()
-                    .get_name(id)
-                    .expect("name for id should always exist")
-                    .clone();
+                let name = self.edge_meta.layer_meta().get_name(id).clone();
                 Box::new(iter::once(name))
             }
             LayerIds::Multiple(ids) => {
@@ -208,11 +203,8 @@ impl<const N: usize> TemporalGraph<N> {
         }
     }
 
-    pub(crate) fn get_layer_name(&self, layer: usize) -> String {
-        self.edge_meta
-            .get_layer_name_by_id(layer)
-            .unwrap_or_else(|| panic!("layer id '{layer}' doesn't exist"))
-            .to_string()
+    pub(crate) fn get_layer_name(&self, layer: usize) -> ArcStr {
+        self.edge_meta.get_layer_name_by_id(layer)
     }
 
     pub(crate) fn graph_earliest_time(&self) -> Option<i64> {
@@ -263,32 +255,6 @@ impl<const N: usize> TemporalGraph<N> {
     #[inline]
     pub(crate) fn edge_entry(&self, e: EID) -> Entry<'_, EdgeStore, N> {
         self.storage.get_edge(e.into())
-    }
-
-    pub(crate) fn vertex_reverse_prop_id(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
-        self.vertex_meta.get_prop_name(prop_id, is_static)
-    }
-
-    pub(crate) fn edge_temp_prop_ids(&self, e: EID) -> Vec<usize> {
-        let edge = self.storage.get_edge(e.into());
-        edge.temp_prop_ids(None)
-    }
-
-    pub(crate) fn vertex_temp_prop_ids(&self, e: VID) -> Vec<usize> {
-        let edge = self.storage.get_node(e.into());
-        edge.temp_prop_ids()
-    }
-
-    pub(crate) fn edge_find_prop(&self, prop: &str, is_static: bool) -> Option<usize> {
-        self.edge_meta.get_prop_id(prop, is_static)
-    }
-
-    pub(crate) fn vertex_find_prop(&self, prop: &str, is_static: bool) -> Option<usize> {
-        self.vertex_meta.get_prop_id(prop, is_static)
-    }
-
-    pub(crate) fn edge_reverse_prop_id(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
-        self.edge_meta.get_prop_name(prop_id, is_static)
     }
 }
 
@@ -388,10 +354,7 @@ impl<const N: usize> TemporalGraph<N> {
         let mut layer = edge.layer_mut(layer);
         for (prop_id, prop) in props {
             layer.add_constant_prop(prop_id, prop).map_err(|err| {
-                IllegalMutate::from_source(
-                    err,
-                    &self.edge_meta.get_prop_name(prop_id, true).unwrap(),
-                )
+                IllegalMutate::from_source(err, &self.edge_meta.get_prop_name(prop_id, true))
             })?;
         }
         Ok(())
@@ -418,15 +381,15 @@ impl<const N: usize> TemporalGraph<N> {
         Ok(())
     }
 
-    pub(crate) fn get_constant_prop(&self, name: &str) -> Option<Prop> {
-        self.graph_props.get_constant(name)
+    pub(crate) fn get_constant_prop(&self, id: usize) -> Option<Prop> {
+        self.graph_props.get_constant(id)
     }
 
-    pub(crate) fn get_temporal_prop(&self, name: &str) -> Option<LockedView<TProp>> {
-        self.graph_props.get_temporal(name)
+    pub(crate) fn get_temporal_prop(&self, id: usize) -> Option<LockedView<TProp>> {
+        self.graph_props.get_temporal_prop(id)
     }
 
-    pub(crate) fn constant_property_names(&self) -> ArcReadLockedVec<ArcStr> {
+    pub(crate) fn const_prop_names(&self) -> ArcReadLockedVec<ArcStr> {
         self.graph_props.constant_names()
     }
 

--- a/raphtory/src/core/entities/properties/graph_props.rs
+++ b/raphtory/src/core/entities/properties/graph_props.rs
@@ -36,6 +36,16 @@ impl GraphProps {
     }
 
     #[inline]
+    pub fn const_prop_meta(&self) -> &DictMapper {
+        &self.constant_mapper
+    }
+
+    #[inline]
+    pub fn temporal_prop_meta(&self) -> &DictMapper {
+        &self.temporal_mapper
+    }
+
+    #[inline]
     pub(crate) fn resolve_property(&self, name: &str, is_static: bool) -> usize {
         if is_static {
             self.constant_mapper.get_or_create_id(name)
@@ -54,11 +64,7 @@ impl GraphProps {
             Some(old_value) => {
                 if !(old_value == &prop) {
                     return Err(MutateGraphError::IllegalGraphPropertyChange {
-                        name: self
-                            .constant_mapper
-                            .get_name(prop_id)
-                            .expect("property exists if it has a value")
-                            .to_string(),
+                        name: self.constant_mapper.get_name(prop_id).to_string(),
                         old_value: old_value.clone(),
                         new_value: prop,
                     });
@@ -81,19 +87,17 @@ impl GraphProps {
         (*prop_entry).set(t, prop)
     }
 
-    pub(crate) fn get_constant(&self, name: &str) -> Option<Prop> {
-        let prop_id = self.constant_mapper.get_id(name)?;
-        let entry = self.constant.get(&prop_id)?;
+    pub(crate) fn get_constant(&self, id: usize) -> Option<Prop> {
+        let entry = self.constant.get(&id)?;
         entry.as_ref().cloned()
     }
 
-    pub(crate) fn get_temporal(&self, name: &str) -> Option<LockedView<'_, TProp>> {
-        let prop_id = self.temporal_mapper.get_id(name)?;
+    pub(crate) fn get_temporal_prop(&self, prop_id: usize) -> Option<LockedView<'_, TProp>> {
         let entry = self.temporal.get(&prop_id)?;
         Some(LockedView::DashMap(entry))
     }
 
-    pub fn get_constant_id(&self, name: &str) -> Option<usize> {
+    pub fn get_const_prop_id(&self, name: &str) -> Option<usize> {
         self.constant_mapper.get_id(name)
     }
 
@@ -101,11 +105,11 @@ impl GraphProps {
         self.temporal_mapper.get_id(name)
     }
 
-    pub fn get_constant_name(&self, prop_id: usize) -> Option<ArcStr> {
+    pub fn get_const_prop_name(&self, prop_id: usize) -> ArcStr {
         self.constant_mapper.get_name(prop_id)
     }
 
-    pub fn get_temporal_name(&self, prop_id: usize) -> Option<ArcStr> {
+    pub fn get_temporal_name(&self, prop_id: usize) -> ArcStr {
         self.temporal_mapper.get_name(prop_id)
     }
 
@@ -123,7 +127,15 @@ impl GraphProps {
         self.constant_mapper.get_keys()
     }
 
+    pub(crate) fn const_prop_ids(&self) -> impl Iterator<Item = usize> {
+        0..self.constant_mapper.len()
+    }
+
     pub(crate) fn temporal_names(&self) -> ArcReadLockedVec<ArcStr> {
         self.temporal_mapper.get_keys()
+    }
+
+    pub(crate) fn temporal_ids(&self) -> impl Iterator<Item = usize> {
+        0..self.temporal_mapper.len()
     }
 }

--- a/raphtory/src/core/entities/properties/props.rs
+++ b/raphtory/src/core/entities/properties/props.rs
@@ -86,7 +86,7 @@ impl Props {
         }
     }
 
-    pub fn static_prop(&self, prop_id: usize) -> Option<&Prop> {
+    pub fn const_prop(&self, prop_id: usize) -> Option<&Prop> {
         let prop = self.constant_props.get(prop_id)?;
         prop.as_ref()
     }
@@ -95,11 +95,11 @@ impl Props {
         self.temporal_props.get(prop_id)
     }
 
-    pub fn static_prop_ids(&self) -> Vec<usize> {
+    pub fn const_prop_ids(&self) -> impl Iterator<Item = usize> + '_ {
         self.constant_props.filled_ids()
     }
 
-    pub fn temporal_prop_ids(&self) -> Vec<usize> {
+    pub fn temporal_prop_ids(&self) -> impl Iterator<Item = usize> + '_ {
         self.temporal_props.filled_ids()
     }
 }
@@ -112,7 +112,7 @@ pub struct Meta {
 }
 
 impl Meta {
-    pub fn constant_prop_meta(&self) -> &PropMapper {
+    pub fn const_prop_meta(&self) -> &PropMapper {
         &self.meta_prop_constant
     }
 
@@ -169,8 +169,8 @@ impl Meta {
         self.meta_layer.map.get(name).as_deref().copied()
     }
 
-    pub fn get_layer_name_by_id(&self, id: usize) -> Option<String> {
-        self.meta_layer.get_name(id).map(|v| v.to_string())
+    pub fn get_layer_name_by_id(&self, id: usize) -> ArcStr {
+        self.meta_layer.get_name(id)
     }
 
     pub fn get_all_layers(&self) -> Vec<usize> {
@@ -189,7 +189,7 @@ impl Meta {
         }
     }
 
-    pub fn get_prop_name(&self, prop_id: usize, is_static: bool) -> Option<ArcStr> {
+    pub fn get_prop_name(&self, prop_id: usize, is_static: bool) -> ArcStr {
         if is_static {
             self.meta_prop_constant.get_name(prop_id)
         } else {
@@ -275,9 +275,12 @@ impl DictMapper {
         self.map.get(name).map(|id| *id)
     }
 
-    pub fn get_name(&self, id: usize) -> Option<ArcStr> {
+    pub fn get_name(&self, id: usize) -> ArcStr {
         let guard = self.reverse_map.read();
-        guard.get(id).map(|v| v.clone())
+        guard
+            .get(id)
+            .map(|v| v.clone())
+            .expect("internal ids should always be mapped to a name")
     }
 
     pub fn get_keys(&self) -> ArcReadLockedVec<ArcStr> {

--- a/raphtory/src/core/entities/properties/tprop.rs
+++ b/raphtory/src/core/entities/properties/tprop.rs
@@ -34,7 +34,7 @@ pub enum TProp {
     DTime(TCell<NaiveDateTime>),
     Graph(TCell<Graph>),
     List(TCell<Arc<Vec<Prop>>>),
-    Map(TCell<Arc<HashMap<String, Prop>>>),
+    Map(TCell<Arc<HashMap<ArcStr, Prop>>>),
 }
 
 impl TProp {

--- a/raphtory/src/core/entities/vertices/vertex.rs
+++ b/raphtory/src/core/entities/vertices/vertex.rs
@@ -42,13 +42,10 @@ impl<'a, const N: usize> Vertex<'a, N> {
 
     pub fn temporal_properties(
         &'a self,
-        name: &str,
+        prop_id: usize,
         window: Option<Range<i64>>,
     ) -> impl Iterator<Item = (i64, Prop)> + 'a {
-        let prop_id = self.graph.vertex_meta.get_prop_id(name, false);
-        prop_id
-            .into_iter()
-            .flat_map(move |prop_id| self.node.temporal_properties(prop_id, window.clone()))
+        self.node.temporal_properties(prop_id, window)
     }
 
     pub fn neighbours<'b>(

--- a/raphtory/src/core/entities/vertices/vertex_store.rs
+++ b/raphtory/src/core/entities/vertices/vertex_store.rs
@@ -159,8 +159,8 @@ impl VertexStore {
         }
     }
 
-    pub(crate) fn static_property(&self, prop_id: usize) -> Option<&Prop> {
-        self.props.as_ref().and_then(|ps| ps.static_prop(prop_id))
+    pub(crate) fn const_prop(&self, prop_id: usize) -> Option<&Prop> {
+        self.props.as_ref().and_then(|ps| ps.const_prop(prop_id))
     }
 
     #[inline]
@@ -332,22 +332,22 @@ impl VertexStore {
         self.layers[layer_id].get_page_vec(last, page_size, dir)
     }
 
-    pub(crate) fn constant_prop_ids(&self) -> Vec<usize> {
+    pub(crate) fn const_prop_ids(&self) -> impl Iterator<Item = usize> + '_ {
         self.props
             .as_ref()
-            .map(|ps| ps.static_prop_ids())
-            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|ps| ps.const_prop_ids())
     }
 
     pub(crate) fn temporal_property(&self, prop_id: usize) -> Option<&TProp> {
         self.props.as_ref().and_then(|ps| ps.temporal_prop(prop_id))
     }
 
-    pub(crate) fn temp_prop_ids(&self) -> Vec<usize> {
+    pub(crate) fn temporal_prop_ids(&self) -> impl Iterator<Item = usize> + '_ {
         self.props
             .as_ref()
-            .map(|ps| ps.temporal_prop_ids())
-            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|ps| ps.temporal_prop_ids())
     }
 
     pub(crate) fn active(&self, w: Range<i64>) -> bool {

--- a/raphtory/src/core/mod.rs
+++ b/raphtory/src/core/mod.rs
@@ -146,7 +146,7 @@ pub enum Prop {
     F64(f64),
     Bool(bool),
     List(Arc<Vec<Prop>>),
-    Map(Arc<HashMap<String, Prop>>),
+    Map(Arc<HashMap<ArcStr, Prop>>),
     DTime(NaiveDateTime),
     Graph(Graph),
 }
@@ -280,8 +280,8 @@ pub trait PropUnwrap: Sized {
         self.into_list().unwrap()
     }
 
-    fn into_map(self) -> Option<Arc<HashMap<String, Prop>>>;
-    fn unwrap_map(self) -> Arc<HashMap<String, Prop>> {
+    fn into_map(self) -> Option<Arc<HashMap<ArcStr, Prop>>>;
+    fn unwrap_map(self) -> Arc<HashMap<ArcStr, Prop>> {
         self.into_map().unwrap()
     }
 
@@ -341,7 +341,7 @@ impl<P: PropUnwrap> PropUnwrap for Option<P> {
         self.and_then(|p| p.into_list())
     }
 
-    fn into_map(self) -> Option<Arc<HashMap<String, Prop>>> {
+    fn into_map(self) -> Option<Arc<HashMap<ArcStr, Prop>>> {
         self.and_then(|p| p.into_map())
     }
 
@@ -443,7 +443,7 @@ impl PropUnwrap for Prop {
         }
     }
 
-    fn into_map(self) -> Option<Arc<HashMap<String, Prop>>> {
+    fn into_map(self) -> Option<Arc<HashMap<ArcStr, Prop>>> {
         if let Prop::Map(v) = self {
             Some(v)
         } else {
@@ -595,8 +595,8 @@ impl From<bool> for Prop {
     }
 }
 
-impl From<HashMap<String, Prop>> for Prop {
-    fn from(value: HashMap<String, Prop>) -> Self {
+impl From<HashMap<ArcStr, Prop>> for Prop {
+    fn from(value: HashMap<ArcStr, Prop>) -> Self {
         Prop::Map(Arc::new(value))
     }
 }
@@ -617,7 +617,7 @@ pub trait IntoPropMap {
     fn into_prop_map(self) -> Prop;
 }
 
-impl<I: IntoIterator<Item = (K, V)>, K: Into<String>, V: Into<Prop>> IntoPropMap for I {
+impl<I: IntoIterator<Item = (K, V)>, K: Into<ArcStr>, V: Into<Prop>> IntoPropMap for I {
     fn into_prop_map(self) -> Prop {
         Prop::Map(Arc::new(
             self.into_iter()

--- a/raphtory/src/db/api/properties/constant_props.rs
+++ b/raphtory/src/db/api/properties/constant_props.rs
@@ -13,14 +13,11 @@ impl<P: ConstPropertiesOps> ConstProperties<P> {
         Self { props }
     }
     pub fn keys(&self) -> Vec<ArcStr> {
-        self.props
-            .const_property_keys()
-            .map(|v| v.clone())
-            .collect()
+        self.props.const_prop_keys().map(|v| v.clone()).collect()
     }
 
     pub fn values(&self) -> Vec<Prop> {
-        self.props.const_property_values()
+        self.props.const_prop_values()
     }
 
     pub fn iter(&self) -> Box<dyn Iterator<Item = (ArcStr, Prop)> + '_> {
@@ -28,7 +25,8 @@ impl<P: ConstPropertiesOps> ConstProperties<P> {
     }
 
     pub fn get(&self, key: &str) -> Option<Prop> {
-        self.props.get_const_property(key)
+        let id = self.props.get_const_prop_id(key)?;
+        self.props.get_const_prop(id)
     }
 
     pub fn contains(&self, key: &str) -> bool {

--- a/raphtory/src/db/api/properties/internal.rs
+++ b/raphtory/src/db/api/properties/internal.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 use enum_dispatch::enum_dispatch;
 
-pub type Key = usize; //Fixme: This should really be the internal usize index but that means more reworking of the low-level api
-
 #[enum_dispatch]
 pub trait TemporalPropertyViewOps {
     fn temporal_value(&self, id: usize) -> Option<Prop> {

--- a/raphtory/src/db/api/properties/internal.rs
+++ b/raphtory/src/db/api/properties/internal.rs
@@ -4,16 +4,16 @@ use crate::{
 };
 use enum_dispatch::enum_dispatch;
 
-pub type Key = ArcStr; //Fixme: This should really be the internal usize index but that means more reworking of the low-level api
+pub type Key = usize; //Fixme: This should really be the internal usize index but that means more reworking of the low-level api
 
 #[enum_dispatch]
 pub trait TemporalPropertyViewOps {
-    fn temporal_value(&self, id: &Key) -> Option<Prop> {
+    fn temporal_value(&self, id: usize) -> Option<Prop> {
         self.temporal_values(id).last().cloned()
     }
-    fn temporal_history(&self, id: &Key) -> Vec<i64>;
-    fn temporal_values(&self, id: &Key) -> Vec<Prop>;
-    fn temporal_value_at(&self, id: &Key, t: i64) -> Option<Prop> {
+    fn temporal_history(&self, id: usize) -> Vec<i64>;
+    fn temporal_values(&self, id: usize) -> Vec<Prop>;
+    fn temporal_value_at(&self, id: usize, t: i64) -> Option<Prop> {
         let history = self.temporal_history(id);
         match history.binary_search(&t) {
             Ok(index) => Some(self.temporal_values(id)[index].clone()),
@@ -24,25 +24,36 @@ pub trait TemporalPropertyViewOps {
 
 #[enum_dispatch]
 pub trait ConstPropertiesOps {
-    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>>;
-    fn const_property_values(&self) -> Vec<Prop> {
-        self.const_property_keys()
-            .map(|k| self.get_const_property(&k).expect("should exist"))
+    /// Find id for property name (note this only checks the meta-data, not if the property actually exists for the entity)
+    fn get_const_prop_id(&self, name: &str) -> Option<usize>;
+    fn get_const_prop_name(&self, id: usize) -> ArcStr;
+    fn const_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_>;
+    fn const_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
+        Box::new(self.const_prop_ids().map(|id| self.get_const_prop_name(id)))
+    }
+    fn const_prop_values(&self) -> Vec<Prop> {
+        self.const_prop_ids()
+            .map(|k| {
+                self.get_const_prop(k)
+                    .expect("ids that come from the internal iterator should exist")
+            })
             .collect()
     }
-    fn get_const_property(&self, key: &str) -> Option<Prop>;
+    fn get_const_prop(&self, id: usize) -> Option<Prop>;
 }
 
 #[enum_dispatch]
 pub trait TemporalPropertiesOps {
-    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_>;
-    fn temporal_property_values(&self) -> Box<dyn Iterator<Item = Key> + '_> {
+    fn get_temporal_prop_id(&self, name: &str) -> Option<usize>;
+    fn get_temporal_prop_name(&self, id: usize) -> ArcStr;
+
+    fn temporal_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_>;
+    fn temporal_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
         Box::new(
-            self.temporal_property_keys()
-                .flat_map(|k| self.get_temporal_property(&k)),
+            self.temporal_prop_ids()
+                .map(|id| self.get_temporal_prop_name(id)),
         )
     }
-    fn get_temporal_property(&self, key: &str) -> Option<Key>;
 }
 
 pub trait PropertiesOps:
@@ -64,19 +75,23 @@ impl<P: InheritTemporalPropertyViewOps> TemporalPropertyViewOps for P
 where
     P::Base: TemporalPropertyViewOps,
 {
-    fn temporal_value(&self, id: &Key) -> Option<Prop> {
+    #[inline]
+    fn temporal_value(&self, id: usize) -> Option<Prop> {
         self.base().temporal_value(id)
     }
 
-    fn temporal_history(&self, id: &Key) -> Vec<i64> {
+    #[inline]
+    fn temporal_history(&self, id: usize) -> Vec<i64> {
         self.base().temporal_history(id)
     }
 
-    fn temporal_values(&self, id: &Key) -> Vec<Prop> {
+    #[inline]
+    fn temporal_values(&self, id: usize) -> Vec<Prop> {
         self.base().temporal_values(id)
     }
 
-    fn temporal_value_at(&self, id: &Key, t: i64) -> Option<Prop> {
+    #[inline]
+    fn temporal_value_at(&self, id: usize, t: i64) -> Option<Prop> {
         self.base().temporal_value_at(id, t)
     }
 }
@@ -87,16 +102,24 @@ impl<P: InheritTemporalPropertiesOps> TemporalPropertiesOps for P
 where
     P::Base: TemporalPropertiesOps,
 {
-    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
-        self.base().temporal_property_keys()
+    #[inline]
+    fn get_temporal_prop_id(&self, name: &str) -> Option<usize> {
+        self.base().get_temporal_prop_id(name)
     }
 
-    fn temporal_property_values(&self) -> Box<dyn Iterator<Item = Key> + '_> {
-        self.base().temporal_property_values()
+    #[inline]
+    fn get_temporal_prop_name(&self, id: usize) -> ArcStr {
+        self.base().get_temporal_prop_name(id)
     }
 
-    fn get_temporal_property(&self, key: &str) -> Option<Key> {
-        self.base().get_temporal_property(key)
+    #[inline]
+    fn temporal_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.base().temporal_prop_ids()
+    }
+
+    #[inline]
+    fn temporal_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
+        self.base().temporal_prop_keys()
     }
 }
 
@@ -104,15 +127,33 @@ impl<P: InheritStaticPropertiesOps> ConstPropertiesOps for P
 where
     P::Base: ConstPropertiesOps,
 {
-    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
-        self.base().const_property_keys()
+    #[inline]
+    fn get_const_prop_id(&self, name: &str) -> Option<usize> {
+        self.base().get_const_prop_id(name)
     }
 
-    fn const_property_values(&self) -> Vec<Prop> {
-        self.base().const_property_values()
+    #[inline]
+    fn get_const_prop_name(&self, id: usize) -> ArcStr {
+        self.base().get_const_prop_name(id)
     }
 
-    fn get_const_property(&self, key: &str) -> Option<Prop> {
-        self.base().get_const_property(key)
+    #[inline]
+    fn const_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.base().const_prop_ids()
+    }
+
+    #[inline]
+    fn const_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
+        self.base().const_prop_keys()
+    }
+
+    #[inline]
+    fn const_prop_values(&self) -> Vec<Prop> {
+        self.base().const_prop_values()
+    }
+
+    #[inline]
+    fn get_const_prop(&self, id: usize) -> Option<Prop> {
+        self.base().get_const_prop(id)
     }
 }

--- a/raphtory/src/db/api/properties/temporal_props.rs
+++ b/raphtory/src/db/api/properties/temporal_props.rs
@@ -16,19 +16,19 @@ impl<P: PropertiesOps> TemporalPropertyView<P> {
         TemporalPropertyView { props, id: key }
     }
     pub fn history(&self) -> Vec<i64> {
-        self.props.temporal_history(&self.id)
+        self.props.temporal_history(self.id)
     }
     pub fn values(&self) -> Vec<Prop> {
-        self.props.temporal_values(&self.id)
+        self.props.temporal_values(self.id)
     }
     pub fn iter(&self) -> impl Iterator<Item = (i64, Prop)> {
         self.into_iter()
     }
     pub fn at(&self, t: i64) -> Option<Prop> {
-        self.props.temporal_value_at(&self.id, t)
+        self.props.temporal_value_at(self.id, t)
     }
     pub fn latest(&self) -> Option<Prop> {
-        self.props.temporal_value(&self.id)
+        self.props.temporal_value(self.id)
     }
 }
 
@@ -74,16 +74,16 @@ impl<P: PropertiesOps + Clone> TemporalProperties<P> {
         Self { props }
     }
     pub fn keys(&self) -> impl Iterator<Item = ArcStr> + '_ {
-        self.props.temporal_property_keys()
+        self.props.temporal_prop_keys()
     }
 
-    pub fn contains<Q: AsRef<str>>(&self, key: Q) -> bool {
-        self.get(key).is_some()
+    pub fn contains(&self, key: &str) -> bool {
+        self.props.get_temporal_prop_id(key).is_some()
     }
 
     pub fn values(&self) -> impl Iterator<Item = TemporalPropertyView<P>> + '_ {
         self.props
-            .temporal_property_values()
+            .temporal_prop_ids()
             .map(|k| TemporalPropertyView::new(self.props.clone(), k))
     }
 
@@ -95,9 +95,9 @@ impl<P: PropertiesOps + Clone> TemporalProperties<P> {
         self.keys().zip(self.values())
     }
 
-    pub fn get<Q: AsRef<str>>(&self, key: Q) -> Option<TemporalPropertyView<P>> {
+    pub fn get(&self, key: &str) -> Option<TemporalPropertyView<P>> {
         self.props
-            .get_temporal_property(key.as_ref())
+            .get_temporal_prop_id(key)
             .map(|k| TemporalPropertyView::new(self.props.clone(), k))
     }
 
@@ -153,7 +153,7 @@ impl<P: PropertiesOps> PropUnwrap for TemporalPropertyView<P> {
         self.latest().into_list()
     }
 
-    fn into_map(self) -> Option<Arc<HashMap<String, Prop>>> {
+    fn into_map(self) -> Option<Arc<HashMap<ArcStr, Prop>>> {
         self.latest().into_map()
     }
 

--- a/raphtory/src/db/api/properties/temporal_props.rs
+++ b/raphtory/src/db/api/properties/temporal_props.rs
@@ -1,18 +1,18 @@
 use crate::{
     core::{ArcStr, Prop, PropUnwrap},
-    db::api::properties::internal::{Key, PropertiesOps},
+    db::api::properties::internal::PropertiesOps,
     prelude::Graph,
 };
 use chrono::NaiveDateTime;
 use std::{collections::HashMap, iter::Zip, sync::Arc};
 
 pub struct TemporalPropertyView<P: PropertiesOps> {
-    pub(crate) id: Key,
+    pub(crate) id: usize,
     pub(crate) props: P,
 }
 
 impl<P: PropertiesOps> TemporalPropertyView<P> {
-    pub(crate) fn new(props: P, key: Key) -> Self {
+    pub(crate) fn new(props: P, key: usize) -> Self {
         TemporalPropertyView { props, id: key }
     }
     pub fn history(&self) -> Vec<i64> {

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -110,7 +110,7 @@ pub trait EdgeViewOps:
     fn layer_name(&self) -> Option<ArcStr> {
         self.eref()
             .layer()
-            .and_then(|l_id| self.graph().get_layer_name(*l_id))
+            .map(|l_id| self.graph().get_layer_name(*l_id))
     }
 
     /// Gets the TimeIndexEntry if the edge is exploded

--- a/raphtory/src/db/api/view/graph.rs
+++ b/raphtory/src/db/api/view/graph.rs
@@ -185,9 +185,7 @@ impl<G: BoxableGraphView + Sized + Clone> GraphViewOps for G {
             for ee in e.explode_layers() {
                 let layer_id = *ee.edge.layer().expect("exploded layers");
                 let layer_ids = LayerIds::One(layer_id);
-                let layer_name = self
-                    .get_layer_name(layer_id)
-                    .expect("layer id on edge is valid");
+                let layer_name = self.get_layer_name(layer_id);
                 let layer_name: Option<&str> = if layer_id == 0 {
                     None
                 } else {

--- a/raphtory/src/db/api/view/internal/core_ops.rs
+++ b/raphtory/src/db/api/view/internal/core_ops.rs
@@ -4,7 +4,7 @@ use crate::{
             edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
             properties::{
                 graph_props::GraphProps,
-                props::{ArcReadLockedVec, Meta},
+                props::Meta,
                 tprop::{LockedLayeredTProp, TProp},
             },
             vertices::{vertex_ref::VertexRef, vertex_store::VertexStore},

--- a/raphtory/src/db/api/view/internal/core_ops.rs
+++ b/raphtory/src/db/api/view/internal/core_ops.rs
@@ -33,7 +33,7 @@ pub trait CoreGraphOps {
 
     fn graph_meta(&self) -> &GraphProps;
 
-    fn get_layer_name(&self, layer_id: usize) -> Option<ArcStr>;
+    fn get_layer_name(&self, layer_id: usize) -> ArcStr;
 
     fn get_layer_id(&self, name: &str) -> Option<usize>;
 
@@ -64,13 +64,6 @@ pub trait CoreGraphOps {
     /// Gets the internal reference for an external vertex reference and keeps internal references unchanged. Assumes vertex exists!
     fn internalise_vertex_unchecked(&self, v: VertexRef) -> VID;
 
-    /// Lists the keys of all static properties of the graph
-    ///
-    /// # Returns
-    ///
-    /// Vec<String> - The keys of the static properties.
-    fn constant_prop_names(&self) -> ArcReadLockedVec<ArcStr>;
-
     /// Gets a static graph property.
     ///
     /// # Arguments
@@ -80,14 +73,7 @@ pub trait CoreGraphOps {
     /// # Returns
     ///
     /// Option<Prop> - The property value if it exists.
-    fn constant_prop(&self, name: &str) -> Option<Prop>;
-
-    /// Lists the keys of all temporal properties of the graph
-    ///
-    /// # Returns
-    ///
-    /// Vec<String> - The keys of the static properties.
-    fn temporal_prop_names(&self) -> ArcReadLockedVec<ArcStr>;
+    fn constant_prop(&self, id: usize) -> Option<Prop>;
 
     /// Gets a temporal graph property.
     ///
@@ -98,7 +84,7 @@ pub trait CoreGraphOps {
     /// # Returns
     ///
     /// Option<LockedView<TProp>> - The history of property values if it exists.
-    fn temporal_prop(&self, name: &str) -> Option<LockedView<TProp>>;
+    fn temporal_prop(&self, id: usize) -> Option<LockedView<TProp>>;
 
     /// Gets a static property of a given vertex given the name and vertex reference.
     ///
@@ -110,9 +96,9 @@ pub trait CoreGraphOps {
     /// # Returns
     ///
     /// Option<Prop> - The property value if it exists.
-    fn constant_vertex_prop(&self, v: VID, name: &str) -> Option<Prop>;
+    fn constant_vertex_prop(&self, v: VID, id: usize) -> Option<Prop>;
 
-    /// Gets the keys of static properties of a given vertex
+    /// Gets the keys of constant properties of a given vertex
     ///
     /// # Arguments
     ///
@@ -120,8 +106,8 @@ pub trait CoreGraphOps {
     ///
     /// # Returns
     ///
-    /// Vec<String> - The keys of the static properties.
-    fn constant_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr>;
+    /// The keys of the constant properties.
+    fn constant_vertex_prop_ids(&self, v: VID) -> Box<dyn Iterator<Item = usize> + '_>;
 
     /// Gets a temporal property of a given vertex given the name and vertex reference.
     ///
@@ -133,9 +119,9 @@ pub trait CoreGraphOps {
     /// # Returns
     ///
     /// Option<LockedView<TProp>> - The history of property values if it exists.
-    fn temporal_vertex_prop(&self, v: VID, name: &str) -> Option<LockedView<TProp>>;
+    fn temporal_vertex_prop(&self, v: VID, id: usize) -> Option<LockedView<TProp>>;
 
-    /// Returns a vector of all names of temporal properties within the given vertex
+    /// Returns a vector of all ids of temporal properties within the given vertex
     ///
     /// # Arguments
     ///
@@ -143,22 +129,9 @@ pub trait CoreGraphOps {
     ///
     /// # Returns
     ///
-    /// A vector of strings representing the names of the temporal properties
-    fn temporal_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr>;
+    /// the ids of the temporal properties
+    fn temporal_vertex_prop_ids(&self, v: VID) -> Box<dyn Iterator<Item = usize> + '_>;
 
-    /// Returns a vector of all names of temporal properties that exist on at least one vertex
-    ///
-    /// # Returns
-    ///
-    /// A vector of strings representing the names of the temporal properties
-    fn all_vertex_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr>;
-
-    /// Returns a vector of all names of temporal properties that exist on at least one vertex
-    ///
-    /// # Returns
-    ///
-    /// A vector of strings representing the names of the temporal properties
-    fn all_edge_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr>;
     /// Returns the static edge property with the given name for the
     /// given edge reference.
     ///
@@ -170,7 +143,7 @@ pub trait CoreGraphOps {
     /// # Returns
     ///
     /// A property if it exists
-    fn constant_edge_prop(&self, e: EdgeRef, name: &str, layer_ids: LayerIds) -> Option<Prop>;
+    fn get_const_edge_prop(&self, e: EdgeRef, id: usize, layer_ids: LayerIds) -> Option<Prop>;
 
     /// Returns a vector of keys for the static properties of the given edge reference.
     ///
@@ -180,8 +153,12 @@ pub trait CoreGraphOps {
     ///
     /// # Returns
     ///
-    /// * A `Vec` of `String` containing the keys for the static properties of the given edge.
-    fn constant_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr>;
+    /// the keys for the constant properties of the given edge.
+    fn const_edge_prop_ids(
+        &self,
+        e: EdgeRef,
+        layer_ids: LayerIds,
+    ) -> Box<dyn Iterator<Item = usize> + '_>;
 
     /// Returns a vector of all temporal values of the edge property with the given name for the
     /// given edge reference.
@@ -197,7 +174,7 @@ pub trait CoreGraphOps {
     fn temporal_edge_prop(
         &self,
         e: EdgeRef,
-        name: &str,
+        id: usize,
         layer_ids: LayerIds,
     ) -> Option<LockedLayeredTProp>;
 
@@ -209,8 +186,12 @@ pub trait CoreGraphOps {
     ///
     /// # Returns
     ///
-    /// * A `Vec` of `String` containing the keys for the temporal properties of the given edge.
-    fn temporal_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr>;
+    /// * keys for the temporal properties of the given edge.
+    fn temporal_edge_prop_ids(
+        &self,
+        e: EdgeRef,
+        layer_ids: LayerIds,
+    ) -> Box<dyn Iterator<Item = usize> + '_>;
 
     fn core_edges(&self) -> Box<dyn Iterator<Item = ArcEntry<EdgeStore>>>;
 
@@ -262,7 +243,7 @@ impl<G: DelegateCoreOps + ?Sized> CoreGraphOps for G {
     }
 
     #[inline]
-    fn get_layer_name(&self, layer_id: usize) -> Option<ArcStr> {
+    fn get_layer_name(&self, layer_id: usize) -> ArcStr {
         self.graph().get_layer_name(layer_id)
     }
 
@@ -311,78 +292,66 @@ impl<G: DelegateCoreOps + ?Sized> CoreGraphOps for G {
     }
 
     #[inline]
-    fn constant_prop_names(&self) -> ArcReadLockedVec<ArcStr> {
-        self.graph().constant_prop_names()
+    fn constant_prop(&self, id: usize) -> Option<Prop> {
+        self.graph().constant_prop(id)
     }
 
     #[inline]
-    fn constant_prop(&self, name: &str) -> Option<Prop> {
-        self.graph().constant_prop(name)
+    fn temporal_prop(&self, id: usize) -> Option<LockedView<TProp>> {
+        self.graph().temporal_prop(id)
     }
 
     #[inline]
-    fn temporal_prop_names(&self) -> ArcReadLockedVec<ArcStr> {
-        self.graph().temporal_prop_names()
+    fn constant_vertex_prop(&self, v: VID, id: usize) -> Option<Prop> {
+        self.graph().constant_vertex_prop(v, id)
     }
 
     #[inline]
-    fn temporal_prop(&self, name: &str) -> Option<LockedView<TProp>> {
-        self.graph().temporal_prop(name)
+    fn constant_vertex_prop_ids(&self, v: VID) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.graph().constant_vertex_prop_ids(v)
     }
 
     #[inline]
-    fn constant_vertex_prop(&self, v: VID, name: &str) -> Option<Prop> {
-        self.graph().constant_vertex_prop(v, name)
+    fn temporal_vertex_prop(&self, v: VID, id: usize) -> Option<LockedView<TProp>> {
+        self.graph().temporal_vertex_prop(v, id)
     }
 
     #[inline]
-    fn constant_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr> {
-        self.graph().constant_vertex_prop_names(v)
+    fn temporal_vertex_prop_ids(&self, v: VID) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.graph().temporal_vertex_prop_ids(v)
     }
 
     #[inline]
-    fn temporal_vertex_prop(&self, v: VID, name: &str) -> Option<LockedView<TProp>> {
-        self.graph().temporal_vertex_prop(v, name)
+    fn get_const_edge_prop(&self, e: EdgeRef, id: usize, layer_ids: LayerIds) -> Option<Prop> {
+        self.graph().get_const_edge_prop(e, id, layer_ids)
     }
 
     #[inline]
-    fn temporal_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr> {
-        self.graph().temporal_vertex_prop_names(v)
-    }
-
-    #[inline]
-    fn all_vertex_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr> {
-        self.graph().all_vertex_prop_names(is_static)
-    }
-
-    #[inline]
-    fn all_edge_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr> {
-        self.graph().all_edge_prop_names(is_static)
-    }
-
-    #[inline]
-    fn constant_edge_prop(&self, e: EdgeRef, name: &str, layer_ids: LayerIds) -> Option<Prop> {
-        self.graph().constant_edge_prop(e, name, layer_ids)
-    }
-
-    #[inline]
-    fn constant_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr> {
-        self.graph().constant_edge_prop_names(e, layer_ids)
+    fn const_edge_prop_ids(
+        &self,
+        e: EdgeRef,
+        layer_ids: LayerIds,
+    ) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.graph().const_edge_prop_ids(e, layer_ids)
     }
 
     #[inline]
     fn temporal_edge_prop(
         &self,
         e: EdgeRef,
-        name: &str,
+        id: usize,
         layer_ids: LayerIds,
     ) -> Option<LockedLayeredTProp> {
-        self.graph().temporal_edge_prop(e, name, layer_ids)
+        self.graph().temporal_edge_prop(e, id, layer_ids)
     }
 
     #[inline]
-    fn temporal_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr> {
-        self.graph().temporal_edge_prop_names(e, layer_ids)
+    fn temporal_edge_prop_ids(
+        &self,
+        e: EdgeRef,
+        layer_ids: LayerIds,
+    ) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.graph().temporal_edge_prop_ids(e, layer_ids)
     }
 
     #[inline]

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -20,8 +20,13 @@ pub type EdgeFilter = Arc<dyn Fn(&EdgeStore, &LayerIds) -> bool + Send + Sync>;
 #[enum_dispatch]
 pub trait EdgeFilterOps {
     /// Return the optional edge filter for the graph
-
     fn edge_filter(&self) -> Option<&EdgeFilter>;
+
+    /// Called by the windowed graph to get the edge filter (override if it should include more/different edges than a non-windowed graph)
+    #[inline]
+    fn edge_filter_window(&self) -> Option<&EdgeFilter> {
+        self.edge_filter()
+    }
 }
 
 pub trait InheritEdgeFilterOps: Base {}

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -4,7 +4,7 @@ use crate::{
             edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
             properties::{
                 graph_props::GraphProps,
-                props::{ArcReadLockedVec, Meta},
+                props::Meta,
                 tprop::{LockedLayeredTProp, TProp},
             },
             vertices::{vertex_ref::VertexRef, vertex_store::VertexStore},
@@ -22,7 +22,7 @@ use crate::{
         api::{
             mutation::internal::{InternalAdditionOps, InternalPropertyAdditionOps},
             properties::internal::{
-                ConstPropertiesOps, Key, TemporalPropertiesOps, TemporalPropertyViewOps,
+                ConstPropertiesOps, TemporalPropertiesOps, TemporalPropertyViewOps,
             },
             view::{internal::*, BoxedIter},
         },

--- a/raphtory/src/db/api/view/internal/time_semantics.rs
+++ b/raphtory/src/db/api/view/internal/time_semantics.rs
@@ -11,7 +11,6 @@ use crate::{
         internal::{materialize::MaterializedGraph, Base, CoreGraphOps, EdgeFilter, GraphOps},
         BoxedIter,
     },
-    prelude::Layer,
 };
 use enum_dispatch::enum_dispatch;
 use std::ops::Range;

--- a/raphtory/src/db/graph/edge.rs
+++ b/raphtory/src/db/graph/edge.rs
@@ -8,7 +8,7 @@
 use super::views::layer_graph::LayeredGraph;
 use crate::{
     core::{
-        entities::{edges::edge_ref::EdgeRef, VID},
+        entities::{edges::edge_ref::EdgeRef, LayerIds, VID},
         storage::timeindex::TimeIndexEntry,
         utils::{errors::GraphError, time::IntoTime},
         ArcStr,
@@ -34,6 +34,7 @@ use crate::{
 use std::{
     fmt::{Debug, Formatter},
     iter,
+    sync::Arc,
 };
 
 /// A view of an edge in the graph.
@@ -50,6 +51,10 @@ impl<G: GraphViewOps> Static for EdgeView<G> {}
 impl<G: GraphViewOps> EdgeView<G> {
     pub fn new(graph: G, edge: EdgeRef) -> Self {
         Self { graph, edge }
+    }
+
+    pub(crate) fn layer_ids(&self) -> LayerIds {
+        self.graph.layer_ids().constrain_from_edge(self.edge)
     }
 }
 
@@ -147,28 +152,40 @@ impl<G: GraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps> EdgeVi
 }
 
 impl<G: GraphViewOps> ConstPropertiesOps for EdgeView<G> {
-    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
-        let layer_ids = self.graph.layer_ids().constrain_from_edge(self.edge);
-        self.graph.constant_edge_prop_names(self.edge, layer_ids)
+    fn get_const_prop_id(&self, name: &str) -> Option<usize> {
+        self.graph.edge_meta().const_prop_meta().get_id(name)
     }
 
-    fn get_const_property(&self, key: &str) -> Option<Prop> {
-        let layer_ids = self.graph.layer_ids().constrain_from_edge(self.edge);
-        self.graph.constant_edge_prop(self.edge, key, layer_ids)
+    fn get_const_prop_name(&self, id: usize) -> ArcStr {
+        self.graph.edge_meta().const_prop_meta().get_name(id)
+    }
+
+    fn const_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.graph
+            .const_edge_prop_ids(self.edge, self.graph.layer_ids())
+    }
+
+    fn const_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
+        let reverse_map = self.graph.edge_meta().const_prop_meta().get_keys();
+        Box::new(self.const_prop_ids().map(move |id| reverse_map[id].clone()))
+    }
+
+    fn get_const_prop(&self, id: usize) -> Option<Prop> {
+        self.graph
+            .get_const_edge_prop(self.edge, id, self.graph.layer_ids())
     }
 }
 
 impl<G: GraphViewOps> TemporalPropertyViewOps for EdgeView<G> {
-    fn temporal_history(&self, id: &Key) -> Vec<i64> {
-        let layer_ids = self.graph.layer_ids().constrain_from_edge(self.edge);
+    fn temporal_history(&self, id: usize) -> Vec<i64> {
         self.graph
-            .temporal_edge_prop_vec(self.edge, id, layer_ids)
+            .temporal_edge_prop_vec(self.edge, id, self.graph.layer_ids())
             .into_iter()
             .map(|(t, _)| t)
             .collect()
     }
 
-    fn temporal_values(&self, id: &Key) -> Vec<Prop> {
+    fn temporal_values(&self, id: usize) -> Vec<Prop> {
         let layer_ids = self.graph.layer_ids().constrain_from_edge(self.edge);
         self.graph
             .temporal_edge_prop_vec(self.edge, id, layer_ids)
@@ -179,21 +196,38 @@ impl<G: GraphViewOps> TemporalPropertyViewOps for EdgeView<G> {
 }
 
 impl<G: GraphViewOps> TemporalPropertiesOps for EdgeView<G> {
-    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
+    fn get_temporal_prop_id(&self, name: &str) -> Option<usize> {
+        self.graph
+            .edge_meta()
+            .temporal_prop_meta()
+            .get_id(name)
+            .filter(|id| {
+                self.graph
+                    .has_temporal_edge_prop(self.edge, *id, self.layer_ids())
+            })
+    }
+
+    fn get_temporal_prop_name(&self, id: usize) -> ArcStr {
+        self.graph.edge_meta().temporal_prop_meta().get_name(id)
+    }
+
+    fn temporal_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
         Box::new(
             self.graph
-                .temporal_edge_prop_names(self.edge, self.graph.layer_ids())
-                .filter(|k| self.get_temporal_property(k).is_some()),
+                .temporal_edge_prop_ids(self.edge, self.layer_ids())
+                .filter(|id| {
+                    self.graph
+                        .has_temporal_edge_prop(self.edge, *id, self.layer_ids())
+                }),
         )
     }
 
-    fn get_temporal_property(&self, key: &str) -> Option<Key> {
-        let layer_ids = self.graph.layer_ids();
-        (!self
-            .graph
-            .temporal_edge_prop_vec(self.edge, key, layer_ids)
-            .is_empty())
-        .then_some(key.into())
+    fn temporal_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
+        let reverse_map = self.graph.edge_meta().temporal_prop_meta().get_keys();
+        Box::new(
+            self.temporal_prop_ids()
+                .map(move |id| reverse_map[id].clone()),
+        )
     }
 }
 

--- a/raphtory/src/db/graph/vertex.rs
+++ b/raphtory/src/db/graph/vertex.rs
@@ -73,32 +73,36 @@ impl<G: GraphViewOps> VertexView<G> {
 }
 
 impl<G: GraphViewOps> TemporalPropertiesOps for VertexView<G> {
-    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
-        Box::new(
-            self.graph
-                .temporal_vertex_prop_names(self.vertex)
-                .filter(|k| self.get_temporal_property(k).is_some()),
-        )
+    fn get_temporal_prop_id(&self, name: &str) -> Option<usize> {
+        self.graph
+            .vertex_meta()
+            .temporal_prop_meta()
+            .get_id(name)
+            .filter(|id| self.graph.has_temporal_vertex_prop(self.vertex, *id))
     }
 
-    fn get_temporal_property(&self, key: &str) -> Option<Key> {
-        (!self
-            .graph
-            .temporal_vertex_prop_vec(self.vertex, key)
-            .is_empty())
-        .then(|| key.into())
+    fn get_temporal_prop_name(&self, id: usize) -> ArcStr {
+        self.graph.vertex_meta().temporal_prop_meta().get_name(id)
+    }
+
+    fn temporal_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        Box::new(
+            self.graph
+                .temporal_vertex_prop_ids(self.vertex)
+                .filter(|id| self.graph.has_temporal_vertex_prop(self.vertex, *id)),
+        )
     }
 }
 
 impl<G: GraphViewOps> TemporalPropertyViewOps for VertexView<G> {
-    fn temporal_value(&self, id: &Key) -> Option<Prop> {
+    fn temporal_value(&self, id: usize) -> Option<Prop> {
         self.graph
             .temporal_vertex_prop_vec(self.vertex, id)
             .last()
             .map(|(_, v)| v.to_owned())
     }
 
-    fn temporal_history(&self, id: &Key) -> Vec<i64> {
+    fn temporal_history(&self, id: usize) -> Vec<i64> {
         self.graph
             .temporal_vertex_prop_vec(self.vertex, id)
             .into_iter()
@@ -106,7 +110,7 @@ impl<G: GraphViewOps> TemporalPropertyViewOps for VertexView<G> {
             .collect()
     }
 
-    fn temporal_values(&self, id: &Key) -> Vec<Prop> {
+    fn temporal_values(&self, id: usize) -> Vec<Prop> {
         self.graph
             .temporal_vertex_prop_vec(self.vertex, id)
             .into_iter()
@@ -114,7 +118,7 @@ impl<G: GraphViewOps> TemporalPropertyViewOps for VertexView<G> {
             .collect()
     }
 
-    fn temporal_value_at(&self, id: &Key, t: i64) -> Option<Prop> {
+    fn temporal_value_at(&self, id: usize, t: i64) -> Option<Prop> {
         let history = self.temporal_history(id);
         match history.binary_search(&t) {
             Ok(index) => Some(self.temporal_values(id)[index].clone()),
@@ -124,18 +128,20 @@ impl<G: GraphViewOps> TemporalPropertyViewOps for VertexView<G> {
 }
 
 impl<G: GraphViewOps> ConstPropertiesOps for VertexView<G> {
-    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
-        self.graph.constant_vertex_prop_names(self.vertex)
+    fn get_const_prop_id(&self, name: &str) -> Option<usize> {
+        self.graph.vertex_meta().const_prop_meta().get_id(name)
     }
 
-    fn const_property_values(&self) -> Vec<Prop> {
-        self.const_property_keys()
-            .flat_map(|prop_name| self.graph.constant_vertex_prop(self.vertex, &prop_name))
-            .collect()
+    fn get_const_prop_name(&self, id: usize) -> ArcStr {
+        self.graph.vertex_meta().const_prop_meta().get_name(id)
     }
 
-    fn get_const_property(&self, key: &str) -> Option<Prop> {
-        self.graph.constant_vertex_prop(self.vertex, key)
+    fn const_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        self.graph.constant_vertex_prop_ids(self.vertex)
+    }
+
+    fn get_const_prop(&self, id: usize) -> Option<Prop> {
+        self.graph.constant_vertex_prop(self.vertex, id)
     }
 }
 

--- a/raphtory/src/db/graph/vertex.rs
+++ b/raphtory/src/db/graph/vertex.rs
@@ -14,9 +14,7 @@ use crate::{
                 CollectProperties, TryIntoInputTime,
             },
             properties::{
-                internal::{
-                    ConstPropertiesOps, Key, TemporalPropertiesOps, TemporalPropertyViewOps,
-                },
+                internal::{ConstPropertiesOps, TemporalPropertiesOps, TemporalPropertyViewOps},
                 Properties,
             },
             view::{internal::Static, BoxedIter, Layer, LayerOps},

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -49,7 +49,7 @@ use crate::{
     },
     db::api::{
         properties::internal::{
-            InheritStaticPropertiesOps, Key, TemporalPropertiesOps, TemporalPropertyViewOps,
+            InheritStaticPropertiesOps, TemporalPropertiesOps, TemporalPropertyViewOps,
         },
         view::{
             internal::{
@@ -703,7 +703,7 @@ impl<G: GraphViewOps> WindowedGraph<G> {
         let filter_graph = graph.clone();
         let t_start = t_start.into_time();
         let t_end = t_end.into_time();
-        let base_filter = filter_graph.edge_filter().cloned();
+        let base_filter = filter_graph.edge_filter_window().cloned();
         let filter: EdgeFilter = match base_filter {
             Some(f) => Arc::new(move |e, layers| {
                 f(e, layers) && filter_graph.include_edge_window(e, t_start..t_end, layers)

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -125,14 +125,14 @@ impl<G: GraphViewOps> InheritStaticPropertiesOps for WindowedGraph<G> {}
 impl<G: GraphViewOps> InheritLayerOps for WindowedGraph<G> {}
 
 impl<G: GraphViewOps> TemporalPropertyViewOps for WindowedGraph<G> {
-    fn temporal_history(&self, id: &Key) -> Vec<i64> {
+    fn temporal_history(&self, id: usize) -> Vec<i64> {
         self.temporal_prop_vec(id)
             .into_iter()
             .map(|(t, _)| t)
             .collect()
     }
 
-    fn temporal_values(&self, id: &Key) -> Vec<Prop> {
+    fn temporal_values(&self, id: usize) -> Vec<Prop> {
         self.temporal_prop_vec(id)
             .into_iter()
             .map(|(_, v)| v)
@@ -141,16 +141,22 @@ impl<G: GraphViewOps> TemporalPropertyViewOps for WindowedGraph<G> {
 }
 
 impl<G: GraphViewOps> TemporalPropertiesOps for WindowedGraph<G> {
-    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
-        Box::new(
-            self.graph
-                .temporal_property_keys()
-                .filter(|k| self.get_temporal_property(k).is_some()),
-        )
+    fn get_temporal_prop_id(&self, name: &str) -> Option<usize> {
+        self.graph
+            .get_temporal_prop_id(name)
+            .filter(|id| self.has_temporal_prop(*id))
     }
 
-    fn get_temporal_property(&self, key: &str) -> Option<Key> {
-        (!self.temporal_prop_vec(key).is_empty()).then(|| key.into())
+    fn get_temporal_prop_name(&self, id: usize) -> ArcStr {
+        self.graph.get_temporal_prop_name(id)
+    }
+
+    fn temporal_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        Box::new(
+            self.graph
+                .temporal_prop_ids()
+                .filter(|id| self.has_temporal_prop(*id)),
+        )
     }
 }
 
@@ -335,64 +341,112 @@ impl<G: GraphViewOps> TimeSemantics for WindowedGraph<G> {
         )
     }
 
-    fn temporal_prop_vec(&self, name: &str) -> Vec<(i64, Prop)> {
+    fn has_temporal_prop(&self, prop_id: usize) -> bool {
         self.graph
-            .temporal_prop_vec_window(name, self.t_start, self.t_end)
+            .has_temporal_prop_window(prop_id, self.t_start..self.t_end)
     }
 
-    fn temporal_prop_vec_window(&self, name: &str, t_start: i64, t_end: i64) -> Vec<(i64, Prop)> {
+    fn temporal_prop_vec(&self, prop_id: usize) -> Vec<(i64, Prop)> {
+        self.graph
+            .temporal_prop_vec_window(prop_id, self.t_start, self.t_end)
+    }
+
+    fn has_temporal_prop_window(&self, prop_id: usize, w: Range<i64>) -> bool {
+        self.graph
+            .has_temporal_prop_window(prop_id, self.actual_start(w.start)..self.actual_end(w.end))
+    }
+
+    fn temporal_prop_vec_window(
+        &self,
+        prop_id: usize,
+        t_start: i64,
+        t_end: i64,
+    ) -> Vec<(i64, Prop)> {
         self.graph.temporal_prop_vec_window(
-            name,
+            prop_id,
             self.actual_start(t_start),
             self.actual_end(t_end),
         )
     }
 
-    fn temporal_vertex_prop_vec(&self, v: VID, name: &str) -> Vec<(i64, Prop)> {
+    fn has_temporal_vertex_prop(&self, v: VID, prop_id: usize) -> bool {
         self.graph
-            .temporal_vertex_prop_vec_window(v, name, self.t_start, self.t_end)
+            .has_temporal_vertex_prop_window(v, prop_id, self.t_start..self.t_end)
+    }
+
+    fn temporal_vertex_prop_vec(&self, v: VID, prop_id: usize) -> Vec<(i64, Prop)> {
+        self.graph
+            .temporal_vertex_prop_vec_window(v, prop_id, self.t_start, self.t_end)
+    }
+
+    fn has_temporal_vertex_prop_window(&self, v: VID, prop_id: usize, w: Range<i64>) -> bool {
+        self.graph.has_temporal_vertex_prop_window(
+            v,
+            prop_id,
+            self.actual_start(w.start)..self.actual_end(w.end),
+        )
     }
 
     fn temporal_vertex_prop_vec_window(
         &self,
         v: VID,
-        name: &str,
+        prop_id: usize,
         t_start: i64,
         t_end: i64,
     ) -> Vec<(i64, Prop)> {
         self.graph.temporal_vertex_prop_vec_window(
             v,
-            name,
+            prop_id,
             self.actual_start(t_start),
             self.actual_end(t_end),
+        )
+    }
+
+    fn has_temporal_edge_prop_window(
+        &self,
+        e: EdgeRef,
+        prop_id: usize,
+        w: Range<i64>,
+        layer_ids: LayerIds,
+    ) -> bool {
+        self.graph.has_temporal_edge_prop_window(
+            e,
+            prop_id,
+            self.actual_start(w.start)..self.actual_end(w.end),
+            layer_ids,
         )
     }
 
     fn temporal_edge_prop_vec_window(
         &self,
         e: EdgeRef,
-        name: &str,
+        prop_id: usize,
         t_start: i64,
         t_end: i64,
         layer_ids: LayerIds,
     ) -> Vec<(i64, Prop)> {
         self.graph.temporal_edge_prop_vec_window(
             e,
-            name,
+            prop_id,
             self.actual_start(t_start),
             self.actual_end(t_end),
             layer_ids,
         )
     }
 
+    fn has_temporal_edge_prop(&self, e: EdgeRef, prop_id: usize, layer_ids: LayerIds) -> bool {
+        self.graph
+            .has_temporal_edge_prop_window(e, prop_id, self.t_start..self.t_end, layer_ids)
+    }
+
     fn temporal_edge_prop_vec(
         &self,
         e: EdgeRef,
-        name: &str,
+        prop_id: usize,
         layer_ids: LayerIds,
     ) -> Vec<(i64, Prop)> {
         self.graph
-            .temporal_edge_prop_vec_window(e, name, self.t_start, self.t_end, layer_ids)
+            .temporal_edge_prop_vec_window(e, prop_id, self.t_start, self.t_end, layer_ids)
     }
 }
 

--- a/raphtory/src/db/internal/core_ops.rs
+++ b/raphtory/src/db/internal/core_ops.rs
@@ -5,7 +5,7 @@ use crate::{
             graph::tgraph::InnerTemporalGraph,
             properties::{
                 graph_props::GraphProps,
-                props::{ArcReadLockedVec, Meta},
+                props::Meta,
                 tprop::{LockedLayeredTProp, TProp},
             },
             vertices::{vertex_ref::VertexRef, vertex_store::VertexStore},

--- a/raphtory/src/db/internal/core_ops.rs
+++ b/raphtory/src/db/internal/core_ops.rs
@@ -46,7 +46,7 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn get_layer_name(&self, layer_id: usize) -> Option<ArcStr> {
+    fn get_layer_name(&self, layer_id: usize) -> ArcStr {
         self.inner().edge_meta.layer_meta().get_name(layer_id)
     }
 
@@ -101,73 +101,54 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
     }
 
     #[inline]
-    fn constant_prop_names(&self) -> ArcReadLockedVec<ArcStr> {
-        self.inner().constant_property_names()
+    fn constant_prop(&self, id: usize) -> Option<Prop> {
+        self.inner().get_constant_prop(id)
     }
 
     #[inline]
-    fn constant_prop(&self, name: &str) -> Option<Prop> {
-        self.inner().get_constant_prop(name)
+    fn temporal_prop(&self, id: usize) -> Option<LockedView<TProp>> {
+        self.inner().get_temporal_prop(id)
     }
 
     #[inline]
-    fn temporal_prop_names(&self) -> ArcReadLockedVec<ArcStr> {
-        self.inner().temporal_property_names()
-    }
-
-    #[inline]
-    fn temporal_prop(&self, name: &str) -> Option<LockedView<TProp>> {
-        self.inner().get_temporal_prop(name)
-    }
-
-    #[inline]
-    fn constant_vertex_prop(&self, v: VID, name: &str) -> Option<Prop> {
+    fn constant_vertex_prop(&self, v: VID, prop_id: usize) -> Option<Prop> {
         let entry = self.inner().node_entry(v);
-        let node = entry.value();
-        let prop_id = self.inner().vertex_find_prop(name, true)?;
-        node.static_property(prop_id).cloned()
+        entry.const_prop(prop_id).cloned()
     }
 
     #[inline]
-    fn constant_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr> {
-        let keys = self.inner().vertex_meta.constant_prop_meta().get_keys();
-        let ids = self.inner().node_entry(v).constant_prop_ids();
-        Box::new(ids.into_iter().map(move |prop_id| keys[prop_id].clone()))
-    }
-
-    #[inline]
-    fn temporal_vertex_prop(&self, v: VID, name: &str) -> Option<LockedView<TProp>> {
-        let vertex = self.inner().vertex(v);
-        let prop_id = self.inner().vertex_find_prop(name, false)?;
-
-        vertex.temporal_property(prop_id)
-    }
-
-    #[inline]
-    fn temporal_vertex_prop_names(&self, v: VID) -> BoxedIter<ArcStr> {
-        let keys = self.inner().vertex_meta.temporal_prop_meta().get_keys();
+    fn constant_vertex_prop_ids(&self, v: VID) -> Box<dyn Iterator<Item = usize> + '_> {
+        // FIXME: revisit the locking scheme so we don't have to collect the ids
         Box::new(
             self.inner()
-                .vertex_temp_prop_ids(v)
-                .into_iter()
-                .map(move |id| keys[id].clone()),
+                .node_entry(v)
+                .const_prop_ids()
+                .collect_vec()
+                .into_iter(),
         )
     }
 
     #[inline]
-    fn all_vertex_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr> {
-        self.inner().get_all_vertex_property_names(is_static)
+    fn temporal_vertex_prop(&self, v: VID, prop_id: usize) -> Option<LockedView<TProp>> {
+        let vertex = self.inner().vertex(v);
+        vertex.temporal_property(prop_id)
     }
 
     #[inline]
-    fn all_edge_prop_names(&self, is_static: bool) -> ArcReadLockedVec<ArcStr> {
-        self.inner().get_all_edge_property_names(is_static)
+    fn temporal_vertex_prop_ids(&self, v: VID) -> Box<dyn Iterator<Item = usize> + '_> {
+        // FIXME: revisit the locking scheme so we don't have to collect the ids
+        Box::new(
+            self.inner()
+                .node_entry(v)
+                .temporal_prop_ids()
+                .collect_vec()
+                .into_iter(),
+        )
     }
 
-    fn constant_edge_prop(&self, e: EdgeRef, name: &str, layer_ids: LayerIds) -> Option<Prop> {
+    fn get_const_edge_prop(&self, e: EdgeRef, prop_id: usize, layer_ids: LayerIds) -> Option<Prop> {
         let layer_ids = layer_ids.constrain_from_edge(e);
         let entry = self.inner().edge_entry(e.pid());
-        let prop_id = self.inner().edge_find_prop(name, true)?;
         match layer_ids {
             LayerIds::None => None,
             LayerIds::All => {
@@ -176,14 +157,14 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
                     entry
                         .layer_iter()
                         .next()
-                        .and_then(|layer| layer.static_property(prop_id).cloned())
+                        .and_then(|layer| layer.const_prop(prop_id).cloned())
                 } else {
                     let prop_map: HashMap<_, _> = entry
                         .layer_iter()
                         .enumerate()
                         .flat_map(|(id, layer)| {
                             layer
-                                .static_property(prop_id)
+                                .const_prop(prop_id)
                                 .map(|p| (self.inner().get_layer_name(id), p.clone()))
                         })
                         .collect();
@@ -194,16 +175,14 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
                     }
                 }
             }
-            LayerIds::One(id) => entry
-                .layer(id)
-                .and_then(|l| l.static_property(prop_id).cloned()),
+            LayerIds::One(id) => entry.layer(id).and_then(|l| l.const_prop(prop_id).cloned()),
             LayerIds::Multiple(ids) => {
                 let prop_map: HashMap<_, _> = ids
                     .iter()
                     .flat_map(|&id| {
                         entry.layer(id).and_then(|layer| {
                             layer
-                                .static_property(prop_id)
+                                .const_prop(prop_id)
                                 .map(|p| (self.inner().get_layer_name(id), p.clone()))
                         })
                     })
@@ -217,75 +196,66 @@ impl<const N: usize> CoreGraphOps for InnerTemporalGraph<N> {
         }
     }
 
-    fn constant_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr> {
+    fn const_edge_prop_ids(
+        &self,
+        e: EdgeRef,
+        layer_ids: LayerIds,
+    ) -> Box<dyn Iterator<Item = usize> + '_> {
+        // FIXME: revisit the locking scheme so we don't have to collect all the ids
         let layer_ids = layer_ids.constrain_from_edge(e);
         let entry = self.inner().edge_entry(e.pid());
-        let reverse_map = self.inner().edge_meta.constant_prop_meta().get_keys();
-        match layer_ids {
-            LayerIds::None => Box::new(iter::empty()),
-            LayerIds::All => Box::new(
-                entry
-                    .layer_iter()
-                    .map(|l| l.static_prop_ids())
-                    .kmerge()
-                    .dedup()
-                    .map(move |id| reverse_map[id].clone()),
-            ),
+        let ids: Vec<_> = match layer_ids {
+            LayerIds::None => vec![],
+            LayerIds::All => entry
+                .layer_iter()
+                .map(|l| l.const_prop_ids())
+                .kmerge()
+                .dedup()
+                .collect(),
             LayerIds::One(id) => match entry.layer(id) {
-                Some(l) => Box::new(
-                    l.static_prop_ids()
-                        .into_iter()
-                        .map(move |id| reverse_map[id].clone()),
-                ),
-                None => Box::new(iter::empty()),
+                Some(l) => l.const_prop_ids().collect(),
+                None => vec![],
             },
-            LayerIds::Multiple(ids) => Box::new(
-                ids.iter()
-                    .flat_map(|id| entry.layer(*id).map(|l| l.static_prop_ids()))
-                    .kmerge()
-                    .dedup()
-                    .map(move |id| reverse_map[id].clone()),
-            ),
-        }
+            LayerIds::Multiple(ids) => ids
+                .iter()
+                .flat_map(|id| entry.layer(*id).map(|l| l.const_prop_ids()))
+                .kmerge()
+                .dedup()
+                .collect(),
+        };
+        Box::new(ids.into_iter())
     }
 
     #[inline]
     fn temporal_edge_prop(
         &self,
         e: EdgeRef,
-        name: &str,
+        prop_id: usize,
         layer_ids: LayerIds,
     ) -> Option<LockedLayeredTProp> {
         let layer_ids = layer_ids.constrain_from_edge(e);
         let edge = self.inner().edge(e.pid());
-        let prop_id = self.inner().edge_find_prop(name, false)?;
         edge.temporal_property(layer_ids, prop_id)
     }
 
-    fn temporal_edge_prop_names(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<ArcStr> {
-        let layer_ids = layer_ids.constrain_from_edge(e);
+    fn temporal_edge_prop_ids(
+        &self,
+        e: EdgeRef,
+        layer_ids: LayerIds,
+    ) -> Box<dyn Iterator<Item = usize> + '_> {
+        // FIXME: revisit the locking scheme so we don't have to collect the ids
         let entry = self.inner().edge_entry(e.pid());
-        let reverse_map = self.inner().edge_meta.temporal_prop_meta().get_keys();
         match layer_ids {
             LayerIds::None => Box::new(iter::empty()),
-            LayerIds::All => Box::new(
-                entry
-                    .temp_prop_ids(None)
-                    .into_iter()
-                    .map(move |id| reverse_map[id].clone()),
-            ),
-            LayerIds::One(id) => Box::new(
-                entry
-                    .temp_prop_ids(Some(id))
-                    .into_iter()
-                    .map(move |id| reverse_map[id].clone()),
-            ),
+            LayerIds::All => Box::new(entry.temp_prop_ids(None).collect_vec().into_iter()),
+            LayerIds::One(id) => Box::new(entry.temp_prop_ids(Some(id)).collect_vec().into_iter()),
             LayerIds::Multiple(ids) => Box::new(
                 ids.iter()
                     .map(|id| entry.temp_prop_ids(Some(*id)))
                     .kmerge()
                     .dedup()
-                    .map(move |id| reverse_map[id].clone()),
+                    .collect_vec()
+                    .into_iter(),
             ),
         }
     }

--- a/raphtory/src/db/internal/prop_add.rs
+++ b/raphtory/src/db/internal/prop_add.rs
@@ -29,11 +29,7 @@ impl<const N: usize> InternalPropertyAdditionOps for InnerTemporalGraph<N> {
         let mut node = self.inner().storage.get_node_mut(vid);
         for (prop_id, value) in props {
             node.add_constant_prop(prop_id, value).map_err(|err| {
-                let name = self
-                    .vertex_meta()
-                    .get_prop_name(prop_id, true)
-                    .expect("name exists")
-                    .to_owned();
+                let name = self.vertex_meta().get_prop_name(prop_id, true);
                 GraphError::ConstantPropertyMutationError {
                     name,
                     new: err.new_value.expect("new value exists"),
@@ -58,11 +54,7 @@ impl<const N: usize> InternalPropertyAdditionOps for InnerTemporalGraph<N> {
             edge_layer
                 .add_constant_prop(prop_id, value)
                 .map_err(|err| {
-                    let name = self
-                        .edge_meta()
-                        .get_prop_name(prop_id, true)
-                        .expect("name exists")
-                        .to_owned();
+                    let name = self.edge_meta().get_prop_name(prop_id, true);
                     GraphError::ConstantPropertyMutationError {
                         name,
                         new: err.new_value.expect("new value exists"),

--- a/raphtory/src/db/internal/static_properties.rs
+++ b/raphtory/src/db/internal/static_properties.rs
@@ -4,11 +4,23 @@ use crate::{
 };
 
 impl<const N: usize> ConstPropertiesOps for InnerTemporalGraph<N> {
-    fn const_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
-        Box::new(self.inner().constant_property_names().into_iter())
+    fn get_const_prop_id(&self, name: &str) -> Option<usize> {
+        self.inner().graph_props.get_const_prop_id(name)
     }
 
-    fn get_const_property(&self, key: &str) -> Option<Prop> {
-        self.inner().get_constant_prop(key)
+    fn get_const_prop_name(&self, id: usize) -> ArcStr {
+        self.inner().graph_props.get_const_prop_name(id)
+    }
+
+    fn const_prop_ids(&self) -> Box<dyn Iterator<Item = usize>> {
+        Box::new(self.inner().graph_props.const_prop_ids())
+    }
+
+    fn const_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
+        Box::new(self.inner().const_prop_names().into_iter())
+    }
+
+    fn get_const_prop(&self, prop_id: usize) -> Option<Prop> {
+        self.inner().get_constant_prop(prop_id)
     }
 }

--- a/raphtory/src/db/internal/temporal_properties.rs
+++ b/raphtory/src/db/internal/temporal_properties.rs
@@ -2,29 +2,30 @@ use crate::{
     core::{entities::graph::tgraph::InnerTemporalGraph, ArcStr, Prop},
     db::api::properties::internal::{Key, TemporalPropertiesOps, TemporalPropertyViewOps},
 };
+use std::ops::Deref;
 
 impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
-    fn temporal_value(&self, id: &Key) -> Option<Prop> {
+    fn temporal_value(&self, id: usize) -> Option<Prop> {
         self.inner()
             .get_temporal_prop(id)
             .and_then(|prop| prop.last_before(i64::MAX).map(|(_, v)| v))
     }
 
-    fn temporal_history(&self, id: &Key) -> Vec<i64> {
+    fn temporal_history(&self, id: usize) -> Vec<i64> {
         self.inner()
             .get_temporal_prop(id)
             .map(|prop| prop.iter().map(|(t, _)| t).collect())
             .unwrap_or_default()
     }
 
-    fn temporal_values(&self, id: &Key) -> Vec<Prop> {
+    fn temporal_values(&self, id: usize) -> Vec<Prop> {
         self.inner()
             .get_temporal_prop(id)
             .map(|prop| prop.iter().map(|(_, v)| v).collect())
             .unwrap_or_default()
     }
 
-    fn temporal_value_at(&self, id: &Key, t: i64) -> Option<Prop> {
+    fn temporal_value_at(&self, id: usize, t: i64) -> Option<Prop> {
         self.inner()
             .get_temporal_prop(id)
             .and_then(|prop| prop.last_before(t.saturating_add(1)).map(|(_, v)| v))
@@ -32,12 +33,19 @@ impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
 }
 
 impl<const N: usize> TemporalPropertiesOps for InnerTemporalGraph<N> {
-    fn temporal_property_keys(&self) -> Box<dyn Iterator<Item = ArcStr>> {
-        // TODO: Is this actually worth doing? the advantage is that there is definitely no writes during the iteration as we keep the guard alive...
-        Box::new(self.inner().temporal_property_names().into_iter())
+    fn get_temporal_prop_id(&self, name: &str) -> Option<usize> {
+        self.inner().graph_props.get_temporal_id(name)
     }
 
-    fn get_temporal_property(&self, key: &str) -> Option<Key> {
-        self.inner().get_temporal_prop(key).map(|_| key.into()) // Fixme: rework to use internal ids
+    fn get_temporal_prop_name(&self, id: usize) -> ArcStr {
+        self.inner().graph_props.get_temporal_name(id)
+    }
+
+    fn temporal_prop_ids(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        Box::new(self.inner().graph_props.temporal_ids())
+    }
+
+    fn temporal_prop_keys(&self) -> Box<dyn Iterator<Item = ArcStr> + '_> {
+        Box::new(self.inner().graph_props.temporal_names().into_iter())
     }
 }

--- a/raphtory/src/db/internal/temporal_properties.rs
+++ b/raphtory/src/db/internal/temporal_properties.rs
@@ -1,8 +1,7 @@
 use crate::{
     core::{entities::graph::tgraph::InnerTemporalGraph, ArcStr, Prop},
-    db::api::properties::internal::{Key, TemporalPropertiesOps, TemporalPropertyViewOps},
+    db::api::properties::internal::{TemporalPropertiesOps, TemporalPropertyViewOps},
 };
-use std::ops::Deref;
 
 impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
     fn temporal_value(&self, id: usize) -> Option<Prop> {

--- a/raphtory/src/db/task/edge/eval_edge.rs
+++ b/raphtory/src/db/task/edge/eval_edge.rs
@@ -7,9 +7,7 @@ use crate::{
     db::{
         api::{
             properties::{
-                internal::{
-                    ConstPropertiesOps, Key, TemporalPropertiesOps, TemporalPropertyViewOps,
-                },
+                internal::{ConstPropertiesOps, TemporalPropertiesOps, TemporalPropertyViewOps},
                 Properties,
             },
             view::*,

--- a/raphtory/src/db/task/edge/window_eval_edge.rs
+++ b/raphtory/src/db/task/edge/window_eval_edge.rs
@@ -7,9 +7,7 @@ use crate::{
     db::{
         api::{
             properties::{
-                internal::{
-                    ConstPropertiesOps, Key, TemporalPropertiesOps, TemporalPropertyViewOps,
-                },
+                internal::{ConstPropertiesOps, TemporalPropertiesOps, TemporalPropertyViewOps},
                 Properties,
             },
             view::{internal::*, *},
@@ -195,7 +193,7 @@ impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> TemporalPropertyViewOps
 impl<'a, G: GraphViewOps, CS: ComputeState, S: 'static> TemporalPropertiesOps
     for WindowEvalEdgeView<'a, G, CS, S>
 {
-    fn get_temporal_prop_id(&self, key: &str) -> Option<Key> {
+    fn get_temporal_prop_id(&self, key: &str) -> Option<usize> {
         self.g
             .edge_meta()
             .temporal_prop_meta()

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -179,9 +179,11 @@ impl<G: GraphViewOps> IndexedGraph<G> {
 
         // TODO: load all these from the graph at some point in the future
         let mut prop_names_set = g
-            .all_vertex_prop_names(false)
+            .vertex_meta()
+            .temporal_prop_meta()
+            .get_keys()
             .into_iter()
-            .chain(g.all_vertex_prop_names(true).into_iter())
+            .chain(g.vertex_meta().const_prop_meta().get_keys().into_iter())
             .collect::<HashSet<_>>();
 
         for vertex in g.vertices() {
@@ -229,9 +231,11 @@ impl<G: GraphViewOps> IndexedGraph<G> {
 
         // TODO: load all these from the graph at some point in the future
         let mut prop_names_set = g
-            .all_edge_prop_names(false)
+            .edge_meta()
+            .temporal_prop_meta()
+            .get_keys()
             .into_iter()
-            .chain(g.all_edge_prop_names(true).into_iter())
+            .chain(g.edge_meta().const_prop_meta().get_keys())
             .collect::<HashSet<_>>();
 
         for edge in g.edges() {
@@ -689,11 +693,7 @@ impl<G: GraphViewOps + InternalAdditionOps> InternalAdditionOps for IndexedGraph
 
         // index all props that are declared in the schema
         for (prop_id, prop) in props.iter() {
-            let prop_name = self
-                .graph
-                .vertex_meta()
-                .get_prop_name(*prop_id, false)
-                .expect("property id should be valid");
+            let prop_name = self.graph.vertex_meta().get_prop_name(*prop_id, false);
             if let Ok(field) = self.vertex_index.schema().get_field(&prop_name) {
                 if let Prop::Str(s) = prop {
                     document.add_text(field, s)

--- a/raphtory/src/vectors/mod.rs
+++ b/raphtory/src/vectors/mod.rs
@@ -6,7 +6,7 @@ use futures_util::future::{join_all, BoxFuture};
 use itertools::{chain, Itertools};
 use std::{
     borrow::Borrow,
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::{hash_map::DefaultHasher, HashMap, HashSet},
     convert::identity,
     fmt::{Display, Formatter},
     fs::{create_dir_all, File},
@@ -699,28 +699,31 @@ impl<G: GraphViewOps> GraphEntity for VertexView<G> {
         let max_time_fmt = self.latest_time().map(time_fmt).unwrap_or_else(missing);
         let max_time = format!("latest activity: {}", max_time_fmt);
 
-        let temporal_keys = self
-            .temporal_property_keys()
-            .filter(|key| !filter_out.contains(&key.as_ref()))
-            .filter(|key| !force_static.contains(&key.as_ref()))
-            .filter(|key| {
+        let temporal_props = self
+            .properties()
+            .temporal()
+            .iter()
+            .filter(|(key, _)| !filter_out.contains(&key.as_ref()))
+            .filter(|(key, _)| !force_static.contains(&key.as_ref()))
+            .filter(|(_, v)| {
                 // the history of the temporal prop has more than one value
-                let props = self.temporal_values(key);
-                let values = props.iter().map(|prop| prop.to_string());
-                values.unique().collect_vec().len() > 1
+                v.values()
+                    .into_iter()
+                    .map(|prop| prop.to_string())
+                    .unique()
+                    .collect_vec()
+                    .len()
+                    > 1
             })
             .collect_vec();
 
-        let temporal_props = temporal_keys.iter().map(|key| {
-            let history = self.temporal_history(&key);
-            let props = self.temporal_values(&key);
-            let values = props.iter().map(|prop| prop.to_string());
-            let time_value_pairs = history.iter().zip(values);
+        let temporal_keys: HashSet<_> = temporal_props.iter().map(|(key, _)| key).collect();
+        let temporal_props = temporal_props.iter().map(|(key, value)| {
+            let time_value_pairs = value.iter().map(|(k, v)| (k, v.to_string()));
             time_value_pairs
                 .unique_by(|(_, value)| value.clone())
                 .map(|(time, value)| {
-                    let key = key.to_string();
-                    let time = time_fmt(*time);
+                    let time = time_fmt(time);
                     format!("{key} changed to {value} at {time}")
                 })
                 .intersperse("\n".to_owned())

--- a/raphtory/src/vectors/mod.rs
+++ b/raphtory/src/vectors/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use futures_util::future::{join_all, BoxFuture};
 // use futures_util::StreamExt;
 use itertools::{chain, Itertools};
+use serde::{Deserialize, Serialize, Serializer};
 use std::{
     borrow::Borrow,
     collections::{hash_map::DefaultHasher, HashMap, HashSet},
@@ -16,17 +17,14 @@ use std::{
     path::Path,
 };
 
-use crate::db::api::{
-    properties::internal::{TemporalPropertiesOps, TemporalPropertyViewOps},
-    view::internal::{DynamicGraph, IntoDynamic},
-};
-use serde::{Deserialize, Serialize, Serializer};
-
 // use crate::model::graph::edge::Edge;
 // use numpy::PyArray2;
 // use pyo3::{types::IntoPyDict, Python};
 use crate::{
-    db::graph::{edge::EdgeView, vertex::VertexView, views::window_graph::WindowedGraph},
+    db::{
+        api::view::internal::{DynamicGraph, IntoDynamic},
+        graph::{edge::EdgeView, vertex::VertexView, views::window_graph::WindowedGraph},
+    },
     prelude::{EdgeViewOps, GraphViewOps, Layer, LayerOps, TimeOps, VertexViewOps},
 };
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Properties operations now use the internal ids for lookups instead of resolving the string names every time
- Checking if a property was updated in a window no longer allocates a vector of all the property updates

### Why are the changes needed?

- cleanup and optimisations

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

usual tests and new test for GraphWithDeletions 


