### PR TITLE
Fix archive graph not keeping node props

### DIFF
--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -333,9 +333,18 @@ impl Mut {
         parent_graph_name: String,
         is_archive: u8,
     ) -> Result<bool> {
-        let mut data = ctx.data_unchecked::<Data>().graphs.write();
+        let data = ctx.data_unchecked::<Data>().graphs.write();
         let subgraph = data.get(&graph_name).ok_or("Graph not found")?;
         subgraph.update_constant_properties([("isArchive", Prop::U8(is_archive))])?;
+
+        let path = subgraph
+            .properties()
+            .constant()
+            .get("path")
+            .ok_or("Path is missing")?
+            .to_string();
+        subgraph.save_to_file(path)?;
+
         Ok(true)
     }
 }

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -334,34 +334,8 @@ impl Mut {
         is_archive: u8,
     ) -> Result<bool> {
         let mut data = ctx.data_unchecked::<Data>().graphs.write();
-
         let subgraph = data.get(&graph_name).ok_or("Graph not found")?;
-
-        let path = subgraph
-            .properties()
-            .constant()
-            .get("path")
-            .ok_or("Path is missing")?
-            .to_string();
-
-        let parent_graph = data.get(&parent_graph_name).ok_or("Graph not found")?;
-        let new_subgraph = parent_graph
-            .subgraph(subgraph.nodes().iter().map(|v| v.name()).collect_vec())
-            .materialize()?;
-
-        let static_props_without_isactive: Vec<(ArcStr, Prop)> = subgraph
-            .properties()
-            .into_iter()
-            .filter(|(a, _)| a != "isArchive")
-            .collect_vec();
-        new_subgraph.update_constant_properties(static_props_without_isactive)?;
-        new_subgraph.update_constant_properties([("isArchive", Prop::U8(is_archive))])?;
-        new_subgraph.save_to_file(path)?;
-
-        let gi: IndexedGraph<MaterializedGraph> = new_subgraph.into();
-
-        data.insert(graph_name, gi);
-
+        subgraph.update_constant_properties([("isArchive", Prop::U8(is_archive))])?;
         Ok(true)
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the `archive_graph` implementation to extract all the information from the subgraph instead of looking at the parent graph. 

### Why are the changes needed?
These changes are needed so that any properties stored in the nodes of the subgraphs are kept when archiving it.

### Does this PR introduce any user-facing change? If yes is this documented?
No. Indeed, the parameter `parent_graph_name` has been kept to avoid causing any breaking changes even though is not needed. Instead, a more generic mutation query to update properties in graphs should be added.

### How was this patch tested?
This was tested manually, the implementation is now very simple.

### Are there any further changes required?
No