### PR TITLE
Bug/simultaneous updates in graph with deletions

### DIFF
--- a/raphtory/src/core/entities/edges/edge_store.rs
+++ b/raphtory/src/core/entities/edges/edge_store.rs
@@ -272,24 +272,24 @@ impl EdgeStore {
         }
     }
 
-    pub fn last_deletion_before(&self, layer_ids: &LayerIds, t: i64) -> Option<i64> {
+    pub fn last_deletion_before(&self, layer_ids: &LayerIds, t: i64) -> Option<TimeIndexEntry> {
         match layer_ids {
             LayerIds::None => None,
             LayerIds::All => self
                 .deletions()
                 .iter()
-                .flat_map(|dels| dels.range(i64::MIN..t).last_t())
+                .flat_map(|dels| dels.range(i64::MIN..t).last().copied())
                 .max(),
             LayerIds::One(id) => {
                 let layer = self.deletions.get(*id)?;
-                layer.range(i64::MIN..t).last_t()
+                layer.range(i64::MIN..t).last().copied()
             }
             LayerIds::Multiple(ids) => ids
                 .iter()
                 .flat_map(|id| {
                     self.deletions
                         .get(*id)
-                        .and_then(|t_index| t_index.range(i64::MIN..t).last_t())
+                        .and_then(|t_index| t_index.range(i64::MIN..t).last().copied())
                 })
                 .max(),
         }
@@ -328,7 +328,7 @@ impl EdgeStore {
                     .and_then(|layer| {
                         layer
                             .temporal_property(prop_id)
-                            .filter(|p| p.iter_window(w.clone()).next().is_some())
+                            .filter(|p| p.iter_window_t(w.clone()).next().is_some())
                     })
                     .is_some()
             }),
@@ -337,7 +337,7 @@ impl EdgeStore {
                 .and_then(|layer| {
                     layer
                         .temporal_property(prop_id)
-                        .filter(|p| p.iter_window(w.clone()).next().is_some())
+                        .filter(|p| p.iter_window_t(w.clone()).next().is_some())
                 })
                 .is_some(),
             LayerIds::Multiple(ids) => ids.iter().any(|id| {
@@ -345,7 +345,7 @@ impl EdgeStore {
                     .and_then(|layer| {
                         layer
                             .temporal_property(prop_id)
-                            .filter(|p| p.iter_window(w.clone()).next().is_some())
+                            .filter(|p| p.iter_window_t(w.clone()).next().is_some())
                     })
                     .is_some()
             }),

--- a/raphtory/src/core/entities/properties/props.rs
+++ b/raphtory/src/core/entities/properties/props.rs
@@ -80,7 +80,7 @@ impl Props {
     ) -> Box<dyn Iterator<Item = (i64, Prop)> + '_> {
         let o = self.temporal_props.get(prop_id);
         if let Some(t_prop) = o {
-            Box::new(t_prop.iter_window(t_start..t_end))
+            Box::new(t_prop.iter_window_t(t_start..t_end))
         } else {
             Box::new(std::iter::empty())
         }

--- a/raphtory/src/core/entities/properties/tcell.rs
+++ b/raphtory/src/core/entities/properties/tcell.rs
@@ -84,23 +84,21 @@ impl<A: Clone + Debug + PartialEq> TCell<A> {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn iter_window(&self, r: Range<i64>) -> Box<dyn Iterator<Item = &A> + '_> {
+    pub fn iter_window(
+        &self,
+        r: Range<TimeIndexEntry>,
+    ) -> Box<dyn Iterator<Item = (&TimeIndexEntry, &A)> + '_> {
         match self {
             TCell::Empty => Box::new(std::iter::empty()),
             TCell::TCell1(t, value) => {
-                if r.contains(t.t()) {
-                    Box::new(std::iter::once(value))
+                if r.contains(t) {
+                    Box::new(std::iter::once((t, value)))
                 } else {
                     Box::new(std::iter::empty())
                 }
             }
-            TCell::TCellCap(svm) => {
-                Box::new(svm.range(TimeIndexEntry::range(r)).map(|(_, value)| value))
-            }
-            TCell::TCellN(btm) => {
-                Box::new(btm.range(TimeIndexEntry::range(r)).map(|(_, value)| value))
-            }
+            TCell::TCellCap(svm) => Box::new(svm.range(r)),
+            TCell::TCellN(btm) => Box::new(btm.range(r)),
         }
     }
 
@@ -144,7 +142,10 @@ impl<A: Clone + Debug + PartialEq> TCell<A> {
 #[cfg(test)]
 mod tcell_tests {
     use super::TCell;
-    use crate::{core::storage::timeindex::TimeIndexEntry, db::api::view::TimeIndex};
+    use crate::{
+        core::storage::timeindex::{AsTime, TimeIndexEntry},
+        db::api::view::TimeIndex,
+    };
 
     #[test]
     fn set_new_value_for_tcell_initialized_as_empty() {
@@ -218,8 +219,10 @@ mod tcell_tests {
     fn updates_to_prop_can_be_window_iterated() {
         let tcell: TCell<String> = TCell::default();
 
-        let actual = tcell.iter_window(i64::MIN..i64::MAX).collect::<Vec<_>>();
-        let expected: Vec<&String> = vec![];
+        let actual = tcell
+            .iter_window(TimeIndexEntry::MIN..TimeIndexEntry::MAX)
+            .collect::<Vec<_>>();
+        let expected = vec![];
         assert_eq!(actual, expected);
 
         assert_eq!(
@@ -230,8 +233,10 @@ mod tcell_tests {
         let tcell = TCell::new(TimeIndexEntry::start(3), "Pometry");
 
         assert_eq!(
-            tcell.iter_window(3..4).collect::<Vec<_>>(),
-            vec![&"Pometry"]
+            tcell
+                .iter_window(TimeIndexEntry::range(3..4))
+                .collect::<Vec<_>>(),
+            vec![(&TimeIndexEntry(3, 0), &"Pometry")]
         );
 
         assert_eq!(
@@ -243,39 +248,74 @@ mod tcell_tests {
         tcell.set(TimeIndexEntry::start(1), "Pometry Inc.");
         tcell.set(TimeIndexEntry::start(2), "Raphtory");
 
+        let one = TimeIndexEntry::start(1);
+        let two = TimeIndexEntry::start(2);
+        let three = TimeIndexEntry::start(3);
+
         assert_eq!(
             tcell.iter_window_t(2..3).collect::<Vec<_>>(),
             vec![(&2, &"Raphtory")]
         );
 
-        let expected: Vec<&String> = vec![];
-        assert_eq!(tcell.iter_window(4..5).collect::<Vec<_>>(), expected);
-
+        let expected = vec![];
         assert_eq!(
-            tcell.iter_window(1..i64::MAX).collect::<Vec<_>>(),
-            vec![&"Pometry Inc.", &"Raphtory", &"Pometry"]
+            tcell
+                .iter_window(TimeIndexEntry::range(4..5))
+                .collect::<Vec<_>>(),
+            expected
         );
 
         assert_eq!(
-            tcell.iter_window(3..i64::MAX).collect::<Vec<_>>(),
-            vec![&"Pometry"]
+            tcell
+                .iter_window(TimeIndexEntry::range(1..i64::MAX))
+                .collect::<Vec<_>>(),
+            vec![
+                (&one, &"Pometry Inc."),
+                (&two, &"Raphtory"),
+                (&three, &"Pometry")
+            ]
         );
 
         assert_eq!(
-            tcell.iter_window(2..i64::MAX).collect::<Vec<_>>(),
-            vec![&"Raphtory", &"Pometry"]
+            tcell
+                .iter_window(TimeIndexEntry::range(3..i64::MAX))
+                .collect::<Vec<_>>(),
+            vec![(&three, &"Pometry")]
         );
-
-        let expected: Vec<&String> = vec![];
-        assert_eq!(tcell.iter_window(5..i64::MAX).collect::<Vec<_>>(), expected);
 
         assert_eq!(
-            tcell.iter_window(i64::MIN..4).collect::<Vec<_>>(),
-            vec![&"Pometry Inc.", &"Raphtory", &"Pometry"]
+            tcell
+                .iter_window(TimeIndexEntry::range(2..i64::MAX))
+                .collect::<Vec<_>>(),
+            vec![(&two, &"Raphtory"), (&three, &"Pometry")]
         );
 
-        let expected: Vec<&String> = vec![];
-        assert_eq!(tcell.iter_window(i64::MIN..1).collect::<Vec<_>>(), expected);
+        let expected = vec![];
+        assert_eq!(
+            tcell
+                .iter_window(TimeIndexEntry::range(5..i64::MAX))
+                .collect::<Vec<_>>(),
+            expected
+        );
+
+        assert_eq!(
+            tcell
+                .iter_window(TimeIndexEntry::range(i64::MIN..4))
+                .collect::<Vec<_>>(),
+            vec![
+                (&one, &"Pometry Inc."),
+                (&two, &"Raphtory"),
+                (&three, &"Pometry")
+            ]
+        );
+
+        let expected = vec![];
+        assert_eq!(
+            tcell
+                .iter_window(TimeIndexEntry::range(i64::MIN..1))
+                .collect::<Vec<_>>(),
+            expected
+        );
 
         let mut tcell: TCell<i64> = TCell::default();
         for n in 1..130 {
@@ -284,6 +324,11 @@ mod tcell_tests {
 
         assert_eq!(tcell.iter_window_t(i64::MIN..i64::MAX).count(), 129);
 
-        assert_eq!(tcell.iter_window(i64::MIN..i64::MAX).count(), 129)
+        assert_eq!(
+            tcell
+                .iter_window(TimeIndexEntry::range(i64::MIN..i64::MAX))
+                .count(),
+            129
+        )
     }
 }

--- a/raphtory/src/core/storage/timeindex.rs
+++ b/raphtory/src/core/storage/timeindex.rs
@@ -18,7 +18,7 @@ use tantivy::time::Time;
 use super::locked_view::LockedView;
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Ord, PartialOrd, Eq)]
-pub struct TimeIndexEntry(i64, usize);
+pub struct TimeIndexEntry(pub i64, pub usize);
 
 pub trait AsTime: Debug + Copy + Ord + Eq + Send + Sync {
     fn t(&self) -> &i64;
@@ -32,6 +32,9 @@ impl From<i64> for TimeIndexEntry {
 }
 
 impl TimeIndexEntry {
+    pub const MIN: TimeIndexEntry = TimeIndexEntry(i64::MIN, 0);
+
+    pub const MAX: TimeIndexEntry = TimeIndexEntry(i64::MAX, usize::MAX);
     pub fn new(t: i64, s: usize) -> Self {
         Self(t, s)
     }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -5,7 +5,7 @@ use crate::{
             vertices::vertex_store::VertexStore,
             LayerIds, VID,
         },
-        storage::timeindex::{AsTime, TimeIndexOps},
+        storage::timeindex::{AsTime, TimeIndexEntry, TimeIndexOps},
         utils::errors::GraphError,
         Direction, Prop,
     },
@@ -70,53 +70,58 @@ impl GraphWithDeletions {
         ) = match layer_ids {
             LayerIds::None => return false,
             LayerIds::All => (
-                e.additions().iter().flat_map(|v| v.first_t()).min(),
-                e.deletions().iter().flat_map(|v| v.first_t()).min(),
+                e.additions().iter().flat_map(|v| v.first()).min().copied(),
+                e.deletions().iter().flat_map(|v| v.first()).min().copied(),
                 e.additions()
                     .iter()
-                    .flat_map(|v| v.range(i64::MIN..t.saturating_add(1)).last_t())
+                    .flat_map(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
                     .max(),
                 e.deletions()
                     .iter()
-                    .flat_map(|v| v.range(i64::MIN..t).last_t())
+                    .flat_map(|v| v.range(i64::MIN..t).last().copied())
                     .max(),
             ),
             LayerIds::One(l_id) => (
-                e.additions().get(*l_id).and_then(|v| v.first_t()),
-                e.deletions().get(*l_id).and_then(|v| v.first_t()),
+                e.additions().get(*l_id).and_then(|v| v.first().copied()),
+                e.deletions().get(*l_id).and_then(|v| v.first().copied()),
                 e.additions()
                     .get(*l_id)
-                    .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last_t()),
+                    .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied()),
                 e.deletions()
                     .get(*l_id)
-                    .and_then(|v| v.range(i64::MIN..t).last_t()),
+                    .and_then(|v| v.range(i64::MIN..t).last().copied()),
             ),
             LayerIds::Multiple(ids) => (
                 ids.iter()
-                    .flat_map(|l_id| e.additions().get(*l_id).and_then(|v| v.first_t()))
-                    .min(),
+                    .flat_map(|l_id| e.additions().get(*l_id).and_then(|v| v.first()))
+                    .min()
+                    .copied(),
                 ids.iter()
-                    .flat_map(|l_id| e.deletions().get(*l_id).and_then(|v| v.first_t()))
-                    .min(),
+                    .flat_map(|l_id| e.deletions().get(*l_id).and_then(|v| v.first()))
+                    .min()
+                    .copied(),
                 ids.iter()
                     .flat_map(|l_id| {
                         e.additions()
                             .get(*l_id)
-                            .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last_t())
+                            .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
                     })
                     .max(),
                 ids.iter()
                     .flat_map(|l_id| {
                         e.deletions()
                             .get(*l_id)
-                            .and_then(|v| v.range(i64::MIN..t).last_t())
+                            .and_then(|v| v.range(i64::MIN..t).last().copied())
                     })
                     .max(),
             ),
         };
 
         // None is less than any value (see test below)
-        (first_deletion < first_addition && first_deletion.filter(|v| *v >= t).is_some())
+        (first_deletion < first_addition
+            && first_deletion
+                .filter(|v| *v >= TimeIndexEntry::start(t))
+                .is_some())
             || last_addition_before_start > last_deletion_before_start
     }
 
@@ -130,11 +135,10 @@ impl GraphWithDeletions {
         let edges = self.graph.inner().storage.edges.read_lock();
         v.edge_tuples(layers, Direction::BOTH)
             .map(|eref| edges.get(eref.pid().into()))
-            .filter(|e| {
+            .find(|e| {
                 edge_filter.map(|f| f(e, layers)).unwrap_or(true)
                     && self.edge_alive_at(e, t, layers)
             })
-            .next()
             .is_some()
     }
 
@@ -346,7 +350,7 @@ impl TimeSemantics for GraphWithDeletions {
     fn edge_earliest_time(&self, e: EdgeRef, layer_ids: LayerIds) -> Option<i64> {
         e.time().map(|ti| *ti.t()).or_else(|| {
             let entry = self.core_edge(e.pid());
-            if self.edge_alive_at(&entry, i64::MIN, &layer_ids.clone()) {
+            if self.edge_alive_at(&entry, i64::MIN, &layer_ids) {
                 Some(i64::MIN)
             } else {
                 self.edge_additions(e, layer_ids).first().map(|ti| *ti.t())
@@ -498,23 +502,24 @@ impl TimeSemantics for GraphWithDeletions {
         if entry.has_temporal_prop(&layer_ids, prop_id) {
             let search_start = entry
                 .last_deletion_before(&layer_ids, w.start)
-                .unwrap_or(i64::MIN); // if property was added at any point since the last deletion, it is still there
+                .unwrap_or(TimeIndexEntry::MIN); // if property was added at any point since the last deletion, it is still there
+            let search_end = TimeIndexEntry::start(w.end);
             match layer_ids {
                 LayerIds::None => false,
                 LayerIds::All => entry.layer_ids_iter().any(|id| {
                     entry
                         .temporal_prop_layer(id, prop_id)
-                        .filter(|prop| prop.iter_window(search_start..w.end).next().is_some())
+                        .filter(|prop| prop.iter_window(search_start..search_end).next().is_some())
                         .is_some()
                 }),
                 LayerIds::One(id) => entry
                     .temporal_prop_layer(id, prop_id)
-                    .filter(|prop| prop.iter_window(search_start..w.end).next().is_some())
+                    .filter(|prop| prop.iter_window(search_start..search_end).next().is_some())
                     .is_some(),
                 LayerIds::Multiple(ids) => ids.iter().any(|&id| {
                     entry
                         .temporal_prop_layer(id, prop_id)
-                        .filter(|prop| prop.iter_window(search_start..w.end).next().is_some())
+                        .filter(|prop| prop.iter_window(search_start..search_end).next().is_some())
                         .is_some()
                 }),
             }
@@ -675,9 +680,11 @@ mod test_deletions {
     fn test_ordering_of_addition_and_deletion() {
         let g = GraphWithDeletions::new();
 
+        //deletion before addition (edge exists from (-inf,1) and (1, inf)
         g.delete_edge(1, 1, 2, None).unwrap();
         g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
 
+        //deletion after addition (edge exists only at 2)
         g.add_edge(2, 3, 4, [("test", "test")], None).unwrap();
         g.delete_edge(2, 3, 4, None).unwrap();
 

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -670,4 +670,21 @@ mod test_deletions {
             vec![(5, Prop::str("test")), (11i64, Prop::str("test11"))],
         );
     }
+
+    #[test]
+    fn test_ordering_of_addition_and_deletion() {
+        let g = GraphWithDeletions::new();
+
+        g.delete_edge(1, 1, 2, None).unwrap();
+        g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
+
+        g.add_edge(2, 3, 4, [("test", "test")], None).unwrap();
+        g.delete_edge(2, 3, 4, None).unwrap();
+
+        assert!(g.window(0, 1).has_edge(1, 2, Layer::Default));
+        assert!(!g.window(0, 2).has_edge(3, 4, Layer::Default));
+        assert!(g.window(1, 2).has_edge(1, 2, Layer::Default));
+        assert!(g.window(2, 3).has_edge(3, 4, Layer::Default));
+        assert!(!g.window(3, 4).has_edge(3, 4, Layer::Default));
+    }
 }

--- a/raphtory/src/db/internal/time_semantics.rs
+++ b/raphtory/src/db/internal/time_semantics.rs
@@ -232,7 +232,7 @@ impl<const N: usize> TimeSemantics for InnerTemporalGraph<N> {
         self.inner()
             .graph_props
             .get_temporal_prop(prop_id)
-            .filter(|p| p.iter_window(w).next().is_some())
+            .filter(|p| p.iter_window_t(w).next().is_some())
             .is_some()
     }
 
@@ -244,7 +244,7 @@ impl<const N: usize> TimeSemantics for InnerTemporalGraph<N> {
     ) -> Vec<(i64, Prop)> {
         self.inner()
             .get_temporal_prop(prop_id)
-            .map(|prop| prop.iter_window(t_start..t_end).collect())
+            .map(|prop| prop.iter_window_t(t_start..t_end).collect())
             .unwrap_or_default()
     }
 
@@ -264,7 +264,7 @@ impl<const N: usize> TimeSemantics for InnerTemporalGraph<N> {
         let entry = self.inner().storage.get_node(v);
         entry
             .temporal_property(prop_id)
-            .filter(|p| p.iter_window(w).next().is_some())
+            .filter(|p| p.iter_window_t(w).next().is_some())
             .is_some()
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes GraphWithDeletions to use secondary index to get addition/deletion order correct

### Why are the changes needed?

GraphWithDeletions was ignoring the secondary index 

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

added a test for different order of addition and deletion at the same time point

### Are there any further changes required?


