### PR TITLE
Helper function for getting the first/last update in a entities history

### DIFF
--- a/raphtory-graphql/src/model/graph/edge.rs
+++ b/raphtory-graphql/src/model/graph/edge.rs
@@ -57,10 +57,13 @@ impl Edge {
     async fn earliest_time(&self) -> Option<i64> {
         self.ee.earliest_time()
     }
+    async fn first_update(&self) -> Option<i64> {self.vv.history().first()}
 
     async fn latest_time(&self) -> Option<i64> {
         self.ee.latest_time()
     }
+    async fn last_update(&self) -> Option<i64> {self.vv.history().last()}
+
 
     async fn time(&self) -> Option<i64> {
         self.ee.time()

--- a/raphtory-graphql/src/model/graph/edge.rs
+++ b/raphtory-graphql/src/model/graph/edge.rs
@@ -57,13 +57,16 @@ impl Edge {
     async fn earliest_time(&self) -> Option<i64> {
         self.ee.earliest_time()
     }
-    async fn first_update(&self) -> Option<i64> {self.vv.history().first()}
+    async fn first_update(&self) -> Option<i64> {
+        self.ee.history().first().cloned()
+    }
 
     async fn latest_time(&self) -> Option<i64> {
         self.ee.latest_time()
     }
-    async fn last_update(&self) -> Option<i64> {self.vv.history().last()}
-
+    async fn last_update(&self) -> Option<i64> {
+        self.ee.history().last().cloned()
+    }
 
     async fn time(&self) -> Option<i64> {
         self.ee.time()

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -72,13 +72,17 @@ impl Node {
         self.vv.earliest_time()
     }
 
-    async fn first_update(&self) -> Option<i64> {self.vv.history().first()}
+    async fn first_update(&self) -> Option<i64> {
+        self.vv.history().first().cloned()
+    }
 
     async fn latest_time(&self) -> Option<i64> {
         self.vv.latest_time()
     }
 
-    async fn last_update(&self) -> Option<i64> {self.vv.history().last()}
+    async fn last_update(&self) -> Option<i64> {
+        self.vv.history().last().cloned()
+    }
 
     async fn start(&self) -> Option<i64> {
         self.vv.start()

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -72,9 +72,13 @@ impl Node {
         self.vv.earliest_time()
     }
 
+    async fn first_update(&self) -> Option<i64> {self.vv.history().first()}
+
     async fn latest_time(&self) -> Option<i64> {
         self.vv.latest_time()
     }
+
+    async fn last_update(&self) -> Option<i64> {self.vv.history().last()}
 
     async fn start(&self) -> Option<i64> {
         self.vv.start()


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Added to helper functions to the Graphql apis to get the first and last updates in an entities history

### Why are the changes needed?

- Saves people from having to serialise/process the full history 

### Does this PR introduce any user-facing change? If yes is this documented?

- Yes and Yes

### How was this patch tested?

- Tested as part of Pometry's UI

### Are there any further changes required?

- This is a stop gap as part of a bigger rework of the history APIs

