### PR TITLE
fix is_valid on GraphWithDeletions

### DIFF
--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -479,9 +479,8 @@ impl TimeSemantics for GraphWithDeletions {
     fn edge_is_valid(&self, e: EdgeRef, layer_ids: LayerIds) -> bool {
         let edge = self.graph.core_edge(e.pid());
         let res = edge
-            .additions_iter(&layer_ids)
-            .zip(edge.deletions_iter(&layer_ids))
-            .any(|(a, d)| a.last() > d.last());
+            .updates_iter(&layer_ids)
+            .any(|(_, additions, deletions)| additions.last() > deletions.last());
         res
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the bug where an edge for GraphWithDeletions that is never deleted returns `is_valid() == false`



