### PR TITLE
fix edge property semantics for the graph with deletions

### DIFF
--- a/examples/netflow/src/lib.rs
+++ b/examples/netflow/src/lib.rs
@@ -2,7 +2,7 @@ mod netflow_one_path_vertex;
 
 use crate::netflow_one_path_vertex::netflow_one_path_vertex;
 use pyo3::prelude::*;
-use raphtory::db::api::view::{DynamicGraph, StaticGraphViewOps};
+use raphtory::db::api::view::DynamicGraph;
 
 #[pyfunction(name = "netflow_one_path_vertex")]
 fn py_netflow_one_path_vertex(graph: DynamicGraph, no_time: bool, threads: Option<usize>) -> usize {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`edge.properties().get()` no longer panics due to unwrap on None when the edge is deleted exactly at the start of the window
### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


