### PR TITLE
Added date_time history/items to Temporal properties

### DIFF
--- a/raphtory/src/db/api/properties/internal.rs
+++ b/raphtory/src/db/api/properties/internal.rs
@@ -2,6 +2,7 @@ use crate::{
     core::{ArcStr, Prop},
     db::api::view::internal::Base,
 };
+use chrono::NaiveDateTime;
 use enum_dispatch::enum_dispatch;
 
 #[enum_dispatch]
@@ -10,6 +11,12 @@ pub trait TemporalPropertyViewOps {
         self.temporal_values(id).last().cloned()
     }
     fn temporal_history(&self, id: usize) -> Vec<i64>;
+    fn temporal_history_date_time(&self, id: usize) -> Option<Vec<NaiveDateTime>> {
+        self.temporal_history(id)
+            .iter()
+            .map(|t| NaiveDateTime::from_timestamp_millis(*t))
+            .collect::<Option<Vec<NaiveDateTime>>>()
+    }
     fn temporal_values(&self, id: usize) -> Vec<Prop>;
     fn temporal_value_at(&self, id: usize, t: i64) -> Option<Prop> {
         let history = self.temporal_history(id);
@@ -81,6 +88,10 @@ where
     #[inline]
     fn temporal_history(&self, id: usize) -> Vec<i64> {
         self.base().temporal_history(id)
+    }
+    #[inline]
+    fn temporal_history_date_time(&self, id: usize) -> Option<Vec<NaiveDateTime>> {
+        self.base().temporal_history_date_time(id)
     }
 
     #[inline]

--- a/raphtory/src/db/api/properties/temporal_props.rs
+++ b/raphtory/src/db/api/properties/temporal_props.rs
@@ -18,12 +18,26 @@ impl<P: PropertiesOps> TemporalPropertyView<P> {
     pub fn history(&self) -> Vec<i64> {
         self.props.temporal_history(self.id)
     }
+    pub fn history_date_time(&self) -> Option<Vec<NaiveDateTime>> {
+        self.props.temporal_history_date_time(self.id)
+    }
     pub fn values(&self) -> Vec<Prop> {
         self.props.temporal_values(self.id)
     }
     pub fn iter(&self) -> impl Iterator<Item = (i64, Prop)> {
         self.into_iter()
     }
+
+    pub fn histories(&self) -> impl Iterator<Item = (i64, Prop)> {
+        self.iter()
+    }
+
+    pub fn histories_date_time(&self) -> Option<impl Iterator<Item = (NaiveDateTime, Prop)>> {
+        let hist = self.history_date_time()?;
+        let vals = self.values();
+        Some(hist.into_iter().zip(vals))
+    }
+
     pub fn at(&self, t: i64) -> Option<Prop> {
         self.props.temporal_value_at(self.id, t)
     }

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -33,6 +33,7 @@ use crate::{
     },
     prelude::{Layer, Prop},
 };
+use chrono::NaiveDateTime;
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 use std::path::Path;

--- a/raphtory/src/db/graph/edge.rs
+++ b/raphtory/src/db/graph/edge.rs
@@ -274,6 +274,13 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> TemporalProperty
             .map(|(t, _)| t)
             .collect()
     }
+    fn temporal_history_date_time(&self, id: usize) -> Option<Vec<NaiveDateTime>> {
+        self.graph
+            .temporal_edge_prop_vec(self.edge, id, self.graph.layer_ids())
+            .into_iter()
+            .map(|(t, _)| NaiveDateTime::from_timestamp_millis(t))
+            .collect::<Option<Vec<NaiveDateTime>>>()
+    }
 
     fn temporal_values(&self, id: usize) -> Vec<Prop> {
         let layer_ids = self.graph.layer_ids().constrain_from_edge(self.edge);

--- a/raphtory/src/db/graph/node.rs
+++ b/raphtory/src/db/graph/node.rs
@@ -27,6 +27,7 @@ use crate::{
     prelude::*,
 };
 
+use chrono::NaiveDateTime;
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -208,6 +209,14 @@ impl<G, GH: TimeSemantics> TemporalPropertyViewOps for NodeView<G, GH> {
             .into_iter()
             .map(|(t, _)| t)
             .collect()
+    }
+
+    fn temporal_history_date_time(&self, id: usize) -> Option<Vec<NaiveDateTime>> {
+        self.graph
+            .temporal_node_prop_vec(self.node, id)
+            .into_iter()
+            .map(|(t, _)| NaiveDateTime::from_timestamp_millis(t))
+            .collect::<Option<Vec<NaiveDateTime>>>()
     }
 
     fn temporal_values(&self, id: usize) -> Vec<Prop> {

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -60,6 +60,7 @@ use crate::{
     },
     prelude::GraphViewOps,
 };
+use chrono::NaiveDateTime;
 use std::{
     cmp::{max, min},
     fmt::{Debug, Formatter},
@@ -123,6 +124,13 @@ impl<'graph, G: GraphViewOps<'graph>> TemporalPropertyViewOps for WindowedGraph<
             .into_iter()
             .map(|(t, _)| t)
             .collect()
+    }
+
+    fn temporal_history_date_time(&self, id: usize) -> Option<Vec<NaiveDateTime>> {
+        self.temporal_prop_vec(id)
+            .into_iter()
+            .map(|(t, _)| NaiveDateTime::from_timestamp_millis(t))
+            .collect::<Option<Vec<NaiveDateTime>>>()
     }
 
     fn temporal_values(&self, id: usize) -> Vec<Prop> {

--- a/raphtory/src/db/internal/temporal_properties.rs
+++ b/raphtory/src/db/internal/temporal_properties.rs
@@ -2,6 +2,7 @@ use crate::{
     core::{entities::graph::tgraph::InnerTemporalGraph, ArcStr, Prop},
     db::api::properties::internal::{TemporalPropertiesOps, TemporalPropertyViewOps},
 };
+use chrono::NaiveDateTime;
 
 impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
     fn temporal_value(&self, id: usize) -> Option<Prop> {
@@ -14,6 +15,17 @@ impl<const N: usize> TemporalPropertyViewOps for InnerTemporalGraph<N> {
         self.inner()
             .get_temporal_prop(id)
             .map(|prop| prop.iter().map(|(t, _)| t).collect())
+            .unwrap_or_default()
+    }
+
+    fn temporal_history_date_time(&self, id: usize) -> Option<Vec<NaiveDateTime>> {
+        self.inner()
+            .get_temporal_prop(id)
+            .map(|prop| {
+                prop.iter()
+                    .map(|(t, _)| NaiveDateTime::from_timestamp_millis(t))
+                    .collect::<Option<Vec<NaiveDateTime>>>()
+            })
             .unwrap_or_default()
     }
 

--- a/raphtory/src/db/task/edge/eval_edge.rs
+++ b/raphtory/src/db/task/edge/eval_edge.rs
@@ -178,6 +178,10 @@ impl<
         self.edge.temporal_history(id)
     }
 
+    fn temporal_history_date_time(&self, id: usize) -> Option<Vec<NaiveDateTime>> {
+        self.edge.temporal_history_date_time(id)
+    }
+
     fn temporal_values(&self, id: usize) -> Vec<Prop> {
         self.edge.temporal_values(id)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added a histories_date_time function to the TemporalProps object
Added a history_date_time and items_date_time function to TemporalProp

### Why are the changes needed?
We now have datetime objects being returns for all structural histories, seems odd to miss these out.
 
### Does this PR introduce any user-facing change? If yes is this documented?
Yes, these have documentation and it will be reflected in the tutorial as well.

### How was this patch tested?
New tests added.

### Are there any further changes required?
Yes, but as a larger refactor of datetimes

