### PR TITLE
Fix the semantics for edge history when using deletions

### DIFF
--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -135,17 +135,13 @@ impl<'graph, E: EdgeViewInternalOps<'graph>> EdgeViewOps<'graph> for E {
     /// list the activation timestamps for the edge
     fn history(&self) -> Vec<i64> {
         let layer_ids = self.graph().layer_ids().constrain_from_edge(self.eref());
-        self.graph()
-            .edge_exploded(self.eref(), layer_ids)
-            .map(|e| *e.time().expect("exploded").t())
-            .collect()
+        self.graph().edge_history(self.eref(), layer_ids)
     }
 
     fn history_date_time(&self) -> Option<Vec<NaiveDateTime>> {
-        let layer_ids = self.graph().layer_ids().constrain_from_edge(self.eref());
-        self.graph()
-            .edge_exploded(self.eref(), layer_ids)
-            .map(|e| NaiveDateTime::from_timestamp_millis(*e.time().expect("exploded").t()))
+        self.history()
+            .into_iter()
+            .map(|t| NaiveDateTime::from_timestamp_millis(t))
             .collect::<Option<Vec<NaiveDateTime>>>()
     }
 

--- a/raphtory/src/db/api/view/internal/time_semantics.rs
+++ b/raphtory/src/db/api/view/internal/time_semantics.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     db::api::view::{
         internal::{Base, CoreGraphOps, EdgeFilter, EdgeWindowFilter},
-        BoxedIter,
+        BoxedIter, MaterializedGraph,
     },
 };
 use enum_dispatch::enum_dispatch;
@@ -84,8 +84,9 @@ pub trait TimeSemantics: CoreGraphOps {
         kmerge(
             core_edge
                 .additions_iter(&layer_ids)
-                .map(|index| index.iter_t().copied()),
+                .map(|index| index.iter()),
         )
+        .map(|te| *te.t())
         .collect()
     }
 
@@ -94,8 +95,9 @@ pub trait TimeSemantics: CoreGraphOps {
         kmerge(
             core_edge
                 .additions_iter(&layer_ids)
-                .map(move |index| index.range_iter(w).map(|ti| *ti.t())),
+                .map(move |index| index.range_iter(w.clone())),
         )
+        .map(|ti| *ti.t())
         .collect()
     }
 

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -768,6 +768,26 @@ mod test_deletions {
     }
 
     #[test]
+    fn test_edge_history() {
+        let g = GraphWithDeletions::new();
+        let e = g.add_edge(0, 1, 2, NO_PROPS, None).unwrap();
+        e.delete(5, None).unwrap();
+        e.add_updates(10, NO_PROPS, None).unwrap();
+        assert_eq!(e.history(), [0, 10]);
+        assert_eq!(e.after(1).history(), [10]);
+        assert!(e.window(1, 4).history().is_empty());
+
+        // exploded edge still exists
+        assert_eq!(
+            e.window(1, 4)
+                .explode()
+                .flat_map(|e| e.earliest_time())
+                .collect_vec(),
+            [1]
+        );
+    }
+
+    #[test]
     fn test_ordering_of_addition_and_deletion() {
         let g = GraphWithDeletions::new();
 

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -1148,4 +1148,72 @@ mod views_test {
         let res = degree_centrality(&w, None);
         println!("{:?}", res)
     }
+
+    #[test]
+    fn test_entity_history() {
+        let g = Graph::new();
+        g.add_node(0, 1, NO_PROPS).unwrap();
+        g.add_node(1, 1, NO_PROPS).unwrap();
+        g.add_node(2, 1, NO_PROPS).unwrap();
+        let v = g.add_node(3, 1, NO_PROPS).unwrap();
+        g.add_edge(0, 1, 2, NO_PROPS, None).unwrap();
+        g.add_edge(1, 1, 2, NO_PROPS, None).unwrap();
+        g.add_edge(2, 1, 2, NO_PROPS, None).unwrap();
+        let e = g.add_edge(3, 1, 2, NO_PROPS, None).unwrap();
+
+        let full_history_1 = vec![0i64, 1, 2, 3];
+
+        let full_history_2 = vec![4i64, 5, 6, 7];
+
+        let windowed_history = vec![0i64, 1];
+
+        assert_eq!(v.history(), full_history_1);
+
+        assert_eq!(v.window(0, 2).history(), windowed_history);
+        assert_eq!(e.history(), full_history_1);
+        assert_eq!(e.window(0, 2).history(), windowed_history);
+
+        g.add_edge(4, 1, 3, NO_PROPS, None).unwrap();
+        g.add_edge(5, 1, 3, NO_PROPS, None).unwrap();
+        g.add_edge(6, 1, 3, NO_PROPS, None).unwrap();
+        g.add_edge(7, 1, 3, NO_PROPS, None).unwrap();
+
+        assert_eq!(
+            g.edges().history().collect_vec(),
+            [full_history_1.clone(), full_history_2.clone()]
+        );
+        assert_eq!(
+            g.nodes()
+                .in_edges()
+                .history()
+                .map(|it| it.collect_vec())
+                .collect_vec(),
+            [vec![], vec![full_history_1], vec![full_history_2],]
+        );
+
+        assert_eq!(
+            g.nodes().earliest_time().flatten().collect_vec(),
+            [0, 0, 4,]
+        );
+
+        assert_eq!(g.nodes().latest_time().flatten().collect_vec(), [7, 3, 7]);
+
+        assert_eq!(
+            g.nodes()
+                .neighbours()
+                .latest_time()
+                .map(|it| it.flatten().collect_vec())
+                .collect_vec(),
+            [vec![3, 7], vec![7], vec![7],]
+        );
+
+        assert_eq!(
+            g.nodes()
+                .neighbours()
+                .earliest_time()
+                .map(|it| it.flatten().collect_vec())
+                .collect_vec(),
+            [vec![0, 4,], vec![0], vec![0],]
+        );
+    }
 }

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -243,6 +243,19 @@ impl<'graph, G: GraphViewOps<'graph>> TimeSemantics for WindowedGraph<G> {
             .node_history_window(v, self.actual_start(w.start)..self.actual_end(w.end))
     }
 
+    fn edge_history(&self, e: EdgeRef, layer_ids: LayerIds) -> Vec<i64> {
+        self.graph
+            .edge_history_window(e, layer_ids, self.start..self.end)
+    }
+
+    fn edge_history_window(&self, e: EdgeRef, layer_ids: LayerIds, w: Range<i64>) -> Vec<i64> {
+        self.graph.edge_history_window(
+            e,
+            layer_ids,
+            self.actual_start(w.start)..self.actual_end(w.end),
+        )
+    }
+
     fn edge_exploded(&self, e: EdgeRef, layer_ids: LayerIds) -> BoxedIter<EdgeRef> {
         self.graph
             .edge_window_exploded(e, self.start..self.end, layer_ids)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Calling `history` on a windowed Edge for `GraphWithDeletions` no longer adds the start of the window as an event. 

### Why are the changes needed?

The old implementation was creating fake data points in the edge history for `GraphWithDeletions` due to using the exploded edges implementation to create edge history. 

### Does this PR introduce any user-facing change? If yes is this documented?

New behaviour should be in line with documentation

### How was this patch tested?

Added a test to check the semantics

### Issues

Partially addresses #1418 (still need to expose deletion history)

### Are there any further changes required?


