### PR TITLE
add __version__ attribute to raphtory and fix the release in the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,6 +10,7 @@ import warnings
 from pathlib import Path
 from typing import Any
 import sphinx_autosummary_accessors
+from raphtory import __version__
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -17,7 +18,7 @@ import sphinx_autosummary_accessors
 project = 'Raphtory'
 copyright = '2023, Pometry'
 author = 'Pometry'
-release = '2021'
+release = __version__
 git_ref = "master"
 
 # -- General configuration ---------------------------------------------------

--- a/python/python/raphtory/__init__.py
+++ b/python/python/raphtory/__init__.py
@@ -17,3 +17,11 @@ if hasattr(raphtory, "__all__"):
 algorithms.__doc__ = "Algorithmic functions that can be run on Raphtory graphs"
 graph_gen.__doc__ = "Generate Raphtory graphs from attachment models"
 graph_loader.__doc__ = "Load and save Raphtory graphs from/to file(s)"
+
+
+try:
+    from importlib.metadata import version as _version
+    __version__ = _version(__name__)
+except Exception:
+    # either 3.7 or package not installed, just don't set a version
+    pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Docs had release set to 2021 for some reason
- `__version__` now exists on python3.8+




