### PR TITLE
Bug/skip name property in search

### DIFF
--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -1112,4 +1112,11 @@ mod test {
 
         assert!(!top_docs.is_empty());
     }
+
+    #[test]
+    fn property_name_on_vertex_does_not_crash() {
+        let g = Graph::new();
+        g.add_vertex(0, "test", [("name", "test")]).unwrap();
+        let gi: IndexedGraph<_> = g.into();
+    }
 }

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -191,6 +191,7 @@ impl<G: GraphViewOps> IndexedGraph<G> {
                 break;
             }
             let mut found_props: HashSet<ArcStr> = HashSet::default();
+            found_props.insert("name".into());
 
             for prop in prop_names_set.iter() {
                 // load temporal props


### PR DESCRIPTION
### What changes were proposed in this pull request?

put back skipping of `"name"` property so IndexedGraph does not crash if it exists

### Why are the changes needed?

avoid panic due to field defined multiple times

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

added test to confirm that we can make an IndexedGraph when a vertex property `"name"` is present

### Are there any further changes required?

We should use prefixes to have separate name spaces for properties so we can have such a property without causing conflicts
