### PR TITLE
Allow saving arbitrary serialized data to nodes

### DIFF
--- a/raphtory-graphql/Cargo.toml
+++ b/raphtory-graphql/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 homepage.workspace = true
 
 [dependencies]
-raphtory = { path = "../raphtory", version = "0.7.0", features = ['vectors', 'search'] }
+raphtory = { path = "../raphtory", version = "0.7.0", features = ['vectors', 'search', "io"] }
 bincode = "1"
 base64 = "0.21.2"
 thiserror = "1.0.44"

--- a/raphtory-graphql/Cargo.toml
+++ b/raphtory-graphql/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "1.0.44"
 dotenv = "0.15.0"
 itertools = "0.12.0"
 serde = {version = "1.0.147", features = ["derive"]}
+serde_json = "1.0"
 once_cell = "1.17.2"
 poem = "1.3.48"
 tokio = {version = "1.18.2", features = ["full"]}
@@ -41,6 +42,4 @@ uuid = "1.4.1"
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-serde_json = "1.0"
 tempfile = "3.6.0"
-

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -422,7 +422,7 @@ mod graphql_test {
         );
 
         // test save graph
-        let req = Request::new(save_graph("g0", r#""{ \"2\": \"{}\" }""#));
+        let req = Request::new(save_graph("g0", r#""{ \"2\": {} }""#));
         let res = schema.execute(req).await;
         println!("{:?}", res.errors);
         assert!(res.errors.is_empty());
@@ -435,7 +435,7 @@ mod graphql_test {
         );
 
         // test save graph overwrite
-        let req = Request::new(save_graph("g1", r#""{ \"1\": \"{}\" }""#));
+        let req = Request::new(save_graph("g1", r#""{ \"1\": {} }""#));
         let res = schema.execute(req).await;
         println!("{:?}", res.errors);
         assert!(res.errors.is_empty());

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -301,10 +301,10 @@ mod graphql_test {
         g0.save_to_file(f0).unwrap();
 
         let g1 = GraphWithDeletions::new();
-        g1.add_node(0, 1, NO_PROPS).unwrap();
+        g1.add_node(0, 1, [("name", "1")]).unwrap();
 
         let g2 = GraphWithDeletions::new();
-        g2.add_node(0, 2, NO_PROPS).unwrap();
+        g2.add_node(0, 2, [("name", "2")]).unwrap();
 
         let data = Data::default();
         let schema = App::create_schema().data(data).finish().unwrap();
@@ -422,7 +422,7 @@ mod graphql_test {
         );
 
         // test save graph
-        let req = Request::new(save_graph("g0", r#"["2"]"#));
+        let req = Request::new(save_graph("g0", r#""{ \"2\": \"{}\" }""#));
         let res = schema.execute(req).await;
         println!("{:?}", res.errors);
         assert!(res.errors.is_empty());
@@ -435,7 +435,7 @@ mod graphql_test {
         );
 
         // test save graph overwrite
-        let req = Request::new(save_graph("g1", r#"["1"]"#));
+        let req = Request::new(save_graph("g1", r#""{ \"1\": \"{}\" }""#));
         let res = schema.execute(req).await;
         println!("{:?}", res.errors);
         assert!(res.errors.is_empty());
@@ -529,7 +529,7 @@ mod graphql_test {
 
         let query = r#"
         mutation($graph: String!) {
-            sendGraph(name: "test", graph: $graph) 
+            sendGraph(name: "test", graph: $graph)
         }
         "#;
         let req =

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -11,8 +11,8 @@ use dynamic_graphql::{
 };
 use itertools::Itertools;
 use raphtory::{
-    core::{utils::errors::GraphError, ArcStr, Prop, entities::nodes::node::Node},
-    db::api::{view::MaterializedGraph, mutation::CollectProperties},
+    core::{entities::nodes::node::Node, utils::errors::GraphError, ArcStr, Prop},
+    db::api::{mutation::CollectProperties, view::MaterializedGraph},
     prelude::{GraphViewOps, NodeViewOps, PropertyAdditionOps},
     search::IndexedGraph,
 };
@@ -203,7 +203,9 @@ impl Mut {
         let parent_graph = data.get(&parent_graph_name).ok_or("Graph not found")?;
 
         let deserialized_node_map: serde_json::Value = serde_json::from_str(graph_nodes.as_str())?;
-        let node_map = deserialized_node_map.as_object().ok_or("graph_nodes not object")?;
+        let node_map = deserialized_node_map
+            .as_object()
+            .ok_or("graph_nodes not object")?;
         let node_ids = node_map.keys().map(|key| key.as_str());
         let new_subgraph = parent_graph.subgraph(node_ids).materialize()?;
 
@@ -250,7 +252,10 @@ impl Mut {
             }
             let node_props = node_map
                 .get(node.name().to_string().as_str())
-                .ok_or(format!("Could not find node {} in provided map", node.name()))?;
+                .ok_or(format!(
+                    "Could not find node {} in provided map",
+                    node.name()
+                ))?;
             let node_props_as_str = node_props.as_str().ok_or("node_props must be string")?;
             node.update_constant_properties([("props", node_props_as_str)])?;
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The ability to save arbitrary serialized data on a per-node basis through GraphQL

### Why are the changes needed?

To enable saving of per-node properties (in a slightly hacky way, as a first step).

### Does this PR introduce any user-facing change? If yes is this documented?

No but we plan on trying to move towards using the actual rust graphs inside JS in the future instead of taking this route.

### How was this patch tested?

The existing save_graph test was patched for this new API

### Are there any further changes required?

In the future we need to evaluate using rust graphs on client-side instead of using this method.


