### PR TITLE
fix edge_latest_time() in GraphWithDeletions and add a test

### DIFF
--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -433,7 +433,7 @@ impl TimeSemantics for GraphWithDeletions {
             )),
             None => {
                 let entry = self.core_edge(e.pid());
-                if self.edge_alive_at(&entry, i64::MIN..i64::MIN, &layer_ids) {
+                if self.edge_alive_at(&entry, i64::MIN..i64::MAX, &layer_ids) {
                     Some(i64::MAX)
                 } else {
                     self.edge_deletions(e, layer_ids).last_t()
@@ -789,5 +789,17 @@ mod test_deletions {
         assert!(g2.window(1, 2).has_edge(1, 2, Layer::Default));
         assert!(g2.window(2, 3).has_edge(3, 4, Layer::Default));
         assert!(!g2.window(3, 4).has_edge(3, 4, Layer::Default));
+    }
+
+    #[test]
+    fn test_edge_latest_time() {
+        let g = GraphWithDeletions::new();
+        let e = g.add_edge(0, 1, 2, NO_PROPS, None).unwrap();
+        e.delete(2, None).unwrap();
+        assert_eq!(e.latest_time(), Some(2));
+        e.add_updates(4, NO_PROPS, None).unwrap();
+        assert_eq!(e.latest_time(), Some(i64::MAX));
+
+        assert_eq!(e.window(0, 3).latest_time(), Some(2));
     }
 }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -693,7 +693,7 @@ mod test_deletions {
         let g = GraphWithDeletions::new();
         let e = g.add_edge(1, 1, 2, [("test", "test")], None).unwrap();
         assert_eq!(e.earliest_time().unwrap(), 1);
-        assert_eq!(e.latest_time(), None);
+        assert_eq!(e.latest_time(), Some(i64::MAX));
         g.delete_edge(10, 1, 2, None).unwrap();
         assert_eq!(e.latest_time().unwrap(), 10);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix a bug where GraphWithDeletions doesn't calculate the latest time for edges correctly and instead always returns the time of the latest deletion.

### How was this patch tested?

added a test 



