### PR TITLE
Adding methods for server side pagination

### DIFF
--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -136,11 +136,7 @@ impl GqlGraph {
     }
 
     async fn search_count(&self, query: String) -> usize {
-        self.graph
-            .search(&query, 999999, 0)
-            .into_iter()
-            .flatten()
-            .count()
+        self.graph.search_count(&query).unwrap_or(0)
     }
 
     async fn node_count(&self, filter: Option<NodeFilter>) -> usize {

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -152,7 +152,7 @@ impl GqlGraph {
                 .filter(|n| filter.matches(n))
                 .count()
         } else {
-            self.graph.vertices().len()
+            self.graph.count_vertices()
         }
     }
 
@@ -165,7 +165,7 @@ impl GqlGraph {
                 .filter(|ev| filter.matches(ev))
                 .count()
         } else {
-            self.graph.edges().count()
+            self.graph.count_edges()
         }
     }
 

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -135,16 +135,122 @@ impl GqlGraph {
             .collect()
     }
 
-    async fn edges<'a>(&self, filter: Option<EdgeFilter>) -> Vec<Edge> {
-        match filter {
-            Some(filter) => self
-                .graph
+    async fn search_count(&self, query: String) -> usize {
+        self.graph
+            .search(&query, 999999, 0)
+            .into_iter()
+            .flatten()
+            .count()
+    }
+
+    async fn node_count(&self, filter: Option<NodeFilter>) -> usize {
+        if let Some(filter) = filter {
+            self.graph
+                .vertices()
+                .iter()
+                .map(|vv| vv.into())
+                .filter(|n| filter.matches(n))
+                .count()
+        } else {
+            self.graph.vertices().len()
+        }
+    }
+
+    async fn edge_count(&self, filter: Option<EdgeFilter>) -> usize {
+        if let Some(filter) = filter {
+            self.graph
                 .edges()
                 .into_iter()
                 .map(|ev| ev.into())
                 .filter(|ev| filter.matches(ev))
-                .collect(),
-            None => self.graph.edges().into_iter().map(|ev| ev.into()).collect(),
+                .count()
+        } else {
+            self.graph.edges().count()
+        }
+    }
+
+    async fn edges<'a>(
+        &self,
+        filter: Option<EdgeFilter>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Vec<Edge> {
+        match (filter, limit, offset) {
+            (None, None, None) => {
+                return self.graph.edges().into_iter().map(|ev| ev.into()).collect()
+            }
+            (Some(filter), Some(limit), Some(offset)) => {
+                return get_edges_with_filter_limit(&self.graph, filter, limit, offset);
+            }
+            (Some(filter), None, Some(offset)) => {
+                return get_edges_with_filter_limit(&self.graph, filter, 10, offset)
+            }
+            (Some(filter), Some(limit), None) => {
+                return get_edges_with_filter_limit(&self.graph, filter, limit, 0)
+            }
+            (Some(filter), None, None) => return get_edges_with_filter(&self.graph, filter),
+            (None, Some(limit), Some(offset)) => {
+                return get_edges_with_limit(&self.graph, limit, offset)
+            }
+            (None, None, Some(offset)) => return get_edges_with_limit(&self.graph, 10, offset),
+            (None, Some(limit), None) => return get_edges_with_limit(&self.graph, limit, 0),
+        }
+
+        fn get_edges_with_filter_limit(
+            graph: &IndexedGraph<DynamicGraph>,
+            filter: EdgeFilter,
+            limit: usize,
+            offset: usize,
+        ) -> Vec<Edge> {
+            let start_time = limit * offset;
+            let end_time = start_time + limit;
+            graph
+                .edges()
+                .into_iter()
+                .enumerate()
+                .map(|(i, ev)| (i, std::convert::Into::<Edge>::into(ev)))
+                .filter_map(|(i, ev)| {
+                    if filter.matches(&ev) && i >= start_time && i < end_time {
+                        Some(ev)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+
+        fn get_edges_with_filter(
+            graph: &IndexedGraph<DynamicGraph>,
+            filter: EdgeFilter,
+        ) -> Vec<Edge> {
+            graph
+                .edges()
+                .into_iter()
+                .map(|ev| ev.into())
+                .filter(|ev| filter.matches(ev))
+                .collect()
+        }
+
+        fn get_edges_with_limit(
+            graph: &IndexedGraph<DynamicGraph>,
+            limit: usize,
+            offset: usize,
+        ) -> Vec<Edge> {
+            let start_time = limit * offset;
+            let end_time = start_time + limit;
+            graph
+                .edges()
+                .into_iter()
+                .enumerate()
+                .map(|(i, ev)| (i, std::convert::Into::<Edge>::into(ev)))
+                .filter_map(|(i, ev)| {
+                    if i >= start_time && i < end_time {
+                        Some(ev)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
         }
     }
 

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -605,6 +605,16 @@ impl<G: GraphViewOps> IndexedGraph<G> {
         Ok(results)
     }
 
+    pub fn search_count(&self, q: &str) -> Result<usize, GraphError> {
+        let searcher = self.reader.searcher();
+        let query_parser = tantivy::query::QueryParser::for_index(&self.vertex_index, vec![]);
+        let query = query_parser.parse_query(q)?;
+
+        let count = searcher.search(&query, &tantivy::collector::Count)?;
+
+        Ok(count)
+    }
+
     pub fn search_edges(
         &self,
         q: &str,

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -605,9 +605,19 @@ impl<G: GraphViewOps> IndexedGraph<G> {
         Ok(results)
     }
 
-    pub fn search_count(&self, q: &str) -> Result<usize, GraphError> {
+    pub fn search_vertex_count(&self, q: &str) -> Result<usize, GraphError> {
         let searcher = self.reader.searcher();
         let query_parser = tantivy::query::QueryParser::for_index(&self.vertex_index, vec![]);
+        let query = query_parser.parse_query(q)?;
+
+        let count = searcher.search(&query, &tantivy::collector::Count)?;
+
+        Ok(count)
+    }
+
+    pub fn search_edge_count(&self, q: &str) -> Result<usize, GraphError> {
+        let searcher = self.edge_reader.searcher();
+        let query_parser = tantivy::query::QueryParser::for_index(&self.edge_index, vec![]);
         let query = query_parser.parse_query(q)?;
 
         let count = searcher.search(&query, &tantivy::collector::Count)?;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added methods to graphql to support server side pagination in the UI, including search count, edge count and node count, and altered edges method so that it can take a limit and offset from the UI.
 
### Why are the changes needed?
Better UI performance, rather than loading all pages at once, only queries each page at a time

### Does this PR introduce any user-facing change? If yes is this documented?
Works like before, just added more functionality to existing methods and new methods

### How was this patch tested?
Playground 

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


