### PR TITLE
Add Nodes object to GQL to support window filtering

### DIFF
--- a/python/tests/test_graphql.py
+++ b/python/tests/test_graphql.py
@@ -41,11 +41,13 @@ def test_graphql():
     map_dir_server.wait_for_online()
 
     query_g1 = """{graph(name: "g1") {nodes {list {name}}}}"""
+    query_g1_window = """{graph(name: "g1") {nodes {before(time: 2) {list {name}}}}}"""
     query_g2 = """{graph(name: "g2") {nodes {list {name}}}}"""
     query_g3 = """{graph(name: "g3") {nodes {list {name}}}}"""
     query_g4 = """{graph(name: "g4") {nodes {list {name}}}}"""
 
     assert map_server.query(query_g1) == {'graph': {'nodes': {"list": [{'name': 'ben'}, {'name': 'hamza'}, {'name': 'haaroon'}]}}}
+    assert map_server.query(query_g1_window) == {'graph': {'nodes': {"before": {"list": [{'name': 'ben'}, {'name': 'hamza'}]}}}}
     assert map_server.query(query_g2) == {'graph': {'nodes': {"list": [{'name': 'Naomi'}, {'name': 'Shivam'}, {'name': 'Pedro'}, {'name': 'Rachel'}]}}}
     assert dir_server.query(query_g3) == {'graph': {'nodes': {"list": [{'name': 'ben_saved'}, {'name': 'hamza_saved'}, {'name': 'haaroon_saved'}]}}}
     assert dir_server.query(query_g4) == {'graph': {'nodes': {"list": [{'name': 'Naomi_saved'}, {'name': 'Shivam_saved'}, {'name': 'Pedro_saved'}, {'name': 'Rachel_saved'}]}}}

--- a/python/tests/test_graphql.py
+++ b/python/tests/test_graphql.py
@@ -40,52 +40,20 @@ def test_graphql():
     dir_server.wait_for_online()
     map_dir_server.wait_for_online()
 
-    query_g1 = """{graph(name: "g1") {nodes {name}}}"""
-    query_g2 = """{graph(name: "g2") {nodes {name}}}"""
-    query_g3 = """{graph(name: "g3") {nodes {name}}}"""
-    query_g4 = """{graph(name: "g4") {nodes {name}}}"""
+    query_g1 = """{graph(name: "g1") {nodes {list {name}}}}"""
+    query_g2 = """{graph(name: "g2") {nodes {list {name}}}}"""
+    query_g3 = """{graph(name: "g3") {nodes {list {name}}}}"""
+    query_g4 = """{graph(name: "g4") {nodes {list {name}}}}"""
 
-    assert str(map_server.query(query_g1)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'ben'}, {'name': 'hamza'}, {'name': 'haaroon'}]}}".replace(
-        " ", ""
-    )
-    assert str(map_server.query(query_g2)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'Naomi'}, {'name': 'Shivam'}, {'name': 'Pedro'}, {'name': 'Rachel'}]}}".replace(
-        " ", ""
-    )
-    assert str(dir_server.query(query_g3)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'ben_saved'}, {'name': 'hamza_saved'}, {'name': 'haaroon_saved'}]}}".replace(
-        " ", ""
-    )
-    assert str(dir_server.query(query_g4)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'Naomi_saved'}, {'name': 'Shivam_saved'}, {'name': 'Pedro_saved'}, {'name': 'Rachel_saved'}]}}".replace(
-        " ", ""
-    )
+    assert map_server.query(query_g1) == {'graph': {'nodes': {"list": [{'name': 'ben'}, {'name': 'hamza'}, {'name': 'haaroon'}]}}}
+    assert map_server.query(query_g2) == {'graph': {'nodes': {"list": [{'name': 'Naomi'}, {'name': 'Shivam'}, {'name': 'Pedro'}, {'name': 'Rachel'}]}}}
+    assert dir_server.query(query_g3) == {'graph': {'nodes': {"list": [{'name': 'ben_saved'}, {'name': 'hamza_saved'}, {'name': 'haaroon_saved'}]}}}
+    assert dir_server.query(query_g4) == {'graph': {'nodes': {"list": [{'name': 'Naomi_saved'}, {'name': 'Shivam_saved'}, {'name': 'Pedro_saved'}, {'name': 'Rachel_saved'}]}}}
 
-    assert str(map_dir_server.query(query_g1)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'ben'}, {'name': 'hamza'}, {'name': 'haaroon'}]}}".replace(
-        " ", ""
-    )
-    assert str(map_dir_server.query(query_g2)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'Naomi'}, {'name': 'Shivam'}, {'name': 'Pedro'}, {'name': 'Rachel'}]}}".replace(
-        " ", ""
-    )
-    assert str(map_dir_server.query(query_g4)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'Naomi_saved'}, {'name': 'Shivam_saved'}, {'name': 'Pedro_saved'}, {'name': 'Rachel_saved'}]}}".replace(
-        " ", ""
-    )
-    assert str(map_dir_server.query(query_g3)).replace(
-        " ", ""
-    ) == "{'graph': {'nodes': [{'name': 'ben_saved'}, {'name': 'hamza_saved'}, {'name': 'haaroon_saved'}]}}".replace(
-        " ", ""
-    )
+    assert map_dir_server.query(query_g1) == {'graph': {'nodes': {"list": [{'name': 'ben'}, {'name': 'hamza'}, {'name': 'haaroon'}]}}}
+    assert map_dir_server.query(query_g2) == {'graph': {'nodes': {"list": [{'name': 'Naomi'}, {'name': 'Shivam'}, {'name': 'Pedro'}, {'name': 'Rachel'}]}}}
+    assert map_dir_server.query(query_g4) == {'graph': {'nodes': {"list": [{'name': 'Naomi_saved'}, {'name': 'Shivam_saved'}, {'name': 'Pedro_saved'}, {'name': 'Rachel_saved'}]}}}
+    assert map_dir_server.query(query_g3) == {'graph': {'nodes': {"list": [{'name': 'ben_saved'}, {'name': 'hamza_saved'}, {'name': 'haaroon_saved'}]}}}
 
     map_server.stop()
     dir_server.stop()
@@ -133,14 +101,16 @@ def generic_client_test(raphtory_client, temp_dir):
     query = """query GetNodes($graphname: String!) {
         graph(name: $graphname) {
             nodes {
-            name
+                list {
+                    name
+                }
             }
         }
     }"""
     variables = {"graphname": "g1.bincode"}
     res = raphtory_client.query(query, variables)
     assert res == {
-        "graph": {"nodes": [{"name": "ben"}, {"name": "hamza"}, {"name": "haaroon"}]}
+        "graph": {"nodes": {"list": [{"name": "ben"}, {"name": "hamza"}, {"name": "haaroon"}]}}
     }
 
     # load a new graph into the client from a path
@@ -166,13 +136,15 @@ def generic_client_test(raphtory_client, temp_dir):
     query = """query GetNodes($graphname: String!) {
         graph(name: $graphname) {
             nodes {
-                name
+                list {
+                    name
+                }
             }
         }
     }"""
     variables = {"graphname": "hello"}
     res = raphtory_client.query(query, variables)
-    assert res == {"graph": {"nodes": [{"name": "1"}]}}
+    assert res == {"graph": {"nodes": {"list": [{"name": "1"}]}}}
 
 
 def test_windows_and_layers():

--- a/raphtory-graphql/src/model/filters/node_filter.rs
+++ b/raphtory-graphql/src/model/filters/node_filter.rs
@@ -10,7 +10,7 @@ use crate::model::{
 use dynamic_graphql::InputObject;
 use raphtory::db::api::view::NodeViewOps;
 
-#[derive(InputObject)]
+#[derive(InputObject, Clone)]
 pub struct NodeFilter {
     ids: Option<StringVecFilter>,
     names: Option<StringVecFilter>,

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -1,7 +1,7 @@
 use crate::model::{
     algorithms::graph_algorithms::GraphAlgorithms,
     filters::{edge_filter::EdgeFilter, node_filter::NodeFilter},
-    graph::{edge::Edge, get_expanded_edges, node::Node, property::GqlProperties},
+    graph::{edge::Edge, get_expanded_edges, node::Node, nodes::GqlNodes, property::GqlProperties},
     schema::graph_schema::GraphSchema,
 };
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
@@ -237,17 +237,8 @@ impl GqlGraph {
         self.graph.node(v_ref).map(|v| v.into())
     }
 
-    async fn nodes(&self, filter: Option<NodeFilter>) -> Vec<Node> {
-        match filter {
-            Some(filter) => self
-                .graph
-                .nodes()
-                .iter()
-                .map(|vv| vv.into())
-                .filter(|n| filter.matches(n))
-                .collect(),
-            None => self.graph.nodes().iter().map(|vv| vv.into()).collect(),
-        }
+    async fn nodes(&self, filter: Option<NodeFilter>) -> GqlNodes {
+        GqlNodes::new(self.graph.nodes(), filter)
     }
 
     async fn search_nodes(&self, query: String, limit: usize, offset: usize) -> Vec<Node> {

--- a/raphtory-graphql/src/model/graph/mod.rs
+++ b/raphtory-graphql/src/model/graph/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 pub(crate) mod edge;
 pub(crate) mod graph;
 pub(crate) mod node;
+mod nodes;
 pub(crate) mod property;
 pub(crate) mod vectorised_graph;
 

--- a/raphtory-graphql/src/model/graph/nodes.rs
+++ b/raphtory-graphql/src/model/graph/nodes.rs
@@ -1,0 +1,100 @@
+use crate::model::{filters::node_filter::NodeFilter, graph::node::Node};
+use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
+use raphtory::{
+    db::{api::view::DynamicGraph, graph::nodes::Nodes},
+    prelude::*,
+};
+
+#[derive(ResolvedObject)]
+pub(crate) struct GqlNodes {
+    pub(crate) nn: Nodes<'static, DynamicGraph>,
+    pub(crate) filter: Option<NodeFilter>,
+}
+
+impl GqlNodes {
+    fn update<N: Into<Nodes<'static, DynamicGraph>>>(&self, nodes: N) -> Self {
+        GqlNodes::new(nodes, self.filter.clone())
+    }
+}
+
+impl GqlNodes {
+    pub(crate) fn new<N: Into<Nodes<'static, DynamicGraph>>>(
+        nodes: N,
+        filter: Option<NodeFilter>,
+    ) -> Self {
+        Self {
+            nn: nodes.into(),
+            filter,
+        }
+    }
+}
+
+#[ResolvedObjectFields]
+impl GqlNodes {
+    ////////////////////////
+    // LAYERS AND WINDOWS //
+    ////////////////////////
+
+    async fn layers(&self, names: Vec<String>) -> Option<Self> {
+        self.nn.layer(names).map(|v| self.update(v))
+    }
+
+    async fn layer(&self, name: String) -> Option<Self> {
+        self.nn.layer(name).map(|v| self.update(v))
+    }
+
+    async fn window(&self, start: i64, end: i64) -> Self {
+        self.update(self.nn.window(start, end))
+    }
+
+    async fn at(&self, time: i64) -> Self {
+        self.update(self.nn.at(time))
+    }
+
+    async fn before(&self, time: i64) -> Self {
+        self.update(self.nn.before(time))
+    }
+
+    async fn after(&self, time: i64) -> Self {
+        self.update(self.nn.after(time))
+    }
+
+    async fn shrink_window(&self, start: i64, end: i64) -> Self {
+        self.update(self.nn.shrink_window(start, end))
+    }
+
+    async fn shrink_start(&self, start: i64) -> Self {
+        self.update(self.nn.shrink_start(start))
+    }
+
+    async fn shrink_end(&self, end: i64) -> Self {
+        self.update(self.nn.shrink_end(end))
+    }
+
+    ////////////////////////
+    //// TIME QUERIES //////
+    ////////////////////////
+
+    async fn start(&self) -> Option<i64> {
+        self.nn.start()
+    }
+
+    async fn end(&self) -> Option<i64> {
+        self.nn.end()
+    }
+
+    /////////////////
+    //// List ///////
+    /////////////////
+    async fn list(&self) -> Vec<Node> {
+        match self.filter.as_ref() {
+            None => self.nn.iter().map(|n| n.into()).collect(),
+            Some(filter) => self
+                .nn
+                .iter()
+                .map(|vv| vv.into())
+                .filter(|n| filter.matches(n))
+                .collect(),
+        }
+    }
+}

--- a/raphtory/src/db/api/view/internal/into_dynamic.rs
+++ b/raphtory/src/db/api/view/internal/into_dynamic.rs
@@ -1,23 +1,13 @@
-use crate::db::{
-    api::view::{internal::DynamicGraph, StaticGraphViewOps},
-    graph::views::{
-        layer_graph::LayeredGraph, node_subgraph::NodeSubgraph, window_graph::WindowedGraph,
-    },
+use crate::db::api::view::{
+    internal::{DynamicGraph, Static},
+    StaticGraphViewOps,
 };
-use enum_dispatch::enum_dispatch;
 
-#[enum_dispatch]
 pub trait IntoDynamic: 'static {
     fn into_dynamic(self) -> DynamicGraph;
 }
 
-impl<G: StaticGraphViewOps> IntoDynamic for WindowedGraph<G> {
-    fn into_dynamic(self) -> DynamicGraph {
-        DynamicGraph::new(self)
-    }
-}
-
-impl<G: StaticGraphViewOps> IntoDynamic for LayeredGraph<G> {
+impl<G: StaticGraphViewOps + Static> IntoDynamic for G {
     fn into_dynamic(self) -> DynamicGraph {
         DynamicGraph::new(self)
     }
@@ -26,11 +16,5 @@ impl<G: StaticGraphViewOps> IntoDynamic for LayeredGraph<G> {
 impl IntoDynamic for DynamicGraph {
     fn into_dynamic(self) -> DynamicGraph {
         self
-    }
-}
-
-impl<G: StaticGraphViewOps> IntoDynamic for NodeSubgraph<G> {
-    fn into_dynamic(self) -> DynamicGraph {
-        DynamicGraph::new(self)
     }
 }

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -40,7 +40,6 @@ use std::path::Path;
 
 #[enum_dispatch(CoreGraphOps)]
 #[enum_dispatch(InternalLayerOps)]
-#[enum_dispatch(IntoDynamic)]
 #[enum_dispatch(TimeSemantics)]
 #[enum_dispatch(EdgeFilterOps)]
 #[enum_dispatch(InternalMaterialize)]
@@ -54,6 +53,8 @@ pub enum MaterializedGraph {
     EventGraph(Graph),
     PersistentGraph(GraphWithDeletions),
 }
+
+impl Static for MaterializedGraph {}
 
 impl<'graph> GraphOps<'graph> for MaterializedGraph {
     fn internal_node_ref(

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -20,9 +20,7 @@ use crate::{
     core::{entities::graph::tgraph::InnerTemporalGraph, utils::errors::GraphError},
     db::api::{
         mutation::internal::{InheritAdditionOps, InheritPropertyAdditionOps},
-        view::internal::{
-            Base, DynamicGraph, InheritViewOps, IntoDynamic, MaterializedGraph, Static,
-        },
+        view::internal::{Base, InheritViewOps, MaterializedGraph, Static},
     },
     prelude::*,
 };
@@ -189,12 +187,6 @@ impl Graph {
 
     pub fn as_arc(&self) -> Arc<InternalGraph> {
         self.0.clone()
-    }
-}
-
-impl IntoDynamic for Graph {
-    fn into_dynamic(self) -> DynamicGraph {
-        DynamicGraph::new(self)
     }
 }
 

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -47,12 +47,6 @@ impl From<InternalGraph> for GraphWithDeletions {
     }
 }
 
-impl IntoDynamic for GraphWithDeletions {
-    fn into_dynamic(self) -> DynamicGraph {
-        DynamicGraph::new(self)
-    }
-}
-
 impl Display for GraphWithDeletions {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.graph, f)

--- a/raphtory/src/search/into_indexed.rs
+++ b/raphtory/src/search/into_indexed.rs
@@ -1,15 +1,9 @@
 use crate::{
     db::{
-        api::{
-            properties::{
-                dyn_props::{DynProperties, DynProps},
-                Properties,
-            },
-            view::{
-                internal::{DynamicGraph, IntoDynamic, OneHopFilter},
-                time::internal::InternalTimeOps,
-                StaticGraphViewOps,
-            },
+        api::view::{
+            internal::{DynamicGraph, IntoDynamic, OneHopFilter},
+            time::internal::InternalTimeOps,
+            StaticGraphViewOps,
         },
         graph::views::{
             layer_graph::LayeredGraph, node_subgraph::NodeSubgraph, window_graph::WindowedGraph,
@@ -18,7 +12,6 @@ use crate::{
     prelude::GraphViewOps,
     search::IndexedGraph,
 };
-use std::sync::Arc;
 
 pub trait DynamicIndexedGraph {
     fn into_dynamic_indexed(self) -> IndexedGraph<DynamicGraph>;
@@ -77,12 +70,5 @@ impl<G: StaticGraphViewOps + IntoDynamic> DynamicIndexedGraph for IndexedGraph<G
             reader: self.reader,
             edge_reader: self.edge_reader,
         }
-    }
-}
-
-impl From<Properties<IndexedGraph<DynamicGraph>>> for DynProperties {
-    fn from(value: Properties<IndexedGraph<DynamicGraph>>) -> Self {
-        let props: DynProps = Arc::new(value.props);
-        Properties::new(props)
     }
 }

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         api::{
             mutation::internal::InternalAdditionOps,
             view::{
-                internal::{DynamicGraph, InheritViewOps, IntoDynamic},
+                internal::{DynamicGraph, InheritViewOps, IntoDynamic, Static},
                 EdgeViewInternalOps, StaticGraphViewOps,
             },
         },
@@ -48,11 +48,7 @@ impl<G> Deref for IndexedGraph<G> {
     }
 }
 
-impl<G: StaticGraphViewOps> IntoDynamic for IndexedGraph<G> {
-    fn into_dynamic(self) -> DynamicGraph {
-        DynamicGraph::new(self)
-    }
-}
+impl<G: StaticGraphViewOps> Static for IndexedGraph<G> {}
 
 impl<G: StaticGraphViewOps> InheritViewOps for IndexedGraph<G> {}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

the nodes query on a graph now returns a Nodes object which properly implements window filtering (such that one can get filtered node lists)

### Why are the changes needed?

make it easier to work with 

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

added test that filters and updated existing tests

### Are there any further changes required?

Any existing nodes queries need to be updated to add the new `list` subquery

