### PR TITLE
Fix id strings in graphql

### DIFF
--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -119,7 +119,7 @@ mod graphql_test {
                 "graph": {
                     "nodes": [
                         {
-                            "id": 11
+                            "id": "11"
                         }
                     ]
                 }
@@ -359,7 +359,7 @@ mod graphql_test {
         let req = Request::new(list_nodes("g1"));
         let res = schema.execute(req).await;
         let res_json = res.data.into_json().unwrap();
-        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": "1"}]}}));
 
         // reload all graphs from folder
         let req = Request::new(load_all);
@@ -369,13 +369,13 @@ mod graphql_test {
         let req = Request::new(list_nodes("g0"));
         let res = schema.execute(req).await;
         let res_json = res.data.into_json().unwrap();
-        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 2}]}}));
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": "2"}]}}));
 
         // g1 still has node 1
         let req = Request::new(list_nodes("g1"));
         let res = schema.execute(req).await;
         let res_json = res.data.into_json().unwrap();
-        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": "1"}]}}));
     }
 
     #[tokio::test]
@@ -425,7 +425,7 @@ mod graphql_test {
         let res = schema.execute(req).await;
         assert_eq!(res.errors.len(), 0);
         let res_json = res.data.into_json().unwrap();
-        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": "1"}]}}));
     }
 
     #[tokio::test]
@@ -465,7 +465,7 @@ mod graphql_test {
         let res = schema.execute(req).await;
         assert_eq!(res.errors.len(), 0);
         let res_json = res.data.into_json().unwrap();
-        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": 1}]}}));
+        assert_eq!(res_json, json!({"graph": {"nodes": [{"id": "1"}]}}));
 
         let receive_graph = r#"
         query {

--- a/raphtory-graphql/src/model/filters/edge_filter.rs
+++ b/raphtory-graphql/src/model/filters/edge_filter.rs
@@ -20,22 +20,20 @@ pub struct EdgeFilter {
 
 impl EdgeFilter {
     pub(crate) fn matches(&self, edge: &Edge) -> bool {
+        // Filters edges where BOTH the src and dst id match one of the ids in the filter
         if let Some(ids_filter) = &self.node_ids {
             let src = edge.ee.src().id();
             let dst = edge.ee.dst().id();
-            if ids_filter.contains(&src.to_string()) || ids_filter.contains(&dst.to_string()) {
-                return true;
-            } else {
+            if !ids_filter.contains(&src.to_string()) || !ids_filter.contains(&dst.to_string()) {
                 return false;
             }
         }
 
+        // Filters edges where BOTH the src and dst name match one of the names in the filter
         if let Some(names_filter) = &self.node_names {
             let src = edge.ee.src().name();
             let dst = edge.ee.dst().name();
-            if names_filter.contains(&src) || names_filter.contains(&dst) {
-                return true;
-            } else {
+            if !names_filter.contains(&src) || !names_filter.contains(&dst) {
                 return false;
             }
         }

--- a/raphtory-graphql/src/model/filters/edge_filter.rs
+++ b/raphtory-graphql/src/model/filters/edge_filter.rs
@@ -23,7 +23,9 @@ impl EdgeFilter {
         if let Some(ids_filter) = &self.node_ids {
             let src = edge.ee.src().id();
             let dst = edge.ee.dst().id();
-            if !ids_filter.contains(&src.to_string()) || !ids_filter.contains(&dst.to_string()) {
+            if ids_filter.contains(&src.to_string()) || ids_filter.contains(&dst.to_string()) {
+                return true;
+            } else {
                 return false;
             }
         }
@@ -31,7 +33,9 @@ impl EdgeFilter {
         if let Some(names_filter) = &self.node_names {
             let src = edge.ee.src().name();
             let dst = edge.ee.dst().name();
-            if !names_filter.contains(&src) || !names_filter.contains(&dst) {
+            if names_filter.contains(&src) || names_filter.contains(&dst) {
+                return true;
+            } else {
                 return false;
             }
         }

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -33,8 +33,8 @@ impl<G: GraphViewOps + IntoDynamic> From<VertexView<G>> for Node {
 
 #[ResolvedObjectFields]
 impl Node {
-    async fn id(&self) -> u64 {
-        self.vv.id()
+    async fn id(&self) -> String {
+        self.vv.id().to_string()
     }
 
     pub async fn name(&self) -> String {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix output id as string rather than number in raphtory-graphql

### Why are the changes needed?
ids rounding up in apollo from raphtory since default in apollo is 32 bit and we have u64 in raphtory

### Does this PR introduce any user-facing change? If yes is this documented?
no

### How was this patch tested?
playground + ui

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


