### PR TITLE
Feature/improve time ops

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -74,6 +74,7 @@ jobs:
           auto-push: false
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'
+          comment-on-alert: true
           fail-on-alert: false
           save-data-file: false
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,6 +75,7 @@ jobs:
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'
           comment-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: false
           save-data-file: false
 

--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -280,9 +280,9 @@ def test_graph_properties():
 
     def time_history_test(time, key, value):
         if value is None:
-            assert g.at(time).properties.temporal.get(key) is None
+            assert g.before(time+1).properties.temporal.get(key) is None
         else:
-            assert g.at(time).properties.temporal.get(key).items() == value
+            assert g.before(time+1).properties.temporal.get(key).items() == value
 
     time_history_test(2, "prop 6", [(1, False), (2, True)])
     time_history_test(1, "static prop", None)
@@ -325,7 +325,7 @@ def test_graph_properties():
         "prop 5": "world",
         "prop 6": True,
     }
-    assert g.at(2).properties.as_dict() == {
+    assert g.before(3).properties.as_dict() == {
         "prop 1": 1,
         "prop 2": "hi",
         "prop 3": True,
@@ -341,7 +341,7 @@ def test_graph_properties():
         "prop 6": [(1, False), (2, True)],
     }
 
-    assert g.at(2).properties.temporal.histories() == {
+    assert g.before(3).properties.temporal.histories() == {
         "prop 4": [(1, 11)],
         "prop 5": [(1, "world")],
         "prop 6": [(1, False), (2, True)],
@@ -356,14 +356,14 @@ def test_graph_properties():
     expected_names_no_static = sorted(["prop 4", "prop 5", "prop 6"])
     assert sorted(g.properties.temporal.keys()) == expected_names_no_static
 
-    assert sorted(g.at(1).properties.temporal.keys()) == expected_names_no_static
+    assert sorted(g.before(2).properties.temporal.keys()) == expected_names_no_static
 
     # testing has_property
     assert "prop 4" in g.properties
     assert "prop 7" not in g.properties
-    assert "prop 7" not in g.at(1).properties
+    assert "prop 7" not in g.before(2).properties
     assert "prop 1" in g.properties
-    assert "prop 2" in g.at(1).properties
+    assert "prop 2" in g.before(2).properties
     assert "static prop" not in g.properties.constant
 
 
@@ -415,7 +415,7 @@ def test_vertex_properties():
     time_history_test(1, "static prop", None)
 
     def time_static_property_test(time, key, value):
-        gg = g.at(time)
+        gg = g.before(time+1)
         if value is None:
             assert gg.vertex(1).properties.constant.get(key) is None
             assert gg.vertices.properties.constant.get(key) is None
@@ -442,7 +442,7 @@ def test_vertex_properties():
 
     # testing property
     def time_property_test(time, key, value):
-        gg = g.at(time)
+        gg = g.before(time+1)
         if value is None:
             assert gg.vertex(1).properties.get(key) is None
             assert gg.vertices.properties.get(key) is None
@@ -523,21 +523,21 @@ def test_vertex_properties():
         "prop 4": [[True]],
     }
 
-    assert g.at(2).vertex(1).properties == {
+    assert g.before(3).vertex(1).properties == {
         "prop 1": 2,
         "prop 4": False,
         "prop 2": 0.6,
         "static prop": 123,
         "prop 3": "hi",
     }
-    assert g.at(2).vertices.properties == {
+    assert g.before(3).vertices.properties == {
         "prop 1": [2],
         "prop 4": [False],
         "prop 2": [0.6],
         "static prop": [123],
         "prop 3": ["hi"],
     }
-    assert g.at(2).vertices.out_neighbours.properties == {
+    assert g.before(3).vertices.out_neighbours.properties == {
         "prop 1": [[2]],
         "prop 4": [[False]],
         "prop 2": [[0.6]],
@@ -567,17 +567,16 @@ def test_vertex_properties():
 
     assert g.at(2).vertex(1).properties.temporal == {
         "prop 2": [(2, 0.6)],
-        "prop 4": [(1, True), (2, False)],
-        "prop 1": [(1, 1), (2, 2)],
-        "prop 3": [(1, "hi")],
+        "prop 4": [(2, False)],
+        "prop 1": [(2, 2)],
     }
-    assert g.at(2).vertices.properties.temporal == {
+    assert g.before(3).vertices.properties.temporal == {
         "prop 2": [[(2, 0.6)]],
         "prop 4": [[(1, True), (2, False)]],
         "prop 1": [[(1, 1), (2, 2)]],
         "prop 3": [[(1, "hi")]],
     }
-    assert g.at(2).vertices.out_neighbours.properties.temporal == {
+    assert g.before(3).vertices.out_neighbours.properties.temporal == {
         "prop 2": [[[(2, 0.6)]]],
         "prop 4": [[[(1, True), (2, False)]]],
         "prop 1": [[[(1, 1), (2, 2)]]],
@@ -679,7 +678,7 @@ def test_edge_properties():
     assert g.at(1).edge(1, 2).properties.temporal.get("static prop") is None
 
     assert g.at(1).edge(1, 2).properties.constant.get("static prop") == 123
-    assert g.at(100).edge(1, 2).properties.constant.get("static prop") == 123
+    assert g.before(101).edge(1, 2).properties.constant.get("static prop") == 123
     assert g.edge(1, 2).properties.constant.get("static prop") == 123
     assert g.edge(1, 2).properties.constant.get("prop 4") is None
 
@@ -707,7 +706,7 @@ def test_edge_properties():
         "prop 4": True,
     }
 
-    assert g.at(2).edge(1, 2).properties == {
+    assert g.before(3).edge(1, 2).properties == {
         "prop 1": 2,
         "prop 4": False,
         "prop 2": 0.6,
@@ -725,9 +724,14 @@ def test_edge_properties():
 
     assert g.at(2).edge(1, 2).properties.temporal == {
         "prop 2": [(2, 0.6)],
-        "prop 4": [(1, True), (2, False)],
-        "prop 1": [(1, 1), (2, 2)],
-        "prop 3": [(1, "hi")],
+        "prop 4": [(2, False)],
+        "prop 1": [(2, 2)],
+    }
+
+    assert g.after(2).edge(1, 2).properties.temporal == {
+        "prop 2": [(3, 0.9)],
+        "prop 3": [(3, "hello")],
+        "prop 4": [(3, True)],
     }
 
     # testing property names
@@ -875,12 +879,20 @@ def test_save_load_graph():
 def test_graph_at():
     g = create_graph()
 
-    view = g.at(2)
+    view = g.at(1)
+    assert view.vertex(1).degree() == 2
+    assert view.vertex(2).degree() == 1
+
+    view = g.before(3)
     assert view.vertex(1).degree() == 3
     assert view.vertex(3).degree() == 1
 
-    view = g.at(7)
+    view = g.before(8)
     assert view.vertex(3).degree() == 2
+
+    view = g.after(6)
+    assert view.vertex(2).degree() == 1
+    assert view.vertex(3).degree() == 1
 
 
 def test_add_node_string():
@@ -917,7 +929,7 @@ def test_all_neighbours_window():
     g.add_edge(3, 3, 2, {})
     g.add_edge(4, 2, 4, {})
 
-    view = g.at(2)
+    view = g.before(3)
     v = view.vertex(2)
     assert list(v.window(0, 2).in_neighbours.id) == [1]
     assert list(v.window(0, 2).out_neighbours.id) == [3]
@@ -934,7 +946,7 @@ def test_all_degrees_window():
     g.add_edge(4, 2, 4, {})
     g.add_edge(5, 2, 1, {})
 
-    view = g.at(4)
+    view = g.before(5)
     v = view.vertex(2)
     assert v.window(0, 4).in_degree() == 3
     assert v.window(start=2).in_degree() == 2
@@ -957,7 +969,7 @@ def test_all_edge_window():
     g.add_edge(4, 2, 4, {})
     g.add_edge(5, 2, 1, {})
 
-    view = g.at(4)
+    view = g.before(5)
     v = view.vertex(2)
     assert sorted(v.window(0, 4).in_edges.src.id) == [1, 3, 4]
     assert sorted(v.window(end=4).in_edges.src.id) == [1, 3, 4]
@@ -1012,8 +1024,7 @@ def test_triplet_count():
     g.add_edge(0, 2, 3, {})
     g.add_edge(0, 3, 1, {})
 
-    v = g.at(1)
-    assert algorithms.triplet_count(v) == 3
+    assert algorithms.triplet_count(g) == 3
 
 
 def test_global_clustering_coeffficient():
@@ -1026,8 +1037,8 @@ def test_global_clustering_coeffficient():
     g.add_edge(0, 4, 1, {})
     g.add_edge(0, 5, 2, {})
 
-    v = g.at(1)
-    assert algorithms.global_clustering_coefficient(v) == 0.5454545454545454
+    assert algorithms.global_clustering_coefficient(g) == 0.5454545454545454
+    assert algorithms.global_clustering_coefficient(g.at(0)) == 0.5454545454545454
 
 
 def test_edge_time_apis():
@@ -1082,8 +1093,13 @@ def test_edge_earliest_latest_time():
 
     assert list(g.vertex(1).edges.earliest_time) == [0, 0]
     assert list(g.vertex(1).edges.latest_time) == [2, 2]
-    assert list(g.vertex(1).at(1).edges.earliest_time) == [0, 0]
+    assert list(g.vertex(1).at(1).edges.earliest_time) == [1, 1]
+    assert list(g.vertex(1).before(1).edges.earliest_time) == [0, 0]
+    assert list(g.vertex(1).after(1).edges.earliest_time) == [2, 2]
     assert list(g.vertex(1).at(1).edges.latest_time) == [1, 1]
+    assert list(g.vertex(1).before(1).edges.latest_time) == [0, 0]
+    assert list(g.vertex(1).after(1).edges.latest_time) == [2, 2]
+
 
 
 def test_vertex_earliest_time():
@@ -1093,9 +1109,14 @@ def test_vertex_earliest_time():
     g.add_vertex(2, 1, {})
 
     view = g.at(1)
-    assert view.vertex(1).earliest_time == 0
+    assert view.vertex(1).earliest_time == 1
     assert view.vertex(1).latest_time == 1
-    view = g.at(3)
+
+    view = g.after(0)
+    assert view.vertex(1).earliest_time == 1
+    assert view.vertex(1).latest_time == 2
+
+    view = g.before(3)
     assert view.vertex(1).earliest_time == 0
     assert view.vertex(1).latest_time == 2
 
@@ -1227,8 +1248,8 @@ def test_lotr_edge_history():
         31445,
         32656,
     ]
-    assert g.at(1000).edge("Frodo", "Gandalf").history() == [329, 555, 861]
-    assert g.edge("Frodo", "Gandalf").at(1000).history() == [329, 555, 861]
+    assert g.before(1000).edge("Frodo", "Gandalf").history() == [329, 555, 861]
+    assert g.edge("Frodo", "Gandalf").before(1000).history() == [329, 555, 861]
     assert g.window(100, 1000).edge("Frodo", "Gandalf").history() == [329, 555, 861]
     assert g.edge("Frodo", "Gandalf").window(100, 1000).history() == [329, 555, 861]
 
@@ -1316,7 +1337,7 @@ def test_window_size():
     g.add_vertex(1, 1)
     g.add_vertex(4, 4)
 
-    assert g.window_size() == 4
+    assert g.window_size == 4
 
 
 def test_time_index():

--- a/raphtory/src/algorithms/metrics/clustering_coefficient.rs
+++ b/raphtory/src/algorithms/metrics/clustering_coefficient.rs
@@ -91,9 +91,7 @@ mod cc_test {
             graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
         }
 
-        let graph_at = graph.at(1);
-
-        let results = clustering_coefficient(&graph_at);
+        let results = clustering_coefficient(&graph);
         assert_eq!(results, 0.3);
     }
 }

--- a/raphtory/src/algorithms/motifs/triplet_count.rs
+++ b/raphtory/src/algorithms/motifs/triplet_count.rs
@@ -159,7 +159,7 @@ mod triplet_test {
             graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
         }
         let exp_triplet_count = 20;
-        let results = triplet_count(&graph.at(1), None);
+        let results = triplet_count(&graph, None);
 
         assert_eq!(results, exp_triplet_count);
     }

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -782,10 +782,22 @@ mod db_tests {
         assert_eq!(res, 2);
 
         res = g.at(1).edge(1, 2).unwrap().earliest_time().unwrap();
+        assert_eq!(res, 1);
+
+        res = g.before(1).edge(1, 2).unwrap().earliest_time().unwrap();
         assert_eq!(res, 0);
+
+        res = g.after(1).edge(1, 2).unwrap().earliest_time().unwrap();
+        assert_eq!(res, 2);
 
         res = g.at(1).edge(1, 2).unwrap().latest_time().unwrap();
         assert_eq!(res, 1);
+
+        res = g.before(1).edge(1, 2).unwrap().latest_time().unwrap();
+        assert_eq!(res, 0);
+
+        res = g.after(1).edge(1, 2).unwrap().latest_time().unwrap();
+        assert_eq!(res, 2);
 
         let res_list: Vec<i64> = g
             .vertex(1)
@@ -813,7 +825,27 @@ mod db_tests {
             .earliest_time()
             .flatten()
             .collect();
+        assert_eq!(res_list, vec![1, 1]);
+
+        let res_list: Vec<i64> = g
+            .vertex(1)
+            .unwrap()
+            .before(1)
+            .edges()
+            .earliest_time()
+            .flatten()
+            .collect();
         assert_eq!(res_list, vec![0, 0]);
+
+        let res_list: Vec<i64> = g
+            .vertex(1)
+            .unwrap()
+            .after(1)
+            .edges()
+            .earliest_time()
+            .flatten()
+            .collect();
+        assert_eq!(res_list, vec![2, 2]);
 
         let res_list: Vec<i64> = g
             .vertex(1)
@@ -824,6 +856,26 @@ mod db_tests {
             .flatten()
             .collect();
         assert_eq!(res_list, vec![1, 1]);
+
+        let res_list: Vec<i64> = g
+            .vertex(1)
+            .unwrap()
+            .before(1)
+            .edges()
+            .latest_time()
+            .flatten()
+            .collect();
+        assert_eq!(res_list, vec![0, 0]);
+
+        let res_list: Vec<i64> = g
+            .vertex(1)
+            .unwrap()
+            .after(1)
+            .edges()
+            .latest_time()
+            .flatten()
+            .collect();
+        assert_eq!(res_list, vec![2, 2]);
     }
 
     #[test]
@@ -1158,8 +1210,14 @@ mod db_tests {
         assert_eq!(g.vertex(1).unwrap().earliest_time(), Some(1));
         assert_eq!(g.vertex(1).unwrap().latest_time(), Some(3));
 
-        assert_eq!(g.at(2).vertex(1).unwrap().earliest_time(), Some(1));
+        assert_eq!(g.at(2).vertex(1).unwrap().earliest_time(), Some(2));
         assert_eq!(g.at(2).vertex(1).unwrap().latest_time(), Some(2));
+
+        assert_eq!(g.before(2).vertex(1).unwrap().earliest_time(), Some(1));
+        assert_eq!(g.before(2).vertex(1).unwrap().latest_time(), Some(1));
+
+        assert_eq!(g.after(2).vertex(1).unwrap().earliest_time(), Some(3));
+        assert_eq!(g.after(2).vertex(1).unwrap().latest_time(), Some(3));
     }
 
     #[test]

--- a/raphtory/src/db/graph/vertex.rs
+++ b/raphtory/src/db/graph/vertex.rs
@@ -563,13 +563,25 @@ mod vertex_test {
         g.add_vertex(0, 1, NO_PROPS).unwrap();
         g.add_vertex(1, 1, NO_PROPS).unwrap();
         g.add_vertex(2, 1, NO_PROPS).unwrap();
-        let mut view = g.at(1);
+        let view = g.before(2);
         assert_eq!(view.vertex(1).expect("v").earliest_time().unwrap(), 0);
         assert_eq!(view.vertex(1).expect("v").latest_time().unwrap(), 1);
 
-        view = g.at(3);
+        let view = g.before(3);
         assert_eq!(view.vertex(1).expect("v").earliest_time().unwrap(), 0);
         assert_eq!(view.vertex(1).expect("v").latest_time().unwrap(), 2);
+
+        let view = g.after(0);
+        assert_eq!(view.vertex(1).expect("v").earliest_time().unwrap(), 1);
+        assert_eq!(view.vertex(1).expect("v").latest_time().unwrap(), 2);
+
+        let view = g.after(2);
+        assert_eq!(view.vertex(1), None);
+        assert_eq!(view.vertex(1), None);
+
+        let view = g.at(1);
+        assert_eq!(view.vertex(1).expect("v").earliest_time().unwrap(), 1);
+        assert_eq!(view.vertex(1).expect("v").latest_time().unwrap(), 1);
     }
 
     #[test]

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -802,4 +802,24 @@ mod test_deletions {
 
         assert_eq!(e.window(0, 3).latest_time(), Some(2));
     }
+
+    #[test]
+    fn test_view_start_end() {
+        let g = GraphWithDeletions::new();
+        let e = g.add_edge(0, 1, 2, NO_PROPS, None).unwrap();
+        assert_eq!(g.start(), Some(0));
+        assert_eq!(g.end(), Some(1));
+        e.delete(2, None).unwrap();
+        assert_eq!(g.start(), Some(0));
+        assert_eq!(g.end(), Some(3));
+        let w = g.window(g.start().unwrap(), g.end().unwrap());
+        assert!(g.has_edge(1, 2, Layer::All));
+        assert!(w.has_edge(1, 2, Layer::All));
+        assert_eq!(w.start(), Some(0));
+        assert_eq!(w.end(), Some(3));
+
+        e.add_updates(4, NO_PROPS, None).unwrap();
+        assert_eq!(g.start(), Some(0));
+        assert_eq!(g.end(), Some(5));
+    }
 }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -37,7 +37,6 @@ use std::{
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GraphWithDeletions {
     graph: Arc<InternalGraph>,
-    partial_windows: bool,
 }
 
 impl Static for GraphWithDeletions {}
@@ -46,7 +45,6 @@ impl From<InternalGraph> for GraphWithDeletions {
     fn from(value: InternalGraph) -> Self {
         Self {
             graph: Arc::new(value),
-            partial_windows: false,
         }
     }
 }
@@ -64,110 +62,75 @@ impl Display for GraphWithDeletions {
 }
 
 impl GraphWithDeletions {
-    pub fn ignore_deletions_in_window(&self) -> GraphWithDeletions {
-        Self {
-            graph: self.graph.clone(),
-            partial_windows: true,
-        }
-    }
-
-    pub fn include_deletions_in_window(&self) -> GraphWithDeletions {
-        Self {
-            graph: self.graph.clone(),
-            partial_windows: false,
-        }
-    }
-
-    fn edge_alive_at(&self, e: &EdgeStore, range: Range<i64>, layer_ids: &LayerIds) -> bool {
-        let t = if self.partial_windows {
-            range.start
-        } else {
-            range.end
+    fn edge_alive_at(&self, e: &EdgeStore, t: i64, layer_ids: &LayerIds) -> bool {
+        // FIXME: assumes additions are before deletions if at the same timestamp (need to have strict ordering/secondary index)
+        let (
+            first_addition,
+            first_deletion,
+            last_addition_before_start,
+            last_deletion_before_start,
+        ) = match layer_ids {
+            LayerIds::None => return false,
+            LayerIds::All => (
+                e.additions().iter().flat_map(|v| v.first()).min().copied(),
+                e.deletions().iter().flat_map(|v| v.first()).min().copied(),
+                e.additions()
+                    .iter()
+                    .flat_map(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
+                    .max(),
+                e.deletions()
+                    .iter()
+                    .flat_map(|v| v.range(i64::MIN..t).last().copied())
+                    .max(),
+            ),
+            LayerIds::One(l_id) => (
+                e.additions().get(*l_id).and_then(|v| v.first().copied()),
+                e.deletions().get(*l_id).and_then(|v| v.first().copied()),
+                e.additions()
+                    .get(*l_id)
+                    .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied()),
+                e.deletions()
+                    .get(*l_id)
+                    .and_then(|v| v.range(i64::MIN..t).last().copied()),
+            ),
+            LayerIds::Multiple(ids) => (
+                ids.iter()
+                    .flat_map(|l_id| e.additions().get(*l_id).and_then(|v| v.first()))
+                    .min()
+                    .copied(),
+                ids.iter()
+                    .flat_map(|l_id| e.deletions().get(*l_id).and_then(|v| v.first()))
+                    .min()
+                    .copied(),
+                ids.iter()
+                    .flat_map(|l_id| {
+                        e.additions()
+                            .get(*l_id)
+                            .and_then(|v| v.range(i64::MIN..t.saturating_add(1)).last().copied())
+                    })
+                    .max(),
+                ids.iter()
+                    .flat_map(|l_id| {
+                        e.deletions()
+                            .get(*l_id)
+                            .and_then(|v| v.range(i64::MIN..t).last().copied())
+                    })
+                    .max(),
+            ),
         };
 
-        let get_last_addition = |v: &TimeIndex<TimeIndexEntry>| {
-            if self.partial_windows {
-                v.range(i64::MIN..t.saturating_add(1)).last().copied()
-            } else {
-                v.range(i64::MIN..t).last().copied()
-            }
-        };
-
-        let (first_addition, first_deletion, last_addition_before, last_deletion_before) =
-            match layer_ids {
-                LayerIds::None => return false,
-                LayerIds::All => (
-                    e.additions().iter().flat_map(|v| v.first()).min().copied(),
-                    e.deletions().iter().flat_map(|v| v.first()).min().copied(),
-                    e.additions()
-                        .iter()
-                        .flat_map(|v| get_last_addition(v))
-                        .max(),
-                    e.deletions()
-                        .iter()
-                        .flat_map(|v| v.range(i64::MIN..t).last().copied())
-                        .max(),
-                ),
-                LayerIds::One(l_id) => (
-                    e.additions().get(*l_id).and_then(|v| v.first().copied()),
-                    e.deletions().get(*l_id).and_then(|v| v.first().copied()),
-                    e.additions().get(*l_id).and_then(|v| get_last_addition(v)),
-                    e.deletions()
-                        .get(*l_id)
-                        .and_then(|v| v.range(i64::MIN..t).last().copied()),
-                ),
-                LayerIds::Multiple(ids) => (
-                    ids.iter()
-                        .flat_map(|l_id| e.additions().get(*l_id).and_then(|v| v.first()))
-                        .min()
-                        .copied(),
-                    ids.iter()
-                        .flat_map(|l_id| e.deletions().get(*l_id).and_then(|v| v.first()))
-                        .min()
-                        .copied(),
-                    ids.iter()
-                        .flat_map(|l_id| {
-                            e.additions().get(*l_id).and_then(|v| get_last_addition(v))
-                        })
-                        .max(),
-                    ids.iter()
-                        .flat_map(|l_id| {
-                            e.deletions()
-                                .get(*l_id)
-                                .and_then(|v| v.range(i64::MIN..t).last().copied())
-                        })
-                        .max(),
-                ),
-            };
-
-        if self.partial_windows {
-            (first_deletion < first_addition
-                && first_deletion
-                    .filter(|v| *v >= TimeIndexEntry::start(t))
-                    .is_some())
-                || last_addition_before > last_deletion_before
-        } else {
-            (first_deletion < first_addition
-                && first_deletion
-                    .filter(|v| *v >= TimeIndexEntry::end(t))
-                    .is_some())
-                || match (last_addition_before, last_deletion_before) {
-                    (Some(last_addition_before), Some(last_deletion_before)) => {
-                        (last_addition_before.0 > last_deletion_before.0)
-                            || (last_addition_before.0 == last_deletion_before.0
-                                && last_addition_before.0 == t - 1) //this is the case as we only want to include this entity if it is EXACTLY the time it was added/deleted
-                    }
-                    (Some(_), None) => true,
-                    (None, Some(_)) => false,
-                    (None, None) => false,
-                }
-        }
+        // None is less than any value (see test below)
+        (first_deletion < first_addition
+            && first_deletion
+                .filter(|v| *v >= TimeIndexEntry::start(t))
+                .is_some())
+            || last_addition_before_start > last_deletion_before_start
     }
 
     fn vertex_alive_at(
         &self,
         v: &VertexStore,
-        w: Range<i64>,
+        t: i64,
         layers: &LayerIds,
         edge_filter: Option<&EdgeFilter>,
     ) -> bool {
@@ -176,7 +139,7 @@ impl GraphWithDeletions {
             .map(|eref| edges.get(eref.pid().into()))
             .find(|e| {
                 edge_filter.map(|f| f(e, layers)).unwrap_or(true)
-                    && self.edge_alive_at(e, w.clone(), layers)
+                    && self.edge_alive_at(e, t, layers)
             })
             .is_some()
     }
@@ -184,7 +147,6 @@ impl GraphWithDeletions {
     pub fn new() -> Self {
         Self {
             graph: Arc::new(InternalGraph::default()),
-            partial_windows: false,
         }
     }
 
@@ -251,7 +213,6 @@ impl InternalMaterialize for GraphWithDeletions {
     fn new_base_graph(&self, graph: InternalGraph) -> MaterializedGraph {
         MaterializedGraph::PersistentGraph(GraphWithDeletions {
             graph: Arc::new(graph),
-            partial_windows: false,
         })
     }
 
@@ -311,18 +272,12 @@ impl TimeSemantics for GraphWithDeletions {
         edge_filter: Option<&EdgeFilter>,
     ) -> bool {
         let v = self.graph.inner().storage.get_node(v);
-        v.active(w.clone()) || self.vertex_alive_at(&v, w, layer_ids, edge_filter)
+        v.active(w.clone()) || self.vertex_alive_at(&v, w.start, layer_ids, edge_filter)
     }
 
     fn include_edge_window(&self, e: &EdgeStore, w: Range<i64>, layer_ids: &LayerIds) -> bool {
-        if self.partial_windows {
-            //soft deletions
-            // includes edge if it is alive at the start of the window or added during the window
-            e.active(layer_ids, w.clone()) || self.edge_alive_at(e, w, layer_ids)
-        } else {
-            //includes edge if alive at the end of the window
-            self.edge_alive_at(e, w, layer_ids)
-        }
+        // includes edge if it is alive at the start of the window or added during the window
+        e.active(layer_ids, w.clone()) || self.edge_alive_at(e, w.start, layer_ids)
     }
 
     fn vertex_history(&self, v: VID) -> Vec<i64> {
@@ -335,7 +290,7 @@ impl TimeSemantics for GraphWithDeletions {
 
     fn edge_exploded(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<EdgeRef> {
         //Fixme: Need support for duration on exploded edges
-        if self.edge_alive_at(&self.core_edge(e.pid()), i64::MIN..i64::MIN, &layer_ids) {
+        if self.edge_alive_at(&self.core_edge(e.pid()), i64::MIN, &layer_ids) {
             Box::new(
                 iter::once(e.at(i64::MIN.into())).chain(self.graph.edge_window_exploded(
                     e,
@@ -360,7 +315,7 @@ impl TimeSemantics for GraphWithDeletions {
     ) -> BoxedIter<EdgeRef> {
         // FIXME: Need better iterators on LockedView that capture the guard
         let entry = self.core_edge(e.pid());
-        if self.edge_alive_at(&entry, w.clone(), &layer_ids) {
+        if self.edge_alive_at(&entry, w.start, &layer_ids) {
             Box::new(
                 iter::once(e.at(w.start.into())).chain(self.graph.edge_window_exploded(
                     e,
@@ -397,7 +352,7 @@ impl TimeSemantics for GraphWithDeletions {
     fn edge_earliest_time(&self, e: EdgeRef, layer_ids: LayerIds) -> Option<i64> {
         e.time().map(|ti| *ti.t()).or_else(|| {
             let entry = self.core_edge(e.pid());
-            if self.edge_alive_at(&entry, i64::MIN..i64::MIN, &layer_ids) {
+            if self.edge_alive_at(&entry, i64::MIN, &layer_ids) {
                 Some(i64::MIN)
             } else {
                 self.edge_additions(e, layer_ids).first().map(|ti| *ti.t())
@@ -412,7 +367,7 @@ impl TimeSemantics for GraphWithDeletions {
         layer_ids: LayerIds,
     ) -> Option<i64> {
         let entry = self.core_edge(e.pid());
-        if self.edge_alive_at(&entry, w.clone(), &layer_ids) {
+        if self.edge_alive_at(&entry, w.start, &layer_ids) {
             Some(w.start)
         } else {
             self.edge_additions(e, layer_ids).range(w).first_t()
@@ -433,7 +388,7 @@ impl TimeSemantics for GraphWithDeletions {
             )),
             None => {
                 let entry = self.core_edge(e.pid());
-                if self.edge_alive_at(&entry, i64::MIN..i64::MAX, &layer_ids) {
+                if self.edge_alive_at(&entry, i64::MAX, &layer_ids) {
                     Some(i64::MAX)
                 } else {
                     self.edge_deletions(e, layer_ids).last_t()
@@ -461,7 +416,7 @@ impl TimeSemantics for GraphWithDeletions {
             )),
             None => {
                 let entry = self.core_edge(e.pid());
-                if self.edge_alive_at(&entry, w.end - 1..w.end - 1, &layer_ids) {
+                if self.edge_alive_at(&entry, w.end - 1, &layer_ids) {
                     Some(w.end - 1)
                 } else {
                     self.edge_deletions(e, layer_ids).range(w).last_t()
@@ -582,7 +537,7 @@ impl TimeSemantics for GraphWithDeletions {
         match prop {
             Some(p) => {
                 let entry = self.core_edge(e.pid());
-                if self.edge_alive_at(&entry, start..end, &layer_ids) {
+                if self.edge_alive_at(&entry, start, &layer_ids) {
                     p.last_before(start.saturating_add(1))
                         .into_iter()
                         .map(|(_, v)| (start, v))
@@ -774,21 +729,11 @@ mod test_deletions {
         g.add_edge(2, 3, 4, [("test", "test")], None).unwrap();
         g.delete_edge(2, 3, 4, None).unwrap();
 
-        //for this I am assuming that deletions always happen after the creation
-        assert!(!g.window(0, 1).has_edge(1, 2, Layer::Default));
+        assert!(g.window(0, 1).has_edge(1, 2, Layer::Default));
         assert!(!g.window(0, 2).has_edge(3, 4, Layer::Default));
         assert!(g.window(1, 2).has_edge(1, 2, Layer::Default));
-        assert!(g.at(1).has_edge(1, 2, Layer::Default));
         assert!(g.window(2, 3).has_edge(3, 4, Layer::Default));
         assert!(!g.window(3, 4).has_edge(3, 4, Layer::Default));
-
-        let g2 = g.ignore_deletions_in_window();
-
-        assert!(g2.window(0, 1).has_edge(1, 2, Layer::Default));
-        assert!(!g2.window(0, 2).has_edge(3, 4, Layer::Default));
-        assert!(g2.window(1, 2).has_edge(1, 2, Layer::Default));
-        assert!(g2.window(2, 3).has_edge(3, 4, Layer::Default));
-        assert!(!g2.window(3, 4).has_edge(3, 4, Layer::Default));
     }
 
     #[test]

--- a/raphtory/src/graph_loader/mod.rs
+++ b/raphtory/src/graph_loader/mod.rs
@@ -186,14 +186,10 @@ mod graph_loader_test {
         let g_at_empty = g.at(1);
         let g_astart = g.at(7059);
         let g_at_another = g.at(28373);
-        let g_at_max = g.at(i64::MAX);
-        let g_at_min = g.at(i64::MIN);
 
         assert_eq!(g_at_empty.count_vertices(), 0);
-        assert_eq!(g_astart.count_vertices(), 70);
-        assert_eq!(g_at_another.count_vertices(), 123);
-        assert_eq!(g_at_max.count_vertices(), 139);
-        assert_eq!(g_at_min.count_vertices(), 0);
+        assert_eq!(g_astart.count_vertices(), 3);
+        assert_eq!(g_at_another.count_vertices(), 4);
     }
 
     #[test]

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -746,6 +746,13 @@ impl PyEdges {
         .into()
     }
 
+    /// Filter edges to only include events before `end`.
+    ///
+    /// Arguments:
+    ///     end(int): The end time of the window (exclusive).
+    ///
+    /// Returns:
+    ///    A list of edges with the window filter applied.
     fn before(&self, end: PyTime) -> PyEdges {
         let builder = self.builder.clone();
         let end = end.into_time();
@@ -762,6 +769,13 @@ impl PyEdges {
         .into()
     }
 
+    /// Filter edges to only include events after `start`.
+    ///
+    /// Arguments:
+    ///     start(int): The start time of the window (exclusive).
+    ///
+    /// Returns:
+    ///    A list of edges with the window filter applied.
     fn after(&self, start: PyTime) -> PyEdges {
         let builder = self.builder.clone();
         let start = start.into_time();

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -6,7 +6,10 @@
 //!
 use crate::{
     core::{
-        utils::{errors::GraphError, time::error::ParseTimeError},
+        utils::{
+            errors::GraphError,
+            time::{error::ParseTimeError, IntoTime},
+        },
         ArcStr, Direction,
     },
     db::{
@@ -211,103 +214,6 @@ impl PyEdge {
         self.edge.dst().into()
     }
 
-    //******  Perspective APIS  ******//
-
-    /// Get the start time of the Edge.
-    ///
-    /// Returns:
-    ///  The start time of the Edge.
-    #[getter]
-    pub fn start(&self) -> Option<i64> {
-        self.edge.start()
-    }
-
-    /// Get the start datetime of the Edge.
-    ///
-    /// Returns:
-    ///     The start datetime of the Edge.
-    #[getter]
-    pub fn start_date_time(&self) -> Option<NaiveDateTime> {
-        let start_time = self.edge.start()?;
-        NaiveDateTime::from_timestamp_millis(start_time)
-    }
-
-    /// Get the end time of the Edge.
-    ///
-    /// Returns:
-    ///   The end time of the Edge.
-    #[getter]
-    pub fn end(&self) -> Option<i64> {
-        self.edge.end()
-    }
-
-    /// Get the end datetime of the Edge.
-    ///
-    /// Returns:
-    ///    The end datetime of the Edge
-    #[getter]
-    pub fn end_date_time(&self) -> Option<NaiveDateTime> {
-        let end_time = self.edge.end()?;
-        NaiveDateTime::from_timestamp_millis(end_time)
-    }
-
-    /// Get the duration of the Edge.
-    ///
-    /// Arguments:
-    ///   step (int or str): The step size to use when calculating the duration.
-    ///
-    /// Returns:
-    ///   A set of windows containing edges that fall in the time period
-    #[pyo3(signature = (step))]
-    fn expanding(
-        &self,
-        step: PyInterval,
-    ) -> Result<WindowSet<EdgeView<DynamicGraph>>, ParseTimeError> {
-        self.edge.expanding(step)
-    }
-
-    /// Get a set of Edge windows for a given window size, step, start time
-    /// and end time using rolling window.
-    /// A rolling window is a window that moves forward by `step` size at each iteration.
-    ///
-    /// Arguments:
-    ///   window (int or str): The size of the window.
-    ///   step (int or str): The step size to use when calculating the duration. (optional)
-    ///
-    /// Returns:
-    ///   A set of windows containing edges that fall in the time period
-    fn rolling(
-        &self,
-        window: PyInterval,
-        step: Option<PyInterval>,
-    ) -> Result<WindowSet<EdgeView<DynamicGraph>>, ParseTimeError> {
-        self.edge.rolling(window, step)
-    }
-
-    /// Get a new Edge with the properties of this Edge within the specified time window.
-    ///
-    /// Arguments:
-    ///   start (int or str): The start time of the window (optional).
-    ///   end (int or str): The end time of the window (optional).
-    ///
-    /// Returns:
-    ///   A new Edge with the properties of this Edge within the specified time window.
-    #[pyo3(signature = (start = None, end = None))]
-    pub fn window(
-        &self,
-        start: Option<PyTime>,
-        end: Option<PyTime>,
-    ) -> EdgeView<WindowedGraph<DynamicGraph>> {
-        self.edge
-            .window(start.unwrap_or(PyTime::MIN), end.unwrap_or(PyTime::MAX))
-    }
-    /// Get a new Edge with the properties of this Edge within the specified layer.
-    ///
-    /// Arguments:
-    ///   layer_names (str): Layer to be included in the new edge.
-    ///
-    /// Returns:
-    ///   A new Edge with the properties of this Edge within the specified time window.
     #[pyo3(signature = (name))]
     pub fn layer(&self, name: String) -> PyResult<EdgeView<LayeredGraph<DynamicGraph>>> {
         if let Some(edge) = self.edge.layer(name.clone()) {
@@ -342,18 +248,6 @@ impl PyEdge {
                 format!("Layers {layer_names:?} not available for edge, available layers: {available_layers:?}"),
             ))
         }
-    }
-
-    /// Get a new Edge with the properties of this Edge at a specified time.
-    ///
-    /// Arguments:
-    ///   end (int, str or datetime(utrc)): The time to get the properties at.
-    ///
-    /// Returns:
-    ///   A new Edge with the properties of this Edge at a specified time.
-    #[pyo3(signature = (end))]
-    pub fn at(&self, end: PyTime) -> EdgeView<WindowedGraph<DynamicGraph>> {
-        self.edge.at(end)
     }
 
     /// Explodes an Edge into a list of PyEdges. This is useful when you want to iterate over
@@ -456,6 +350,8 @@ impl PyEdge {
         self.repr()
     }
 }
+
+impl_timeops!(PyEdge, edge, EdgeView<DynamicGraph>, "edge");
 
 impl Repr for PyEdge {
     fn repr(&self) -> String {
@@ -843,6 +739,38 @@ impl PyEdges {
                 Box::new(
                     builder()
                         .map(move |e| e.at(end.clone()))
+                        .map(|e| <EdgeView<DynamicGraph>>::from(e)),
+                );
+            box_builder
+        })
+        .into()
+    }
+
+    fn before(&self, end: PyTime) -> PyEdges {
+        let builder = self.builder.clone();
+        let end = end.into_time();
+
+        (move || {
+            let box_builder: Box<(dyn Iterator<Item = EdgeView<DynamicGraph>> + Send + 'static)> =
+                Box::new(
+                    builder()
+                        .map(move |e| e.before(end))
+                        .map(|e| <EdgeView<DynamicGraph>>::from(e)),
+                );
+            box_builder
+        })
+        .into()
+    }
+
+    fn after(&self, start: PyTime) -> PyEdges {
+        let builder = self.builder.clone();
+        let start = start.into_time();
+
+        (move || {
+            let box_builder: Box<(dyn Iterator<Item = EdgeView<DynamicGraph>> + Send + 'static)> =
+                Box::new(
+                    builder()
+                        .map(move |e| e.after(start))
                         .map(|e| <EdgeView<DynamicGraph>>::from(e)),
                 );
             box_builder

--- a/raphtory/src/python/graph/graph_with_deletions.rs
+++ b/raphtory/src/python/graph/graph_with_deletions.rs
@@ -88,13 +88,6 @@ impl PyGraphWithDeletions {
         )
     }
 
-    pub fn include_deletions_in_window(&self, py: Python) -> PyObject {
-        self.graph.include_deletions_in_window().into_py(py)
-    }
-
-    pub fn ignore_deletions_in_window(&self, py: Python) -> PyObject {
-        self.graph.ignore_deletions_in_window().into_py(py)
-    }
     /// Adds a new vertex with the given id and properties to the graph.
     ///
     /// Arguments:

--- a/raphtory/src/python/graph/views/graph_view.rs
+++ b/raphtory/src/python/graph/views/graph_view.rs
@@ -243,119 +243,6 @@ impl PyGraphView {
         (move || clone.edges()).into()
     }
 
-    //******  Perspective APIS  ******//
-
-    /// Returns the default start time for perspectives over the view
-    ///
-    /// Returns:
-    ///     the default start time for perspectives over the view
-    #[getter]
-    pub fn start(&self) -> Option<i64> {
-        self.graph.start()
-    }
-
-    /// Returns the default start datetime for perspectives over the view
-    ///
-    /// Returns:
-    ///     the default start datetime for perspectives over the view
-    #[getter]
-    pub fn start_date_time(&self) -> Option<NaiveDateTime> {
-        let start_time = self.graph.start()?;
-        NaiveDateTime::from_timestamp_millis(start_time)
-    }
-
-    /// Returns the default end time for perspectives over the view
-    ///
-    /// Returns:
-    ///    the default end time for perspectives over the view
-    #[getter]
-    pub fn end(&self) -> Option<i64> {
-        self.graph.end()
-    }
-
-    #[doc = window_size_doc_string!()]
-    pub fn window_size(&self) -> Option<u64> {
-        self.graph.window_size()
-    }
-
-    /// Returns the default end datetime for perspectives over the view
-    ///
-    /// Returns:
-    ///    the default end datetime for perspectives over the view
-    #[getter]
-    pub fn end_date_time(&self) -> Option<NaiveDateTime> {
-        let end_time = self.graph.end()?;
-        NaiveDateTime::from_timestamp_millis(end_time)
-    }
-
-    /// Creates a `WindowSet` with the given `step` size and optional `start` and `end` times,    
-    /// using an expanding window.
-    ///
-    /// An expanding window is a window that grows by `step` size at each iteration.
-    ///
-    /// Arguments:
-    ///     step (int) : the size of the window
-    ///     start (int): the start time of the window (optional)
-    ///     end (int): the end time of the window (optional)
-    ///
-    /// Returns:
-    ///     A `WindowSet` with the given `step` size and optional `start` and `end` times,
-    #[pyo3(signature = (step))]
-    fn expanding(&self, step: PyInterval) -> Result<WindowSet<DynamicGraph>, ParseTimeError> {
-        self.graph.expanding(step)
-    }
-
-    /// Creates a `WindowSet` with the given `window` size and optional `step`, `start` and `end` times,
-    /// using a rolling window.
-    ///
-    /// A rolling window is a window that moves forward by `step` size at each iteration.
-    ///
-    /// Arguments:
-    ///     window (int): the size of the window
-    ///     step (int): the size of the step (optional)
-    ///     start (int): the start time of the window (optional)
-    ///     end: the end time of the window (optional)
-    ///
-    /// Returns:
-    ///  a `WindowSet` with the given `window` size and optional `step`, `start` and `end` times,
-    fn rolling(
-        &self,
-        window: PyInterval,
-        step: Option<PyInterval>,
-    ) -> Result<WindowSet<DynamicGraph>, ParseTimeError> {
-        self.graph.rolling(window, step)
-    }
-
-    /// Create a view including all events between `start` (inclusive) and `end` (exclusive)
-    ///
-    /// Arguments:
-    ///   start (int): the start time of the window (optional)
-    ///   end (int): the end time of the window (optional)
-    ///
-    /// Returns:
-    ///     a view including all events between `start` (inclusive) and `end` (exclusive)
-    #[pyo3(signature = (start=None, end=None))]
-    pub fn window(
-        &self,
-        start: Option<PyTime>,
-        end: Option<PyTime>,
-    ) -> WindowedGraph<DynamicGraph> {
-        self.graph
-            .window(start.unwrap_or(PyTime::MIN), end.unwrap_or(PyTime::MAX))
-    }
-
-    /// Create a view including all events until `end` (inclusive)
-    ///
-    /// Arguments:
-    ///     end (int) : the end time of the window
-    ///
-    /// Returns:
-    ///     a view including all events until `end` (inclusive)
-    #[pyo3(signature = (end))]
-    pub fn at(&self, end: PyTime) -> WindowedGraph<DynamicGraph> {
-        self.graph.at(end)
-    }
-
     #[doc = default_layer_doc_string!()]
     pub fn default_layer(&self) -> LayeredGraph<DynamicGraph> {
         self.graph.default_layer()
@@ -415,6 +302,8 @@ impl PyGraphView {
         self.repr()
     }
 }
+
+impl_timeops!(PyGraphView, graph, DynamicGraph, "graph");
 
 impl Repr for PyGraphView {
     fn repr(&self) -> String {

--- a/raphtory/src/python/types/macros/mod.rs
+++ b/raphtory/src/python/types/macros/mod.rs
@@ -4,3 +4,6 @@ pub mod iterable;
 pub mod nested_iterable;
 #[macro_use]
 pub mod cmp;
+
+#[macro_use]
+pub mod timeops;

--- a/raphtory/src/python/types/macros/timeops.rs
+++ b/raphtory/src/python/types/macros/timeops.rs
@@ -8,7 +8,7 @@ macro_rules! impl_timeops {
     ($obj:ty, $field:ident, $base_type:ty, $name:literal) => {
         #[pyo3::pymethods]
         impl $obj {
-            #[doc = concat!(r" Gets the earliest time that this ", $name, r" is valid")]
+            #[doc = concat!(r" Gets the start time for rolling and expanding windows for this ", $name)]
             ///
             /// Returns:
             #[doc = concat!(r"    The earliest time that this ", $name, r" is valid or None if the ", $name, r" is valid for all times.")]
@@ -17,69 +17,64 @@ macro_rules! impl_timeops {
                 self.$field.start()
             }
 
-            /// Gets the earliest datetime that this vertex is valid
+            #[doc = concat!(r" Gets the earliest datetime that this ", $name, r" is valid")]
             ///
             /// Returns:
-            ///     The earliest datetime that this vertex is valid or None if the vertex is valid for all times.
+            #[doc = concat!(r"     The earliest datetime that this ", $name, r" is valid or None if the ", $name, r" is valid for all times.")]
             #[getter]
             pub fn start_date_time(&self) -> Option<NaiveDateTime> {
                 let start_time = self.$field.start()?;
                 NaiveDateTime::from_timestamp_millis(start_time)
             }
 
-            /// Gets the latest time that this vertex is valid.
+            #[doc = concat!(r" Gets the latest time that this ", $name, r" is valid.")]
             ///
             /// Returns:
-            ///   The latest time that this vertex is valid or None if the vertex is valid for all times.
+            #[doc = concat!("   The latest time that this ", $name, r" is valid or None if the ", $name, r" is valid for all times.")]
             #[getter]
             pub fn end(&self) -> Option<i64> {
                 self.$field.end()
             }
 
-            /// Gets the latest datetime that this vertex is valid
+            #[doc = concat!(r" Gets the latest datetime that this ", $name, r" is valid")]
             ///
             /// Returns:
-            ///     The latest datetime that this vertex is valid or None if the vertex is valid for all times.
+            #[doc = concat!(r"     The latest datetime that this ", $name, r" is valid or None if the ", $name, r" is valid for all times.")]
             #[getter]
             pub fn end_date_time(&self) -> Option<NaiveDateTime> {
                 let end_time = self.$field.end()?;
                 NaiveDateTime::from_timestamp_millis(end_time)
             }
 
+            #[doc = concat!(r" Get the window size (difference between start and end) for this ", $name)]
             #[getter]
             pub fn window_size(&self) -> Option<u64> {
                 self.$field.window_size()
             }
 
-            /// Creates a `PyVertexWindowSet` with the given `step` size and optional `start` and `end` times,
-            /// using an expanding window.
+            /// Creates a `WindowSet` with the given `step` size using an expanding window.
             ///
             /// An expanding window is a window that grows by `step` size at each iteration.
-            /// This will tell you whether a vertex exists at different points in the window and what
-            /// its properties are at those points.
             ///
             /// Arguments:
             ///     step (int): The step size of the window.
             ///
             /// Returns:
-            ///     A `PyVertexWindowSet` object.
+            ///     A `WindowSet` object.
             fn expanding(&self, step: PyInterval) -> Result<WindowSet<$base_type>, ParseTimeError> {
                 self.$field.expanding(step)
             }
 
-            /// Creates a `PyVertexWindowSet` with the given `window` size and optional `step`, `start` and `end` times,
-            /// using a rolling window.
+            /// Creates a `WindowSet` with the given `window` size and optional `step` using a rolling window.
             ///
             /// A rolling window is a window that moves forward by `step` size at each iteration.
-            /// This will tell you whether a vertex exists at different points in the window and what
-            /// its properties are at those points.
             ///
             /// Arguments:
             ///     window: The size of the window.
             ///     step: The step size of the window. Defaults to the window size.
             ///
             /// Returns:
-            ///     A `PyVertexWindowSet` object.
+            ///     A `WindowSet` object.
             fn rolling(
                 &self,
                 window: PyInterval,
@@ -88,14 +83,14 @@ macro_rules! impl_timeops {
                 self.$field.rolling(window, step)
             }
 
-            // #[doc =r" Create a view of the `{}` including all events between `start` (inclusive) and `end` (exclusive)", stringify!($obj))]
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events between `start` (inclusive) and `end` (exclusive)")]
             ///
             /// Arguments:
-            ///     start (int, str or datetime(utc)): The start time of the window. Defaults to the start time of the vertex.
-            ///     end (int, str or datetime(utc)): The end time of the window. Defaults to the end time of the vertex.
+            #[doc = concat!(r"     start: The start time of the window. Defaults to the start time of the ", $name, r".")]
+            #[doc = concat!(r"     end: The end time of the window. Defaults to the end time of the ", $name, r".")]
             ///
             /// Returns:
-            ///    A `PyVertex` object.
+            #[doc = concat!("r    A ", $name, " object.")]
             #[pyo3(signature = (start = None, end = None))]
             pub fn window(
                 &self,
@@ -106,22 +101,35 @@ macro_rules! impl_timeops {
                     .window(start.unwrap_or(PyTime::MIN), end.unwrap_or(PyTime::MAX))
             }
 
-            /// Create a view of the vertex including all events at `t`.
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events at `time`.")]
             ///
             /// Arguments:
-            ///     end (int, str or datetime(utc)): The time of the window.
+            ///     time: The time of the window.
             ///
             /// Returns:
-            ///     A `PyVertex` object.
-            #[pyo3(signature = (end))]
-            pub fn at(&self, end: PyTime) -> <$base_type as TimeOps>::WindowedViewType {
-                self.$field.at(end)
+            #[doc = concat!(r"     A ", $name, r" object.")]
+            pub fn at(&self, time: PyTime) -> <$base_type as TimeOps>::WindowedViewType {
+                self.$field.at(time)
             }
 
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events before `end` (exclusive).")]
+            ///
+            /// Arguments:
+            ///     end: The end time of the window.
+            ///
+            /// Returns:
+            #[doc = concat!(r"     A ", $name, r" object.")]
             pub fn before(&self, end: PyTime) -> <$base_type as TimeOps>::WindowedViewType {
                 self.$field.before(end)
             }
 
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events after `start` (exclusive).")]
+            ///
+            /// Arguments:
+            ///     start: The start time of the window.
+            ///
+            /// Returns:
+            #[doc = concat!(r"     A ", $name, r" object.")]
             pub fn after(&self, start: PyTime) -> <$base_type as TimeOps>::WindowedViewType {
                 self.$field.after(start)
             }

--- a/raphtory/src/python/types/macros/timeops.rs
+++ b/raphtory/src/python/types/macros/timeops.rs
@@ -1,9 +1,11 @@
 /// Macro for implementing all the timeops methods on a python wrapper
 ///
 /// # Arguments
-/// * obj: The name of the struct the methods should be implemented for
+/// * obj: The struct the methods should be implemented for
 /// * field: The name of the struct field holding the rust struct implementing `TimeOps`
-/// * window_type: The `WindowViewType` of `field` (note that this should have an `IntoPy<PyObject>` implementation
+/// * base_type: The rust type of `field` (note that `<$base_type as TimeOps>::WindowedViewType`
+///              and `WindowSet<$base_type>` should have an `IntoPy<PyObject>` implementation)
+/// * name: The name of the object that appears in the docstring
 macro_rules! impl_timeops {
     ($obj:ty, $field:ident, $base_type:ty, $name:literal) => {
         #[pyo3::pymethods]

--- a/raphtory/src/python/types/macros/timeops.rs
+++ b/raphtory/src/python/types/macros/timeops.rs
@@ -1,0 +1,130 @@
+/// Macro for implementing all the timeops methods on a python wrapper
+///
+/// # Arguments
+/// * obj: The name of the struct the methods should be implemented for
+/// * field: The name of the struct field holding the rust struct implementing `TimeOps`
+/// * window_type: The `WindowViewType` of `field` (note that this should have an `IntoPy<PyObject>` implementation
+macro_rules! impl_timeops {
+    ($obj:ty, $field:ident, $base_type:ty, $name:literal) => {
+        #[pyo3::pymethods]
+        impl $obj {
+            #[doc = concat!(r" Gets the earliest time that this ", $name, r" is valid")]
+            ///
+            /// Returns:
+            #[doc = concat!(r"    The earliest time that this ", $name, r" is valid or None if the ", $name, r" is valid for all times.")]
+            #[getter]
+            pub fn start(&self) -> Option<i64> {
+                self.$field.start()
+            }
+
+            /// Gets the earliest datetime that this vertex is valid
+            ///
+            /// Returns:
+            ///     The earliest datetime that this vertex is valid or None if the vertex is valid for all times.
+            #[getter]
+            pub fn start_date_time(&self) -> Option<NaiveDateTime> {
+                let start_time = self.$field.start()?;
+                NaiveDateTime::from_timestamp_millis(start_time)
+            }
+
+            /// Gets the latest time that this vertex is valid.
+            ///
+            /// Returns:
+            ///   The latest time that this vertex is valid or None if the vertex is valid for all times.
+            #[getter]
+            pub fn end(&self) -> Option<i64> {
+                self.$field.end()
+            }
+
+            /// Gets the latest datetime that this vertex is valid
+            ///
+            /// Returns:
+            ///     The latest datetime that this vertex is valid or None if the vertex is valid for all times.
+            #[getter]
+            pub fn end_date_time(&self) -> Option<NaiveDateTime> {
+                let end_time = self.$field.end()?;
+                NaiveDateTime::from_timestamp_millis(end_time)
+            }
+
+            #[getter]
+            pub fn window_size(&self) -> Option<u64> {
+                self.$field.window_size()
+            }
+
+            /// Creates a `PyVertexWindowSet` with the given `step` size and optional `start` and `end` times,
+            /// using an expanding window.
+            ///
+            /// An expanding window is a window that grows by `step` size at each iteration.
+            /// This will tell you whether a vertex exists at different points in the window and what
+            /// its properties are at those points.
+            ///
+            /// Arguments:
+            ///     step (int): The step size of the window.
+            ///
+            /// Returns:
+            ///     A `PyVertexWindowSet` object.
+            fn expanding(&self, step: PyInterval) -> Result<WindowSet<$base_type>, ParseTimeError> {
+                self.$field.expanding(step)
+            }
+
+            /// Creates a `PyVertexWindowSet` with the given `window` size and optional `step`, `start` and `end` times,
+            /// using a rolling window.
+            ///
+            /// A rolling window is a window that moves forward by `step` size at each iteration.
+            /// This will tell you whether a vertex exists at different points in the window and what
+            /// its properties are at those points.
+            ///
+            /// Arguments:
+            ///     window: The size of the window.
+            ///     step: The step size of the window. Defaults to the window size.
+            ///
+            /// Returns:
+            ///     A `PyVertexWindowSet` object.
+            fn rolling(
+                &self,
+                window: PyInterval,
+                step: Option<PyInterval>,
+            ) -> Result<WindowSet<$base_type>, ParseTimeError> {
+                self.$field.rolling(window, step)
+            }
+
+            // #[doc =r" Create a view of the `{}` including all events between `start` (inclusive) and `end` (exclusive)", stringify!($obj))]
+            ///
+            /// Arguments:
+            ///     start (int, str or datetime(utc)): The start time of the window. Defaults to the start time of the vertex.
+            ///     end (int, str or datetime(utc)): The end time of the window. Defaults to the end time of the vertex.
+            ///
+            /// Returns:
+            ///    A `PyVertex` object.
+            #[pyo3(signature = (start = None, end = None))]
+            pub fn window(
+                &self,
+                start: Option<PyTime>,
+                end: Option<PyTime>,
+            ) -> <$base_type as TimeOps>::WindowedViewType {
+                self.$field
+                    .window(start.unwrap_or(PyTime::MIN), end.unwrap_or(PyTime::MAX))
+            }
+
+            /// Create a view of the vertex including all events at `t`.
+            ///
+            /// Arguments:
+            ///     end (int, str or datetime(utc)): The time of the window.
+            ///
+            /// Returns:
+            ///     A `PyVertex` object.
+            #[pyo3(signature = (end))]
+            pub fn at(&self, end: PyTime) -> <$base_type as TimeOps>::WindowedViewType {
+                self.$field.at(end)
+            }
+
+            pub fn before(&self, end: PyTime) -> <$base_type as TimeOps>::WindowedViewType {
+                self.$field.before(end)
+            }
+
+            pub fn after(&self, start: PyTime) -> <$base_type as TimeOps>::WindowedViewType {
+                self.$field.after(start)
+            }
+        }
+    };
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the TimeOps trait to add `before` and `after` methods and change `at` to only show events that happen at that point in time/the current state for the `GraphWithDeletions`

### Why are the changes needed?

Make the `GraphWithDeletions` work as expected and make `at` less confusing

### Does this PR introduce any user-facing change? If yes is this documented?

Yes, need to document this properly

### How was this patch tested?

added more tests for `before`, `at`, `after`

### Issues

fixes #1370 

### Are there any further changes required?


