### PR TITLE
Added 'hard deletion' semantics

### DIFF
--- a/raphtory/src/algorithms/community_detection/in_components.rs
+++ b/raphtory/src/algorithms/community_detection/in_components.rs
@@ -15,7 +15,6 @@ use crate::{
     },
 };
 use std::{
-    cmp,
     collections::{HashMap, HashSet},
 };
 
@@ -42,7 +41,6 @@ where
     let ctx: Context<G, ComputeStateVec> = graph.into();
     let step1 = ATask::new(move |vv: &mut EvalVertexView<'_, G, _, _>| {
         let mut in_components = HashSet::new();
-        let id = vv.id();
         let mut to_check_stack = Vec::new();
         vv.in_neighbours().id().for_each(|id| {
             in_components.insert(id);
@@ -127,7 +125,7 @@ mod components_test {
         correct.insert("6".to_string(), Some(vec![1, 2, 4, 5]));
         correct.insert("7".to_string(), Some(vec![1, 2, 4, 5]));
         correct.insert("8".to_string(), Some(vec![1, 2, 5]));
-        let mut map: HashMap<String, Option<Vec<u64>>> = results
+        let map: HashMap<String, Option<Vec<u64>>> = results
             .into_iter()
             .map(|(k, v)| {
                 (

--- a/raphtory/src/algorithms/community_detection/in_components.rs
+++ b/raphtory/src/algorithms/community_detection/in_components.rs
@@ -14,9 +14,7 @@ use crate::{
         },
     },
 };
-use std::{
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, Debug, Default)]
 struct InState {

--- a/raphtory/src/algorithms/community_detection/out_components.rs
+++ b/raphtory/src/algorithms/community_detection/out_components.rs
@@ -14,9 +14,7 @@ use crate::{
         },
     },
 };
-use std::{
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, Debug, Default)]
 struct OutState {

--- a/raphtory/src/algorithms/community_detection/out_components.rs
+++ b/raphtory/src/algorithms/community_detection/out_components.rs
@@ -15,7 +15,6 @@ use crate::{
     },
 };
 use std::{
-    cmp,
     collections::{HashMap, HashSet},
 };
 
@@ -45,7 +44,6 @@ where
     let ctx: Context<G, ComputeStateVec> = graph.into();
     let step1 = ATask::new(move |vv: &mut EvalVertexView<'_, G, _, _>| {
         let mut out_components = HashSet::new();
-        let id = vv.id();
         let mut to_check_stack = Vec::new();
         vv.out_neighbours().id().for_each(|id| {
             out_components.insert(id);
@@ -130,7 +128,7 @@ mod components_test {
         correct.insert("6".to_string(), Some(vec![]));
         correct.insert("7".to_string(), Some(vec![]));
         correct.insert("8".to_string(), Some(vec![]));
-        let mut map: HashMap<String, Option<Vec<u64>>> = results
+        let map: HashMap<String, Option<Vec<u64>>> = results
             .into_iter()
             .map(|(k, v)| {
                 (

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -701,7 +701,7 @@ mod test_deletions {
         let e = g.edge(3, 4).unwrap();
         assert_eq!(e.earliest_time(), None);
         assert_eq!(e.latest_time().unwrap(), 10);
-        g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
+        g.add_edge(1, 3, 4, [("test", "test")], None).unwrap();
         assert_eq!(e.latest_time().unwrap(), 10);
         assert_eq!(e.earliest_time().unwrap(), 1);
     }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -5,7 +5,7 @@ use crate::{
             vertices::vertex_store::VertexStore,
             LayerIds, VID,
         },
-        storage::timeindex::{AsTime, TimeIndexEntry, TimeIndexOps},
+        storage::timeindex::{AsTime, TimeIndex, TimeIndexEntry, TimeIndexOps},
         utils::errors::GraphError,
         Direction, Prop,
     },
@@ -37,7 +37,7 @@ use std::{
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GraphWithDeletions {
     graph: Arc<InternalGraph>,
-    hard_deletions:bool
+    partial_windows: bool,
 }
 
 impl Static for GraphWithDeletions {}
@@ -46,7 +46,7 @@ impl From<InternalGraph> for GraphWithDeletions {
     fn from(value: InternalGraph) -> Self {
         Self {
             graph: Arc::new(value),
-            hard_deletions: false
+            partial_windows: false,
         }
     }
 }
@@ -64,148 +64,110 @@ impl Display for GraphWithDeletions {
 }
 
 impl GraphWithDeletions {
-
-    pub fn set_hard_deletions(&self) -> GraphWithDeletions {
+    pub fn ignore_deletions_in_window(&self) -> GraphWithDeletions {
         Self {
             graph: self.graph.clone(),
-            hard_deletions: true
+            partial_windows: true,
         }
     }
 
-    pub fn set_soft_deletions(&self) -> GraphWithDeletions {
+    pub fn include_deletions_in_window(&self) -> GraphWithDeletions {
         Self {
             graph: self.graph.clone(),
-            hard_deletions: false
+            partial_windows: false,
         }
     }
 
-    fn edge_alive_at(&self, e: &EdgeStore, start: i64,end: i64, layer_ids: &LayerIds) -> bool {
-        if self.hard_deletions {
-            self.hard_edge_alive_at(e,end,layer_ids)
-        }
-        else {
-            self.soft_edge_alive_at(e,start,layer_ids)
-        }
-    }
-
-    //function for semantics where an edge is only included if the last update was an addition
-    fn hard_edge_alive_at(&self, e: &EdgeStore, t: i64, layer_ids: &LayerIds) -> bool {
-        // FIXME: assumes additions are before deletions if at the same timestamp (need to have strict ordering/secondary index)
-        let (
-            latest_addition,
-            latest_deletion
-        ) = match layer_ids {
-            LayerIds::None => return false,
-            LayerIds::All => (
-                e.additions()
-                    .iter()
-                    .flat_map(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
-                    .max(),
-                e.deletions()
-                    .iter()
-                    .flat_map(|v| v.range(i64::MIN..t).last().copied())
-                    .max(),
-            ),
-            LayerIds::One(l_id) => (
-                e.additions()
-                    .get(*l_id)
-                    .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied()),
-                e.deletions()
-                    .get(*l_id)
-                    .and_then(|v| v.range(i64::MIN..t).last().copied()),
-            ),
-            LayerIds::Multiple(ids) => (
-                ids.iter()
-                    .flat_map(|l_id| {
-                        e.additions()
-                            .get(*l_id)
-                            .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
-                    })
-                    .max(),
-                ids.iter()
-                    .flat_map(|l_id| {
-                        e.deletions()
-                            .get(*l_id)
-                            .and_then(|v| v.range(i64::MIN..t).last().copied())
-                    })
-                    .max(),
-            ),
-        };
-        // None is less than any value (see test below)
-        latest_deletion<latest_addition
-    }
-
-    //function for 'softer' semantics where an edge is included in a window even if it was deleted part way through it
-    fn soft_edge_alive_at(&self, e: &EdgeStore, t: i64, layer_ids: &LayerIds) -> bool {
-        // FIXME: assumes additions are before deletions if at the same timestamp (need to have strict ordering/secondary index)
-        let (
-            first_addition,
-            first_deletion,
-            last_addition_before_start,
-            last_deletion_before_start,
-        ) = match layer_ids {
-            LayerIds::None => return false,
-            LayerIds::All => (
-                e.additions().iter().flat_map(|v| v.first()).min().copied(),
-                e.deletions().iter().flat_map(|v| v.first()).min().copied(),
-                e.additions()
-                    .iter()
-                    .flat_map(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
-                    .max(),
-                e.deletions()
-                    .iter()
-                    .flat_map(|v| v.range(i64::MIN..t).last().copied())
-                    .max(),
-            ),
-            LayerIds::One(l_id) => (
-                e.additions().get(*l_id).and_then(|v| v.first().copied()),
-                e.deletions().get(*l_id).and_then(|v| v.first().copied()),
-                e.additions()
-                    .get(*l_id)
-                    .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied()),
-                e.deletions()
-                    .get(*l_id)
-                    .and_then(|v| v.range(i64::MIN..t).last().copied()),
-            ),
-            LayerIds::Multiple(ids) => (
-                ids.iter()
-                    .flat_map(|l_id| e.additions().get(*l_id).and_then(|v| v.first()))
-                    .min()
-                    .copied(),
-                ids.iter()
-                    .flat_map(|l_id| e.deletions().get(*l_id).and_then(|v| v.first()))
-                    .min()
-                    .copied(),
-                ids.iter()
-                    .flat_map(|l_id| {
-                        e.additions()
-                            .get(*l_id)
-                            .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
-                    })
-                    .max(),
-                ids.iter()
-                    .flat_map(|l_id| {
-                        e.deletions()
-                            .get(*l_id)
-                            .and_then(|v| v.range(i64::MIN..t).last().copied())
-                    })
-                    .max(),
-            ),
+    fn edge_alive_at(&self, e: &EdgeStore, range: Range<i64>, layer_ids: &LayerIds) -> bool {
+        let t = if self.partial_windows {
+            range.start
+        } else {
+            range.end
         };
 
-        // None is less than any value (see test below)
-        (first_deletion < first_addition
-            && first_deletion
-                .filter(|v| *v >= TimeIndexEntry::start(t))
-                .is_some())
-            || last_addition_before_start > last_deletion_before_start
+        let get_last_addition = |v: &TimeIndex<TimeIndexEntry>| {
+            if self.partial_windows {
+                v.range(i64::MIN..t.saturating_add(1)).last().copied()
+            } else {
+                v.range(i64::MIN..t).last().copied()
+            }
+        };
+
+        let (first_addition, first_deletion, last_addition_before, last_deletion_before) =
+            match layer_ids {
+                LayerIds::None => return false,
+                LayerIds::All => (
+                    e.additions().iter().flat_map(|v| v.first()).min().copied(),
+                    e.deletions().iter().flat_map(|v| v.first()).min().copied(),
+                    e.additions()
+                        .iter()
+                        .flat_map(|v| get_last_addition(v))
+                        .max(),
+                    e.deletions()
+                        .iter()
+                        .flat_map(|v| v.range(i64::MIN..t).last().copied())
+                        .max(),
+                ),
+                LayerIds::One(l_id) => (
+                    e.additions().get(*l_id).and_then(|v| v.first().copied()),
+                    e.deletions().get(*l_id).and_then(|v| v.first().copied()),
+                    e.additions().get(*l_id).and_then(|v| get_last_addition(v)),
+                    e.deletions()
+                        .get(*l_id)
+                        .and_then(|v| v.range(i64::MIN..t).last().copied()),
+                ),
+                LayerIds::Multiple(ids) => (
+                    ids.iter()
+                        .flat_map(|l_id| e.additions().get(*l_id).and_then(|v| v.first()))
+                        .min()
+                        .copied(),
+                    ids.iter()
+                        .flat_map(|l_id| e.deletions().get(*l_id).and_then(|v| v.first()))
+                        .min()
+                        .copied(),
+                    ids.iter()
+                        .flat_map(|l_id| {
+                            e.additions().get(*l_id).and_then(|v| get_last_addition(v))
+                        })
+                        .max(),
+                    ids.iter()
+                        .flat_map(|l_id| {
+                            e.deletions()
+                                .get(*l_id)
+                                .and_then(|v| v.range(i64::MIN..t).last().copied())
+                        })
+                        .max(),
+                ),
+            };
+
+        if self.partial_windows {
+            (first_deletion < first_addition
+                && first_deletion
+                    .filter(|v| *v >= TimeIndexEntry::start(t))
+                    .is_some())
+                || last_addition_before > last_deletion_before
+        } else {
+            (first_deletion < first_addition
+                && first_deletion
+                    .filter(|v| *v >= TimeIndexEntry::end(t))
+                    .is_some())
+                || match (last_addition_before, last_deletion_before) {
+                    (Some(last_addition_before), Some(last_deletion_before)) => {
+                        (last_addition_before.0 > last_deletion_before.0)
+                            || (last_addition_before.0 == last_deletion_before.0
+                                && last_addition_before.0 == t-1) //this is the case as we only want to include this entity if it is EXACTLY the time it was added/deleted
+                    }
+                    (Some(_), None) => true,
+                    (None, Some(_)) => false,
+                    (None, None) => false,
+                }
+        }
     }
 
     fn vertex_alive_at(
         &self,
         v: &VertexStore,
-        start: i64,
-        end: i64,
+        w: Range<i64>,
         layers: &LayerIds,
         edge_filter: Option<&EdgeFilter>,
     ) -> bool {
@@ -214,7 +176,7 @@ impl GraphWithDeletions {
             .map(|eref| edges.get(eref.pid().into()))
             .find(|e| {
                 edge_filter.map(|f| f(e, layers)).unwrap_or(true)
-                    && self.edge_alive_at(e, start,end, layers)
+                    && self.edge_alive_at(e, w.clone(), layers)
             })
             .is_some()
     }
@@ -222,7 +184,7 @@ impl GraphWithDeletions {
     pub fn new() -> Self {
         Self {
             graph: Arc::new(InternalGraph::default()),
-            hard_deletions:false
+            partial_windows: false,
         }
     }
 
@@ -289,7 +251,7 @@ impl InternalMaterialize for GraphWithDeletions {
     fn new_base_graph(&self, graph: InternalGraph) -> MaterializedGraph {
         MaterializedGraph::PersistentGraph(GraphWithDeletions {
             graph: Arc::new(graph),
-            hard_deletions:false,
+            partial_windows: false,
         })
     }
 
@@ -349,18 +311,17 @@ impl TimeSemantics for GraphWithDeletions {
         edge_filter: Option<&EdgeFilter>,
     ) -> bool {
         let v = self.graph.inner().storage.get_node(v);
-        v.active(w.clone()) || self.vertex_alive_at(&v, w.start,w.end, layer_ids, edge_filter)
+        v.active(w.clone()) || self.vertex_alive_at(&v, w, layer_ids, edge_filter)
     }
 
     fn include_edge_window(&self, e: &EdgeStore, w: Range<i64>, layer_ids: &LayerIds) -> bool {
-        if self.hard_deletions {
-            //includes edge if alive at the end of the window
-            self.edge_alive_at(e, w.start,w.end, layer_ids)
-        }
-        else{
+        if self.partial_windows {
             //soft deletions
             // includes edge if it is alive at the start of the window or added during the window
-            e.active(layer_ids, w.clone()) || self.edge_alive_at(e, w.start,w.end, layer_ids)
+            e.active(layer_ids, w.clone()) || self.edge_alive_at(e, w, layer_ids)
+        } else {
+            //includes edge if alive at the end of the window
+            self.edge_alive_at(e, w, layer_ids)
         }
     }
 
@@ -374,7 +335,7 @@ impl TimeSemantics for GraphWithDeletions {
 
     fn edge_exploded(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<EdgeRef> {
         //Fixme: Need support for duration on exploded edges
-        if self.edge_alive_at(&self.core_edge(e.pid()), i64::MIN,i64::MIN, &layer_ids) {
+        if self.edge_alive_at(&self.core_edge(e.pid()), i64::MIN..i64::MIN, &layer_ids) {
             Box::new(
                 iter::once(e.at(i64::MIN.into())).chain(self.graph.edge_window_exploded(
                     e,
@@ -399,7 +360,7 @@ impl TimeSemantics for GraphWithDeletions {
     ) -> BoxedIter<EdgeRef> {
         // FIXME: Need better iterators on LockedView that capture the guard
         let entry = self.core_edge(e.pid());
-        if self.edge_alive_at(&entry, w.start,w.end, &layer_ids) {
+        if self.edge_alive_at(&entry, w.clone(), &layer_ids) {
             Box::new(
                 iter::once(e.at(w.start.into())).chain(self.graph.edge_window_exploded(
                     e,
@@ -436,7 +397,7 @@ impl TimeSemantics for GraphWithDeletions {
     fn edge_earliest_time(&self, e: EdgeRef, layer_ids: LayerIds) -> Option<i64> {
         e.time().map(|ti| *ti.t()).or_else(|| {
             let entry = self.core_edge(e.pid());
-            if self.edge_alive_at(&entry, i64::MIN,i64::MIN, &layer_ids) {
+            if self.edge_alive_at(&entry, i64::MIN..i64::MIN, &layer_ids) {
                 Some(i64::MIN)
             } else {
                 self.edge_additions(e, layer_ids).first().map(|ti| *ti.t())
@@ -451,7 +412,7 @@ impl TimeSemantics for GraphWithDeletions {
         layer_ids: LayerIds,
     ) -> Option<i64> {
         let entry = self.core_edge(e.pid());
-        if self.edge_alive_at(&entry, w.start,w.end, &layer_ids) {
+        if self.edge_alive_at(&entry, w.clone(), &layer_ids) {
             Some(w.start)
         } else {
             self.edge_additions(e, layer_ids).range(w).first_t()
@@ -472,7 +433,7 @@ impl TimeSemantics for GraphWithDeletions {
             )),
             None => {
                 let entry = self.core_edge(e.pid());
-                if self.edge_alive_at(&entry, i64::MAX, i64::MIN, &layer_ids) {
+                if self.edge_alive_at(&entry, i64::MIN..i64::MIN, &layer_ids) {
                     Some(i64::MAX)
                 } else {
                     self.edge_deletions(e, layer_ids).last_t()
@@ -500,7 +461,7 @@ impl TimeSemantics for GraphWithDeletions {
             )),
             None => {
                 let entry = self.core_edge(e.pid());
-                if self.edge_alive_at(&entry, w.end - 1,w.end - 1, &layer_ids) {
+                if self.edge_alive_at(&entry, w.end - 1..w.end - 1, &layer_ids) {
                     Some(w.end - 1)
                 } else {
                     self.edge_deletions(e, layer_ids).range(w).last_t()
@@ -621,7 +582,7 @@ impl TimeSemantics for GraphWithDeletions {
         match prop {
             Some(p) => {
                 let entry = self.core_edge(e.pid());
-                if self.edge_alive_at(&entry, start, end, &layer_ids) {
+                if self.edge_alive_at(&entry, start..end, &layer_ids) {
                     p.last_before(start.saturating_add(1))
                         .into_iter()
                         .map(|(_, v)| (start, v))
@@ -702,6 +663,32 @@ mod test_deletions {
     }
 
     #[test]
+    fn test_partial_vs_explicit_deletions() {
+        let g = GraphWithDeletions::new();
+        g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
+        g.delete_edge(10, 1, 2, None).unwrap();
+
+        assert_eq!(g.count_edges(), 1);
+
+        assert_eq!(g.at(12).count_edges(), 0);
+        assert_eq!(g.at(11).count_edges(), 0);
+        assert_eq!(g.at(10).count_edges(), 0);
+        assert_eq!(g.at(9).count_edges(), 1);
+        assert_eq!(g.window(5, 9).count_edges(), 1);
+        assert_eq!(g.window(5, 10).count_edges(), 1);
+        assert_eq!(g.window(5, 11).count_edges(), 0);
+
+        let g2 = g.ignore_deletions_in_window();
+        assert_eq!(g2.at(12).count_edges(), 1);
+        assert_eq!(g2.at(11).count_edges(), 1);
+        assert_eq!(g2.at(10).count_edges(), 1);
+        assert_eq!(g2.at(9).count_edges(), 1);
+        assert_eq!(g2.window(5, 9).count_edges(), 1);
+        assert_eq!(g2.window(5, 10).count_edges(), 1);
+        assert_eq!(g2.window(5, 11).count_edges(), 1);
+    }
+
+    #[test]
     fn test_materialize_only_deletion() {
         let g = GraphWithDeletions::new();
         g.delete_edge(1, 1, 2, None).unwrap();
@@ -769,27 +756,20 @@ mod test_deletions {
         g.add_edge(2, 3, 4, [("test", "test")], None).unwrap();
         g.delete_edge(2, 3, 4, None).unwrap();
 
-        assert!(g.window(0, 1).has_edge(1, 2, Layer::Default));
+        //for this I am assuming that deletions always happen after the creation
+        assert!(!g.window(0, 1).has_edge(1, 2, Layer::Default));
         assert!(!g.window(0, 2).has_edge(3, 4, Layer::Default));
         assert!(g.window(1, 2).has_edge(1, 2, Layer::Default));
+        assert!(g.at(1).has_edge(1, 2, Layer::Default));
         assert!(g.window(2, 3).has_edge(3, 4, Layer::Default));
         assert!(!g.window(3, 4).has_edge(3, 4, Layer::Default));
-    }
 
-    #[test]
-    fn test_hard_deletions() {
-        let g = GraphWithDeletions::new();
-        g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
-        g.delete_edge(10, 1, 2, None).unwrap();
+        let g2 = g.ignore_deletions_in_window();
 
-        assert_eq!(g.count_edges(),1);
-        let g2 = g.set_hard_deletions();
-        assert_eq!(g2.at(12).count_edges(), 0);
-        assert_eq!(g2.at(11).count_edges(), 0);
-        assert_eq!(g2.at(10).count_edges(), 0);
-        assert_eq!(g2.at(9).count_edges(), 1);
-        assert_eq!(g2.window(5,9).count_edges(), 1);
-        assert_eq!(g2.window(5,10).count_edges(), 1);
-        assert_eq!(g2.window(5,11).count_edges(), 0);
+        assert!(g2.window(0, 1).has_edge(1, 2, Layer::Default));
+        assert!(!g2.window(0, 2).has_edge(3, 4, Layer::Default));
+        assert!(g2.window(1, 2).has_edge(1, 2, Layer::Default));
+        assert!(g2.window(2, 3).has_edge(3, 4, Layer::Default));
+        assert!(!g2.window(3, 4).has_edge(3, 4, Layer::Default));
     }
 }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -155,7 +155,7 @@ impl GraphWithDeletions {
                     (Some(last_addition_before), Some(last_deletion_before)) => {
                         (last_addition_before.0 > last_deletion_before.0)
                             || (last_addition_before.0 == last_deletion_before.0
-                                && last_addition_before.0 == t-1) //this is the case as we only want to include this entity if it is EXACTLY the time it was added/deleted
+                                && last_addition_before.0 == t - 1) //this is the case as we only want to include this entity if it is EXACTLY the time it was added/deleted
                     }
                     (Some(_), None) => true,
                     (None, Some(_)) => false,
@@ -686,6 +686,24 @@ mod test_deletions {
         assert_eq!(g2.window(5, 9).count_edges(), 1);
         assert_eq!(g2.window(5, 10).count_edges(), 1);
         assert_eq!(g2.window(5, 11).count_edges(), 1);
+    }
+
+    #[test]
+    fn test_timestamps() {
+        let g = GraphWithDeletions::new();
+        let e = g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
+        assert_eq!(e.earliest_time().unwrap(), 1);
+        assert_eq!(e.latest_time(), None);
+        g.delete_edge(10, 1, 2, None).unwrap();
+        assert_eq!(e.latest_time().unwrap(), 10);
+
+        g.delete_edge(10, 3, 4, None).unwrap();
+        let e = g.edge(3, 4).unwrap();
+        assert_eq!(e.earliest_time(), None);
+        assert_eq!(e.latest_time().unwrap(), 10);
+        g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
+        assert_eq!(e.latest_time().unwrap(), 10);
+        assert_eq!(e.earliest_time().unwrap(), 1);
     }
 
     #[test]

--- a/raphtory/src/python/graph/graph_with_deletions.rs
+++ b/raphtory/src/python/graph/graph_with_deletions.rs
@@ -88,11 +88,11 @@ impl PyGraphWithDeletions {
         )
     }
 
-    pub fn soft_deletions(&self, py: Python) -> PyObject {
+    pub fn include_deletions_in_window(&self, py: Python) -> PyObject {
         self.graph.include_deletions_in_window().into_py(py)
     }
 
-    pub fn hard_deletions(&self, py: Python) -> PyObject {
+    pub fn ignore_deletions_in_window(&self, py: Python) -> PyObject {
         self.graph.ignore_deletions_in_window().into_py(py)
     }
     /// Adds a new vertex with the given id and properties to the graph.

--- a/raphtory/src/python/graph/graph_with_deletions.rs
+++ b/raphtory/src/python/graph/graph_with_deletions.rs
@@ -88,6 +88,14 @@ impl PyGraphWithDeletions {
         )
     }
 
+
+    pub fn soft_deletions(&self,py:Python) -> PyObject {
+        self.graph.set_soft_deletions().into_py(py)
+    }
+
+    pub fn hard_deletions(&self,py:Python) -> PyObject {
+        self.graph.set_hard_deletions().into_py(py)
+    }
     /// Adds a new vertex with the given id and properties to the graph.
     ///
     /// Arguments:

--- a/raphtory/src/python/graph/graph_with_deletions.rs
+++ b/raphtory/src/python/graph/graph_with_deletions.rs
@@ -88,13 +88,12 @@ impl PyGraphWithDeletions {
         )
     }
 
-
-    pub fn soft_deletions(&self,py:Python) -> PyObject {
-        self.graph.set_soft_deletions().into_py(py)
+    pub fn soft_deletions(&self, py: Python) -> PyObject {
+        self.graph.include_deletions_in_window().into_py(py)
     }
 
-    pub fn hard_deletions(&self,py:Python) -> PyObject {
-        self.graph.set_hard_deletions().into_py(py)
+    pub fn hard_deletions(&self, py: Python) -> PyObject {
+        self.graph.ignore_deletions_in_window().into_py(py)
     }
     /// Adds a new vertex with the given id and properties to the graph.
     ///


### PR DESCRIPTION
### What changes were proposed in this pull request?
I have changed the default semantics for a graph with deletions such that it looks for the latest deletion/addition before the end of a window and compares their ordering. This means that if a deletion occurs at some point during the window the edge will not be included.

There is a flag which sets the semantics back to the old 'softer' deletion semantics if required. 

### Why are the changes needed?
The current way of doing things is quite confusing if you are using functions like `at` 

### Does this PR introduce any user-facing change? If yes is this documented?
It does - the documentation for deletions need to be created, once we solidfy this.

### How was this patch tested?
I have added tests for this and fixed the old ones - but more needs to be added 

### Are there any further changes required?
Need to have a lot more discussion on this and make sure the results from all functions make sense before it is officially 'released'

