### PR TITLE
Fixed bug where we do not reset the task runner

### DIFF
--- a/raphtory/src/db/task/context.rs
+++ b/raphtory/src/db/task/context.rs
@@ -57,7 +57,7 @@ where
     }
 
     pub fn reset_ss(&mut self) {
-        self.ss = 1;
+        self.ss = 0;
     }
 
     pub fn resetable_states(&self) -> &[u32] {

--- a/raphtory/src/db/task/context.rs
+++ b/raphtory/src/db/task/context.rs
@@ -56,6 +56,10 @@ where
         self.ss += 1;
     }
 
+    pub fn reset_ss(&mut self) {
+        self.ss = 1;
+    }
+
     pub fn resetable_states(&self) -> &[u32] {
         &self.resetable_states
     }

--- a/raphtory/src/db/task/task_runner.rs
+++ b/raphtory/src/db/task/task_runner.rs
@@ -285,12 +285,13 @@ impl<G: GraphViewOps, CS: ComputeState> TaskRunner<G, CS> {
         } else {
             prev_local_state
         };
-
-        f(
+        let to_return = f(
             GlobalState::new(global_state, ss),
             EvalShardState::new(ss, self.ctx.graph(), shard_state),
             EvalLocalState::new(ss, self.ctx.graph(), vec![]),
             last_local_state,
-        )
+        );
+        self.ctx.reset_ss();
+        to_return
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Small fix such that we can call `runner.run` multiple times in the same algorithm with the same context
### Why are the changes needed?
Without this the second run step can often not run
### Does this PR introduce any user-facing change? If yes is this documented?
No
### How was this patch tested?
Internal algorithm examples
### Are there any further changes required?
No

