### PR TITLE
pull out the EdgeStore functionality into trait EdgeLike 

### DIFF
--- a/raphtory/src/core/entities/edges/edge_store.rs
+++ b/raphtory/src/core/entities/edges/edge_store.rs
@@ -271,7 +271,7 @@ impl EdgeStore {
         }
     }
 
-    pub fn last_deletion(&self, layer_ids: &LayerIds) -> Option<&TimeIndexEntry> {
+    pub fn last_deletion(&self, layer_ids: &LayerIds) -> Option<TimeIndexEntry> {
         match layer_ids {
             LayerIds::None => None,
             LayerIds::All => self.deletions().iter().flat_map(|d| d.last()).max(),
@@ -283,7 +283,7 @@ impl EdgeStore {
         }
     }
 
-    pub fn last_addition(&self, layer_ids: &LayerIds) -> Option<&TimeIndexEntry> {
+    pub fn last_addition(&self, layer_ids: &LayerIds) -> Option<TimeIndexEntry> {
         match layer_ids {
             LayerIds::None => None,
             LayerIds::All => self.additions().iter().flat_map(|d| d.last()).max(),
@@ -301,18 +301,18 @@ impl EdgeStore {
             LayerIds::All => self
                 .deletions()
                 .iter()
-                .flat_map(|dels| dels.range(i64::MIN..t).last().copied())
+                .flat_map(|dels| dels.range(i64::MIN..t).last())
                 .max(),
             LayerIds::One(id) => {
                 let layer = self.deletions.get(*id)?;
-                layer.range(i64::MIN..t).last().copied()
+                layer.range(i64::MIN..t).last()
             }
             LayerIds::Multiple(ids) => ids
                 .iter()
                 .flat_map(|id| {
                     self.deletions
                         .get(*id)
-                        .and_then(|t_index| t_index.range(i64::MIN..t).last().copied())
+                        .and_then(|t_index| t_index.range(i64::MIN..t).last())
                 })
                 .max(),
         }

--- a/raphtory/src/core/entities/graph/tgraph.rs
+++ b/raphtory/src/core/entities/graph/tgraph.rs
@@ -274,7 +274,7 @@ impl<const N: usize> TemporalGraph<N> {
             },
             Some(filter) => {
                 let guard = self.storage.edges.read_lock();
-                guard.par_iter().filter(|e| filter(e, layers)).count()
+                guard.par_iter().filter(|&e| filter(e, layers)).count()
             }
         }
     }

--- a/raphtory/src/core/storage/timeindex.rs
+++ b/raphtory/src/core/storage/timeindex.rs
@@ -297,7 +297,10 @@ pub trait TimeIndexOps {
 
     fn active(&self, w: Range<i64>) -> bool;
 
-    fn range<'a>(&'a self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_>;
+    fn range<'a>(
+        &'a self,
+        w: Range<i64>,
+    ) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_>;
 
     fn first_t(&self) -> Option<i64> {
         self.first().map(|ti| *ti.t())
@@ -328,7 +331,7 @@ impl<T: AsTime> TimeIndexOps for TimeIndex<T> {
         }
     }
 
-    fn range(&self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_>{
+    fn range(&self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_> {
         match &self {
             TimeIndex::Empty => Box::new(TimeIndexWindow::Empty),
             TimeIndex::One(t) => {
@@ -404,7 +407,7 @@ where
         }
     }
 
-    fn range(&self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_>{
+    fn range(&self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_> {
         match self {
             TimeIndexWindow::Empty => Box::new(TimeIndexWindow::Empty),
             TimeIndexWindow::TimeIndexRange { timeindex, range } => {
@@ -468,13 +471,16 @@ where
         self.timeindex.iter().any(|t| t.active(w.clone()))
     }
 
-    fn range<'a>(&'a self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + 'a> {
+    fn range<'a>(
+        &'a self,
+        w: Range<i64>,
+    ) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + 'a> {
         let timeindex = self
             .timeindex
             .iter()
             .map(|t| t.range(w.clone()))
             .collect_vec();
-        Box::new(LayeredTimeIndexWindow{ timeindex })
+        Box::new(LayeredTimeIndexWindow { timeindex })
     }
 
     fn first(&self) -> Option<T> {

--- a/raphtory/src/core/storage/timeindex.rs
+++ b/raphtory/src/core/storage/timeindex.rs
@@ -286,13 +286,6 @@ impl<'a, T: AsTime, V: Deref<Target = Vec<TimeIndex<T>>> + 'a> TimeIndexOps
 }
 
 pub trait TimeIndexOps {
-    // type IterType<'a>: Iterator<Item = &'a i64> + Send + 'a
-    // where
-    //     Self: 'a;
-
-    // type WindowType<'a>: TimeIndexOps<IndexType = Self::IndexType> + 'a
-    // where
-    //     Self: 'a;
     type IndexType: AsTime;
 
     fn active(&self, w: Range<i64>) -> bool;
@@ -318,8 +311,6 @@ pub trait TimeIndexOps {
 }
 
 impl<T: AsTime> TimeIndexOps for TimeIndex<T> {
-    // type IterType<'a> = Box<dyn Iterator<Item = &'a i64> + Send + 'a> where T: 'a;
-    // type WindowType<'a> = TimeIndexWindow<'a, T> where Self: 'a;
     type IndexType = T;
 
     #[inline(always)]
@@ -391,8 +382,6 @@ impl<'b, T: AsTime> TimeIndexOps for TimeIndexWindow<'b, T>
 where
     Self: 'b,
 {
-    // type IterType<'a> = WindowIter<'a> where Self: 'a;
-    // type WindowType<'a> = TimeIndexWindow<'a, T> where Self: 'a;
     type IndexType = T;
 
     fn active(&self, w: Range<i64>) -> bool {
@@ -463,8 +452,6 @@ impl<'b, T: AsTime> TimeIndexOps for LayeredTimeIndexWindow<'b, T>
 where
     Self: 'b,
 {
-    // type IterType<'a> = KMerge<WindowIter<'a>> where Self: 'a;
-    // type WindowType<'a> = LayeredTimeIndexWindow<'a, T> where Self: 'a;
     type IndexType = T;
 
     fn active(&self, w: Range<i64>) -> bool {

--- a/raphtory/src/core/storage/timeindex.rs
+++ b/raphtory/src/core/storage/timeindex.rs
@@ -171,7 +171,7 @@ pub enum TimeIndexWindow<'a, T: AsTime> {
 }
 
 pub struct LayeredTimeIndexWindow<'a, T: AsTime> {
-    timeindex: Vec<TimeIndexWindow<'a, T>>,
+    timeindex: Vec<Box<dyn TimeIndexOps<IndexType = T> + 'a>>,
 }
 
 pub enum WindowIter<'a> {
@@ -253,70 +253,70 @@ impl<'a, T: AsTime, V: Deref<Target = Vec<TimeIndex<T>>> + 'a> LayeredIndex<'a, 
 impl<'a, T: AsTime, V: Deref<Target = Vec<TimeIndex<T>>> + 'a> TimeIndexOps
     for LayeredIndex<'a, T, V>
 {
-    type IterType<'b> = Box<dyn Iterator<Item = &'b i64> + Send + 'b> where Self: 'b;
-    type WindowType<'b> = LayeredTimeIndexWindow<'b, T> where Self: 'b;
+    // type IterType<'b> = Box<dyn Iterator<Item = &'b i64> + Send + 'b> where Self: 'b;
+    // type WindowType<'b> = LayeredTimeIndexWindow<'b, T> where Self: 'b;
     type IndexType = T;
 
     fn active(&self, w: Range<i64>) -> bool {
         self.view.iter().any(|t| t.active(w.clone()))
     }
 
-    fn range(&self, w: Range<i64>) -> LayeredTimeIndexWindow<T> {
+    fn range(&self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_> {
         let timeindex = self
             .view
             .iter()
             .enumerate()
             .filter_map(|(l, t)| self.layers.contains(&l).then(|| t.range(w.clone())))
             .collect_vec();
-        LayeredTimeIndexWindow { timeindex }
+        Box::new(LayeredTimeIndexWindow { timeindex })
     }
 
-    fn first(&self) -> Option<&T> {
+    fn first(&self) -> Option<T> {
         self.view.iter().flat_map(|t| t.first()).min()
     }
 
-    fn last(&self) -> Option<&T> {
+    fn last(&self) -> Option<T> {
         self.view.iter().flat_map(|t| t.last()).max()
     }
 
-    fn iter_t(&self) -> Self::IterType<'_> {
+    fn iter_t(&self) -> Box<dyn Iterator<Item = &i64> + Send + '_> {
         let iter = self.view.iter().map(|t| t.iter_t()).kmerge().dedup();
         Box::new(iter)
     }
 }
 
 pub trait TimeIndexOps {
-    type IterType<'a>: Iterator<Item = &'a i64> + Send + 'a
-    where
-        Self: 'a;
+    // type IterType<'a>: Iterator<Item = &'a i64> + Send + 'a
+    // where
+    //     Self: 'a;
 
-    type WindowType<'a>: TimeIndexOps<IndexType = Self::IndexType> + 'a
-    where
-        Self: 'a;
+    // type WindowType<'a>: TimeIndexOps<IndexType = Self::IndexType> + 'a
+    // where
+    //     Self: 'a;
     type IndexType: AsTime;
 
     fn active(&self, w: Range<i64>) -> bool;
 
-    fn range<'a>(&'a self, w: Range<i64>) -> Self::WindowType<'a>;
+    fn range<'a>(&'a self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_>;
 
     fn first_t(&self) -> Option<i64> {
         self.first().map(|ti| *ti.t())
     }
 
-    fn first(&self) -> Option<&Self::IndexType>;
+    fn first(&self) -> Option<Self::IndexType>;
 
     fn last_t(&self) -> Option<i64> {
         self.last().map(|ti| *ti.t())
     }
 
-    fn last(&self) -> Option<&Self::IndexType>;
+    fn last(&self) -> Option<Self::IndexType>;
 
-    fn iter_t(&self) -> Self::IterType<'_>;
+    fn iter_t(&self) -> Box<dyn Iterator<Item = &i64> + Send + '_>;
 }
 
 impl<T: AsTime> TimeIndexOps for TimeIndex<T> {
-    type IterType<'a> = Box<dyn Iterator<Item = &'a i64> + Send + 'a> where T: 'a;
-    type WindowType<'a> = TimeIndexWindow<'a, T> where Self: 'a;
+    // type IterType<'a> = Box<dyn Iterator<Item = &'a i64> + Send + 'a> where T: 'a;
+    // type WindowType<'a> = TimeIndexWindow<'a, T> where Self: 'a;
     type IndexType = T;
 
     #[inline(always)]
@@ -328,50 +328,50 @@ impl<T: AsTime> TimeIndexOps for TimeIndex<T> {
         }
     }
 
-    fn range(&self, w: Range<i64>) -> TimeIndexWindow<'_, T> {
+    fn range(&self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_>{
         match &self {
-            TimeIndex::Empty => TimeIndexWindow::Empty,
+            TimeIndex::Empty => Box::new(TimeIndexWindow::Empty),
             TimeIndex::One(t) => {
                 if w.contains(t.t()) {
-                    TimeIndexWindow::All(self)
+                    Box::new(TimeIndexWindow::All(self))
                 } else {
-                    TimeIndexWindow::Empty
+                    Box::new(TimeIndexWindow::Empty)
                 }
             }
             TimeIndex::Set(ts) => {
                 if let Some(min_val) = ts.first() {
                     if let Some(max_val) = ts.last() {
                         if min_val.t() >= &w.start && max_val.t() < &w.end {
-                            TimeIndexWindow::All(self)
+                            Box::new(TimeIndexWindow::All(self))
                         } else {
-                            TimeIndexWindow::TimeIndexRange {
+                            Box::new(TimeIndexWindow::TimeIndexRange {
                                 timeindex: self,
                                 range: w,
-                            }
+                            })
                         }
                     } else {
-                        TimeIndexWindow::Empty
+                        Box::new(TimeIndexWindow::Empty)
                     }
                 } else {
-                    TimeIndexWindow::Empty
+                    Box::new(TimeIndexWindow::Empty)
                 }
             }
         }
     }
 
-    fn first(&self) -> Option<&T> {
+    fn first(&self) -> Option<T> {
         match self {
             TimeIndex::Empty => None,
-            TimeIndex::One(t) => Some(t),
-            TimeIndex::Set(ts) => ts.first(),
+            TimeIndex::One(t) => Some(*t),
+            TimeIndex::Set(ts) => ts.first().copied(),
         }
     }
 
-    fn last(&self) -> Option<&T> {
+    fn last(&self) -> Option<T> {
         match self {
             TimeIndex::Empty => None,
-            TimeIndex::One(t) => Some(t),
-            TimeIndex::Set(ts) => ts.last(),
+            TimeIndex::One(t) => Some(*t),
+            TimeIndex::Set(ts) => ts.last().copied(),
         }
     }
 
@@ -388,8 +388,8 @@ impl<'b, T: AsTime> TimeIndexOps for TimeIndexWindow<'b, T>
 where
     Self: 'b,
 {
-    type IterType<'a> = WindowIter<'a> where Self: 'a;
-    type WindowType<'a> = TimeIndexWindow<'a, T> where Self: 'a;
+    // type IterType<'a> = WindowIter<'a> where Self: 'a;
+    // type WindowType<'a> = TimeIndexWindow<'a, T> where Self: 'a;
     type IndexType = T;
 
     fn active(&self, w: Range<i64>) -> bool {
@@ -404,52 +404,54 @@ where
         }
     }
 
-    fn range(&self, w: Range<i64>) -> TimeIndexWindow<T> {
+    fn range(&self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + '_>{
         match self {
-            TimeIndexWindow::Empty => TimeIndexWindow::Empty,
+            TimeIndexWindow::Empty => Box::new(TimeIndexWindow::Empty),
             TimeIndexWindow::TimeIndexRange { timeindex, range } => {
                 let start = max(range.start, w.start);
                 let end = min(range.start, w.start);
                 if end <= start {
-                    TimeIndexWindow::Empty
+                    Box::new(TimeIndexWindow::Empty)
                 } else {
-                    TimeIndexWindow::TimeIndexRange {
+                    Box::new(TimeIndexWindow::TimeIndexRange {
                         timeindex,
                         range: start..end,
-                    }
+                    })
                 }
             }
             TimeIndexWindow::All(timeindex) => timeindex.range(w),
         }
     }
 
-    fn first(&self) -> Option<&T> {
+    fn first(&self) -> Option<T> {
         match self {
             TimeIndexWindow::Empty => None,
             TimeIndexWindow::TimeIndexRange { timeindex, range } => {
-                timeindex.range_iter(range.clone()).next()
+                timeindex.range_iter(range.clone()).next().copied()
             }
             TimeIndexWindow::All(timeindex) => timeindex.first(),
         }
     }
 
-    fn last(&self) -> Option<&T> {
+    fn last(&self) -> Option<T> {
         match self {
             TimeIndexWindow::Empty => None,
             TimeIndexWindow::TimeIndexRange { timeindex, range } => {
-                timeindex.range_iter(range.clone()).next_back()
+                timeindex.range_iter(range.clone()).next_back().copied()
             }
             TimeIndexWindow::All(timeindex) => timeindex.last(),
         }
     }
 
-    fn iter_t(&self) -> Self::IterType<'_> {
+    fn iter_t(&self) -> Box<dyn Iterator<Item = &i64> + Send + '_> {
         match self {
-            TimeIndexWindow::Empty => WindowIter::Empty,
-            TimeIndexWindow::TimeIndexRange { timeindex, range } => WindowIter::TimeIndexRange(
-                Box::new(timeindex.range_iter_forward(range.clone()).map(|t| t.t())),
-            ),
-            TimeIndexWindow::All(timeindex) => WindowIter::All(timeindex.iter_t()),
+            TimeIndexWindow::Empty => Box::new(WindowIter::Empty),
+            TimeIndexWindow::TimeIndexRange { timeindex, range } => {
+                Box::new(WindowIter::TimeIndexRange(Box::new(
+                    timeindex.range_iter_forward(range.clone()).map(|t| t.t()),
+                )))
+            }
+            TimeIndexWindow::All(timeindex) => Box::new(WindowIter::All(timeindex.iter_t())),
         }
     }
 }
@@ -458,32 +460,32 @@ impl<'b, T: AsTime> TimeIndexOps for LayeredTimeIndexWindow<'b, T>
 where
     Self: 'b,
 {
-    type IterType<'a> = KMerge<WindowIter<'a>> where Self: 'a;
-    type WindowType<'a> = LayeredTimeIndexWindow<'a, T> where Self: 'a;
+    // type IterType<'a> = KMerge<WindowIter<'a>> where Self: 'a;
+    // type WindowType<'a> = LayeredTimeIndexWindow<'a, T> where Self: 'a;
     type IndexType = T;
 
     fn active(&self, w: Range<i64>) -> bool {
         self.timeindex.iter().any(|t| t.active(w.clone()))
     }
 
-    fn range<'a>(&'a self, w: Range<i64>) -> Self::WindowType<'a> {
+    fn range<'a>(&'a self, w: Range<i64>) -> Box<dyn TimeIndexOps<IndexType = Self::IndexType> + 'a> {
         let timeindex = self
             .timeindex
             .iter()
             .map(|t| t.range(w.clone()))
             .collect_vec();
-        Self::WindowType { timeindex }
+        Box::new(LayeredTimeIndexWindow{ timeindex })
     }
 
-    fn first(&self) -> Option<&T> {
+    fn first(&self) -> Option<T> {
         self.timeindex.iter().flat_map(|t| t.first()).min()
     }
 
-    fn last(&self) -> Option<&T> {
+    fn last(&self) -> Option<T> {
         self.timeindex.iter().flat_map(|t| t.last()).max()
     }
 
-    fn iter_t(&self) -> Self::IterType<'_> {
-        self.timeindex.iter().map(|t| t.iter_t()).kmerge()
+    fn iter_t(&self) -> Box<dyn Iterator<Item = &i64> + Send + '_> {
+        Box::new(self.timeindex.iter().map(|t| t.iter_t()).kmerge())
     }
 }

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use chrono::NaiveDateTime;
 
 use crate::{
@@ -158,7 +160,7 @@ impl<'graph, E: EdgeViewInternalOps<'graph>> EdgeViewOps<'graph> for E {
             None => {
                 let window_filter = self.graph().include_edge_window();
                 window_filter(
-                    &self.graph().core_edge(self.eref().pid()),
+                    self.graph().core_edge(self.eref().pid()).deref(),
                     &layer_ids,
                     t..t.saturating_add(1),
                 )

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -1,10 +1,9 @@
 use crate::{
     core::{
         entities::{edges::edge_store::EdgeStore, LayerIds, VID},
-        storage::timeindex::TimeIndex,
+        storage::timeindex::{TimeIndex, TimeIndexEntry},
     },
     db::api::view::internal::Base,
-    prelude::TimeIndexEntry,
 };
 use enum_dispatch::enum_dispatch;
 use std::{ops::Range, sync::Arc};

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -10,28 +10,37 @@ use std::{ops::Range, sync::Arc};
 
 pub enum TimeIndexLike<'a> {
     TimeIndex(&'a TimeIndex<TimeIndexEntry>),
-    SliceTimeIndex(Box<dyn Iterator<Item = &'a [i64]> + 'a>),
+    // External(Box<dyn BoxTimeIndexOps>),
 }
 
-impl<'a> TimeIndexLike<'a> {
-    pub fn first(&'a self) -> Option<TimeIndexEntry> {
-        match self {
-            TimeIndexLike::TimeIndex(ti) => ti.first().copied(),
-            TimeIndexLike::SliceTimeIndex(ti) => ti
-                .next()
-                .and_then(|x| x.first().map(|x| TimeIndexEntry::new(*x, 0))),
-        }
+impl <'a> TimeIndexOps for TimeIndexLike<'a> {
+    type IterType<'b> = Box<dyn Iterator<Item = &'b i64> + Send + 'b> where Self: 'b;
+
+    type WindowType<'b> = TimeIndexLike<'b> where Self: 'b;
+
+    type IndexType = i64;
+
+    fn active(&self, w: Range<i64>) -> bool {
+        todo!()
     }
 
-    pub fn range(&'a self, w: Range<i64>) -> TimeIndexLike<'a> {
-        match self {
-            TimeIndexLike::TimeIndex(ti) => ti.range(w).copied(),
-            TimeIndexLike::SliceTimeIndex(ti) => ti
-                .next()
-                .and_then(|x| x.range(w).map(|x| TimeIndexEntry::new(*x, 0))),
-        }
+    fn range(&self, w: Range<i64>) -> Self::WindowType<'_> {
+        todo!()
+    }
+
+    fn first(&self) -> Option<&Self::IndexType> {
+        todo!()
+    }
+
+    fn last(&self) -> Option<&Self::IndexType> {
+        todo!()
+    }
+
+    fn iter_t(&self) -> Self::IterType<'_> {
+        todo!()
     }
 }
+
 pub trait EdgeLike {
     fn active(&self, layer_ids: &LayerIds, w: Range<i64>) -> bool;
     fn has_layer(&self, layer_ids: &LayerIds) -> bool;

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -11,6 +11,7 @@ use std::{ops::Range, sync::Arc};
 pub enum TimeIndexLike<'a> {
     TimeIndex(&'a TimeIndex<TimeIndexEntry>),
     External(&'a dyn TimeIndexOps<IndexType = TimeIndexEntry>),
+    BoxExternal(Box<dyn TimeIndexOps<IndexType = TimeIndexEntry> + 'a>),
 }
 
 impl<'a> TimeIndexOps for TimeIndexLike<'a> {
@@ -20,6 +21,7 @@ impl<'a> TimeIndexOps for TimeIndexLike<'a> {
         match self {
             TimeIndexLike::TimeIndex(ref t) => t.active(w),
             TimeIndexLike::External(ref t) => t.active(w),
+            TimeIndexLike::BoxExternal(ref t) => t.active(w),
         }
     }
 
@@ -27,6 +29,7 @@ impl<'a> TimeIndexOps for TimeIndexLike<'a> {
         match self {
             TimeIndexLike::TimeIndex(ref t) => t.range(w),
             TimeIndexLike::External(ref t) => t.range(w),
+            TimeIndexLike::BoxExternal(ref t) => t.range(w),
         }
     }
 
@@ -34,6 +37,7 @@ impl<'a> TimeIndexOps for TimeIndexLike<'a> {
         match self {
             TimeIndexLike::TimeIndex(ref t) => t.first(),
             TimeIndexLike::External(ref t) => t.first(),
+            TimeIndexLike::BoxExternal(ref t) => t.first(),
         }
     }
 
@@ -41,6 +45,7 @@ impl<'a> TimeIndexOps for TimeIndexLike<'a> {
         match self {
             TimeIndexLike::TimeIndex(ref t) => t.last(),
             TimeIndexLike::External(ref t) => t.last(),
+            TimeIndexLike::BoxExternal(ref t) => t.last(),
         }
     }
 
@@ -48,6 +53,7 @@ impl<'a> TimeIndexOps for TimeIndexLike<'a> {
         match self {
             TimeIndexLike::TimeIndex(ref t) => t.iter_t(),
             TimeIndexLike::External(ref t) => t.iter_t(),
+            TimeIndexLike::BoxExternal(ref t) => t.iter_t(),
         }
     }
 }

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -8,38 +8,7 @@ use crate::{
 use enum_dispatch::enum_dispatch;
 use std::{ops::Range, sync::Arc};
 
-pub enum TimeIndexLike<'a> {
-    TimeIndex(&'a TimeIndex<TimeIndexEntry>),
-    // External(Box<dyn BoxTimeIndexOps>),
-}
-
-impl <'a> TimeIndexOps for TimeIndexLike<'a> {
-    type IterType<'b> = Box<dyn Iterator<Item = &'b i64> + Send + 'b> where Self: 'b;
-
-    type WindowType<'b> = TimeIndexLike<'b> where Self: 'b;
-
-    type IndexType = i64;
-
-    fn active(&self, w: Range<i64>) -> bool {
-        todo!()
-    }
-
-    fn range(&self, w: Range<i64>) -> Self::WindowType<'_> {
-        todo!()
-    }
-
-    fn first(&self) -> Option<&Self::IndexType> {
-        todo!()
-    }
-
-    fn last(&self) -> Option<&Self::IndexType> {
-        todo!()
-    }
-
-    fn iter_t(&self) -> Self::IterType<'_> {
-        todo!()
-    }
-}
+type TimeIndexLike<'a> = &'a TimeIndex<TimeIndexEntry>;
 
 pub trait EdgeLike {
     fn active(&self, layer_ids: &LayerIds, w: Range<i64>) -> bool;
@@ -72,19 +41,19 @@ impl EdgeLike for EdgeStore {
     }
 
     fn additions_iter(&self) -> Box<dyn Iterator<Item = TimeIndexLike<'_>> + '_> {
-        Box::new(self.additions().into_iter().map(TimeIndexLike::TimeIndex))
+        Box::new(self.additions().into_iter())
     }
 
     fn deletions_iter(&self) -> Box<dyn Iterator<Item = TimeIndexLike<'_>> + '_> {
-        Box::new(self.deletions().into_iter().map(TimeIndexLike::TimeIndex))
+        Box::new(self.deletions().into_iter())
     }
 
     fn additions(&self, layer_id: usize) -> Option<TimeIndexLike<'_>> {
-        self.additions().get(layer_id).map(TimeIndexLike::TimeIndex)
+        self.additions().get(layer_id)
     }
 
     fn deletions(&self, layer_id: usize) -> Option<TimeIndexLike<'_>> {
-        self.deletions().get(layer_id).map(TimeIndexLike::TimeIndex)
+        self.deletions().get(layer_id)
     }
 }
 

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -13,7 +13,7 @@ pub enum TimeIndexLike<'a> {
     External(&'a dyn TimeIndexOps<IndexType = TimeIndexEntry>),
 }
 
-impl <'a> TimeIndexOps for TimeIndexLike<'a> {
+impl<'a> TimeIndexOps for TimeIndexLike<'a> {
     type IndexType = TimeIndexEntry;
 
     fn active(&self, w: Range<i64>) -> bool {

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -1,6 +1,10 @@
 use crate::{
-    core::{entities::{edges::edge_store::EdgeStore, LayerIds, VID}, storage::timeindex::TimeIndex},
-    db::api::view::internal::Base, prelude::TimeIndexEntry,
+    core::{
+        entities::{edges::edge_store::EdgeStore, LayerIds, VID},
+        storage::timeindex::TimeIndex,
+    },
+    db::api::view::internal::Base,
+    prelude::TimeIndexEntry,
 };
 use enum_dispatch::enum_dispatch;
 use std::{ops::Range, sync::Arc};
@@ -14,7 +18,7 @@ pub fn extend_filter(
         None => Arc::new(filter),
     }
 }
-pub trait EdgeLike{
+pub trait EdgeLike {
     fn active(&self, layer_ids: &LayerIds, w: Range<i64>) -> bool;
     fn has_layer(&self, layer_ids: &LayerIds) -> bool;
     fn src(&self) -> VID;
@@ -24,7 +28,7 @@ pub trait EdgeLike{
     fn deletions(&self) -> &Vec<TimeIndex<TimeIndexEntry>>;
 }
 
-impl EdgeLike for EdgeStore{
+impl EdgeLike for EdgeStore {
     fn active(&self, layer_ids: &LayerIds, w: Range<i64>) -> bool {
         self.active(layer_ids, w)
     }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -68,40 +68,40 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
         match layer_ids {
             LayerIds::None => return false,
             LayerIds::All => (
-                e.additions_iter().flat_map(|v| v.first().copied()).min(),
-                e.deletions_iter().flat_map(|v| v.first().copied()).min(),
+                e.additions_iter().flat_map(|v| v.first()).min(),
+                e.deletions_iter().flat_map(|v| v.first()).min(),
                 e.additions_iter()
-                    .flat_map(|v| v.range(range.clone()).last().copied())
+                    .flat_map(|v| v.range(range.clone()).last())
                     .max(),
                 e.deletions_iter()
-                    .flat_map(|v| v.range(range.clone()).last().copied())
+                    .flat_map(|v| v.range(range.clone()).last())
                     .max(),
             ),
             LayerIds::One(l_id) => (
-                e.additions(*l_id).and_then(|v| v.first().copied()),
-                e.deletions(*l_id).and_then(|v| v.first().copied()),
+                e.additions(*l_id).and_then(|v| v.first()),
+                e.deletions(*l_id).and_then(|v| v.first()),
                 e.additions(*l_id)
-                    .and_then(|v| v.range(range.clone()).last().copied()),
+                    .and_then(|v| v.range(range.clone()).last()),
                 e.deletions(*l_id)
-                    .and_then(|v| v.range(range.clone()).last().copied()),
+                    .and_then(|v| v.range(range.clone()).last()),
             ),
             LayerIds::Multiple(ids) => (
                 ids.iter()
-                    .flat_map(|l_id| e.additions(*l_id).and_then(|v| v.first().copied()))
+                    .flat_map(|l_id| e.additions(*l_id).and_then(|v| v.first()))
                     .min(),
                 ids.iter()
-                    .flat_map(|l_id| e.deletions(*l_id).and_then(|v| v.first().copied()))
+                    .flat_map(|l_id| e.deletions(*l_id).and_then(|v| v.first()))
                     .min(),
                 ids.iter()
                     .flat_map(|l_id| {
                         e.additions(*l_id)
-                            .and_then(|v| v.range(range.clone()).last().copied())
+                            .and_then(|v| v.range(range.clone()).last())
                     })
                     .max(),
                 ids.iter()
                     .flat_map(|l_id| {
                         e.deletions(*l_id)
-                            .and_then(|v| v.range(range.clone()).last().copied())
+                            .and_then(|v| v.range(range.clone()).last())
                     })
                     .max(),
             ),

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -254,8 +254,8 @@ impl TimeSemantics for GraphWithDeletions {
         &self,
         v: VID,
         w: Range<i64>,
-        layer_ids: &LayerIds,
-        edge_filter: Option<&EdgeFilter>,
+        _layer_ids: &LayerIds,
+        _edge_filter: Option<&EdgeFilter>,
     ) -> bool {
         // FIXME: Think about vertex deletions
         let v = self.graph.inner().storage.get_node(v);
@@ -266,7 +266,7 @@ impl TimeSemantics for GraphWithDeletions {
         self.graph.vertex_earliest_time(v)
     }
 
-    fn vertex_latest_time(&self, v: VID) -> Option<i64> {
+    fn vertex_latest_time(&self, _v: VID) -> Option<i64> {
         Some(i64::MAX)
     }
 
@@ -845,7 +845,7 @@ mod test_deletions {
     #[test]
     fn test_vertex_property_semantics() {
         let g = GraphWithDeletions::new();
-        let v = g.add_vertex(1, 1, [("test_prop", "test value")]).unwrap();
+        let _v = g.add_vertex(1, 1, [("test_prop", "test value")]).unwrap();
         let v = g
             .add_vertex(11, 1, [("test_prop", "test value 2")])
             .unwrap();

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -1,6 +1,10 @@
 use crate::{
     core::{
-        entities::{edges::edge_ref::EdgeRef, vertices::vertex_store::VertexStore, LayerIds, VID},
+        entities::{
+            edges::{edge_ref::EdgeRef},
+            vertices::vertex_store::VertexStore,
+            LayerIds, VID,
+        },
         storage::timeindex::{AsTime, TimeIndexEntry, TimeIndexOps},
         utils::errors::GraphError,
         Direction, Prop,
@@ -64,8 +68,8 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
         match layer_ids {
             LayerIds::None => return false,
             LayerIds::All => (
-                e.additions_iter().flat_map(|v| v.first()).min().copied(),
-                e.deletions_iter().flat_map(|v| v.first()).min().copied(),
+                e.additions_iter().flat_map(|v| v.first()).min(),
+                e.deletions_iter().flat_map(|v| v.first()).min(),
                 e.additions_iter()
                     .flat_map(|v| v.range(range.clone()).last().copied())
                     .max(),
@@ -74,8 +78,8 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
                     .max(),
             ),
             LayerIds::One(l_id) => (
-                e.additions(*l_id).and_then(|v| v.first().copied()),
-                e.deletions(*l_id).and_then(|v| v.first().copied()),
+                e.additions(*l_id).and_then(|v| v.first()),
+                e.deletions(*l_id).and_then(|v| v.first()),
                 e.additions(*l_id)
                     .and_then(|v| v.range(range.clone()).last().copied()),
                 e.deletions(*l_id)
@@ -84,12 +88,10 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
             LayerIds::Multiple(ids) => (
                 ids.iter()
                     .flat_map(|l_id| e.additions(*l_id).and_then(|v| v.first()))
-                    .min()
-                    .copied(),
+                    .min(),
                 ids.iter()
                     .flat_map(|l_id| e.deletions(*l_id).and_then(|v| v.first()))
-                    .min()
-                    .copied(),
+                    .min(),
                 ids.iter()
                     .flat_map(|l_id| {
                         e.additions(*l_id)

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -1,10 +1,6 @@
 use crate::{
     core::{
-        entities::{
-            edges::{edge_ref::EdgeRef},
-            vertices::vertex_store::VertexStore,
-            LayerIds, VID,
-        },
+        entities::{edges::edge_ref::EdgeRef, vertices::vertex_store::VertexStore, LayerIds, VID},
         storage::timeindex::{AsTime, TimeIndexEntry, TimeIndexOps},
         utils::errors::GraphError,
         Direction, Prop,

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -25,7 +25,7 @@ use std::{
     cmp::min,
     fmt::{Display, Formatter},
     iter,
-    ops::{Range, Deref},
+    ops::{Deref, Range},
     path::Path,
     sync::Arc,
 };
@@ -366,7 +366,11 @@ impl TimeSemantics for GraphWithDeletions {
                 .edge_layers(e, layer_ids.clone())
                 .filter(move |&e| {
                     let entry = g.core_edge(e.pid());
-                    window_filter(entry.deref(), &layer_ids.clone().constrain_from_edge(e), w.clone())
+                    window_filter(
+                        entry.deref(),
+                        &layer_ids.clone().constrain_from_edge(e),
+                        w.clone(),
+                    )
                 }),
         )
     }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -68,8 +68,8 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
         match layer_ids {
             LayerIds::None => return false,
             LayerIds::All => (
-                e.additions_iter().flat_map(|v| v.first()).min(),
-                e.deletions_iter().flat_map(|v| v.first()).min(),
+                e.additions_iter().flat_map(|v| v.first().copied()).min(),
+                e.deletions_iter().flat_map(|v| v.first().copied()).min(),
                 e.additions_iter()
                     .flat_map(|v| v.range(range.clone()).last().copied())
                     .max(),
@@ -78,8 +78,8 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
                     .max(),
             ),
             LayerIds::One(l_id) => (
-                e.additions(*l_id).and_then(|v| v.first()),
-                e.deletions(*l_id).and_then(|v| v.first()),
+                e.additions(*l_id).and_then(|v| v.first().copied()),
+                e.deletions(*l_id).and_then(|v| v.first().copied()),
                 e.additions(*l_id)
                     .and_then(|v| v.range(range.clone()).last().copied()),
                 e.deletions(*l_id)
@@ -87,10 +87,10 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
             ),
             LayerIds::Multiple(ids) => (
                 ids.iter()
-                    .flat_map(|l_id| e.additions(*l_id).and_then(|v| v.first()))
+                    .flat_map(|l_id| e.additions(*l_id).and_then(|v| v.first().copied()))
                     .min(),
                 ids.iter()
-                    .flat_map(|l_id| e.deletions(*l_id).and_then(|v| v.first()))
+                    .flat_map(|l_id| e.deletions(*l_id).and_then(|v| v.first().copied()))
                     .min(),
                 ids.iter()
                     .flat_map(|l_id| {
@@ -110,7 +110,7 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
     // None is less than any value (see test below)
     (first_deletion < first_addition
         && first_deletion
-            .filter(|v| *v >= TimeIndexEntry::start(t))
+            .filter(|&v| v >= TimeIndexEntry::start(t))
             .is_some())
         || last_addition_before_start > last_deletion_before_start
 }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -1,10 +1,6 @@
 use crate::{
     core::{
-        entities::{
-            edges::{edge_ref::EdgeRef, edge_store::EdgeStore},
-            vertices::vertex_store::VertexStore,
-            LayerIds, VID,
-        },
+        entities::{edges::edge_ref::EdgeRef, vertices::vertex_store::VertexStore, LayerIds, VID},
         storage::timeindex::{AsTime, TimeIndexEntry, TimeIndexOps},
         utils::errors::GraphError,
         Direction, Prop,
@@ -68,47 +64,41 @@ fn edge_alive_at(e: &dyn EdgeLike, t: i64, layer_ids: &LayerIds) -> bool {
         match layer_ids {
             LayerIds::None => return false,
             LayerIds::All => (
-                e.additions().iter().flat_map(|v| v.first()).min().copied(),
-                e.deletions().iter().flat_map(|v| v.first()).min().copied(),
-                e.additions()
-                    .iter()
+                e.additions_iter().flat_map(|v| v.first()).min().copied(),
+                e.deletions_iter().flat_map(|v| v.first()).min().copied(),
+                e.additions_iter()
                     .flat_map(|v| v.range(range.clone()).last().copied())
                     .max(),
-                e.deletions()
-                    .iter()
+                e.deletions_iter()
                     .flat_map(|v| v.range(range.clone()).last().copied())
                     .max(),
             ),
             LayerIds::One(l_id) => (
-                e.additions().get(*l_id).and_then(|v| v.first().copied()),
-                e.deletions().get(*l_id).and_then(|v| v.first().copied()),
-                e.additions()
-                    .get(*l_id)
+                e.additions(*l_id).and_then(|v| v.first().copied()),
+                e.deletions(*l_id).and_then(|v| v.first().copied()),
+                e.additions(*l_id)
                     .and_then(|v| v.range(range.clone()).last().copied()),
-                e.deletions()
-                    .get(*l_id)
+                e.deletions(*l_id)
                     .and_then(|v| v.range(range.clone()).last().copied()),
             ),
             LayerIds::Multiple(ids) => (
                 ids.iter()
-                    .flat_map(|l_id| e.additions().get(*l_id).and_then(|v| v.first()))
+                    .flat_map(|l_id| e.additions(*l_id).and_then(|v| v.first()))
                     .min()
                     .copied(),
                 ids.iter()
-                    .flat_map(|l_id| e.deletions().get(*l_id).and_then(|v| v.first()))
+                    .flat_map(|l_id| e.deletions(*l_id).and_then(|v| v.first()))
                     .min()
                     .copied(),
                 ids.iter()
                     .flat_map(|l_id| {
-                        e.additions()
-                            .get(*l_id)
+                        e.additions(*l_id)
                             .and_then(|v| v.range(range.clone()).last().copied())
                     })
                     .max(),
                 ids.iter()
                     .flat_map(|l_id| {
-                        e.deletions()
-                            .get(*l_id)
+                        e.deletions(*l_id)
                             .and_then(|v| v.range(range.clone()).last().copied())
                     })
                     .max(),

--- a/raphtory/src/vectors/entity_id.rs
+++ b/raphtory/src/vectors/entity_id.rs
@@ -15,13 +15,6 @@ pub(crate) enum EntityId {
 }
 
 impl EntityId {
-    pub(crate) fn from_node_id(id: u64) -> Self {
-        Self::Node { id }
-    }
-
-    pub(crate) fn from_edge_id(src: u64, dst: u64) -> Self {
-        Self::Edge { src, dst }
-    }
 
     pub(crate) fn from_node<G: StaticGraphViewOps>(node: &VertexView<G>) -> Self {
         Self::Node { id: node.id() }

--- a/raphtory/src/vectors/entity_id.rs
+++ b/raphtory/src/vectors/entity_id.rs
@@ -15,7 +15,6 @@ pub(crate) enum EntityId {
 }
 
 impl EntityId {
-
     pub(crate) fn from_node<G: StaticGraphViewOps>(node: &VertexView<G>) -> Self {
         Self::Node { id: node.id() }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
EdgeStore is specific to the current storage layer
TimeIndexOps needs to be decoupled from the underlying storage
Add External variant in enum to support TimeIndexOps from other storage variants

### Why are the changes needed?
Need to be permit different storage layers

### Does this PR introduce any user-facing change? If yes is this documented?
Nope

### How was this patch tested?
Unit

### Issues

### Are there any further changes required?


