### PR TITLE
Allow props to be returned as JSON & Upgrade rust to 1.75

### DIFF
--- a/.environment.yml
+++ b/.environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - python_abi=3.10
   - readline>=8.1.2
   - libzlib>=1.2.13
-  - rust=1.73.0
+  - rust=1.75.0
   - setuptools=61.2.0
   - sqlite>=3.38.3
   - tk>=8.6.11

--- a/.github/workflows/_release_rust.yml
+++ b/.github/workflows/_release_rust.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
       - name: "Install cargo release"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
         name: Setup Rust
         with:
           profile: minimal
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
       - name: Cargo update

--- a/.github/workflows/release_bump_versions.yml
+++ b/.github/workflows/release_bump_versions.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
       - name: "Install cargo release"

--- a/.github/workflows/test_python_workflow.yml
+++ b/.github/workflows/test_python_workflow.yml
@@ -81,7 +81,7 @@ jobs:
         name: Setup Rust
         with:
           profile: minimal
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
       - name: Install sccache (macOS)

--- a/.github/workflows/test_rust_workflow.yml
+++ b/.github/workflows/test_rust_workflow.yml
@@ -53,6 +53,12 @@ jobs:
           toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
+      - name: Free up space (ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Install sccache (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install sccache

--- a/.github/workflows/test_rust_workflow.yml
+++ b/.github/workflows/test_rust_workflow.yml
@@ -50,7 +50,7 @@ jobs:
         name: Setup Rust
         with:
           profile: minimal
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
       - name: Install sccache (macOS)
@@ -139,7 +139,7 @@ jobs:
         name: Setup Rust
         with:
           profile: minimal
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
       - name: Install sccache (Ubuntu)

--- a/raphtory-graphql/src/model/graph/property.rs
+++ b/raphtory-graphql/src/model/graph/property.rs
@@ -6,6 +6,7 @@ use raphtory::{
         TemporalPropertyView,
     },
 };
+use std::collections::HashMap;
 
 #[derive(ResolvedObject)]
 pub(crate) struct GqlProp {

--- a/raphtory-graphql/src/model/graph/property.rs
+++ b/raphtory-graphql/src/model/graph/property.rs
@@ -8,7 +8,6 @@ use raphtory::{
     },
 };
 use serde_json::{json, Value as JsonValue};
-use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Scalar)]
 pub struct GqlJson(JsonValue);
@@ -77,7 +76,7 @@ impl GqlProp {
         self.prop.to_string()
     }
 
-    async fn to_json(&self) -> GqlJson {
+    async fn value(&self) -> GqlJson {
         let json_value: JsonValue = self.prop.to_json();
         GqlJson::from(json_value)
     }

--- a/raphtory/Cargo.toml
+++ b/raphtory/Cargo.toml
@@ -37,6 +37,7 @@ enum_dispatch = "0.3"
 ordered-float = "4.1.1"
 glam = "0.25.0"
 quad-rand = "0.2.1"
+serde_json = "1"
 
 # io optional dependencies
 csv = {version="1.1.6", optional=true}
@@ -44,7 +45,6 @@ zip = {version ="0.6.6", optional=true}
 neo4rs = {version="0.6.1", optional=true}
 bzip2 = {version="0.4", optional=true}
 flate2 = {version="1.0", optional=true}
-serde_json = {version="1", optional=true}
 reqwest = { version = "0.11.14", features = ["blocking"], optional=true}
 tokio = { version = "1.27.0", features = ["full"], optional=true}
 
@@ -80,7 +80,7 @@ proptest = "1.4.0"
 [features]
 default = []
 # Enables the graph loader io module
-io = ["dep:zip", "dep:neo4rs", "dep:bzip2", "dep:flate2", "dep:csv", "dep:serde_json", "dep:reqwest", "dep:tokio"]
+io = ["dep:zip", "dep:neo4rs", "dep:bzip2", "dep:flate2", "dep:csv", "dep:reqwest", "dep:tokio"]
 # Enables generating the pyo3 python bindings
 python = ["io", "dep:pyo3", "dep:pyo3-asyncio", "dep:num", "dep:display-error-chain", "dep:arrow2", "dep:kdam"]
 # search

--- a/raphtory/src/core/mod.rs
+++ b/raphtory/src/core/mod.rs
@@ -27,6 +27,7 @@
 use crate::{db::graph::graph::Graph, prelude::GraphViewOps};
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::{
     borrow::Borrow,
     cmp::Ordering,
@@ -171,6 +172,34 @@ impl PartialOrd for Prop {
 }
 
 impl Prop {
+    pub fn to_json(&self) -> Value {
+        match self {
+            Prop::Str(value) => Value::String(value.to_string()),
+            Prop::U8(value) => Value::Number((*value).into()),
+            Prop::U16(value) => Value::Number((*value).into()),
+            Prop::I32(value) => Value::Number((*value).into()),
+            Prop::I64(value) => Value::Number((*value).into()),
+            Prop::U32(value) => Value::Number((*value).into()),
+            Prop::U64(value) => Value::Number((*value).into()),
+            Prop::F32(value) => Value::Number(serde_json::Number::from_f64(*value as f64).unwrap()),
+            Prop::F64(value) => Value::Number(serde_json::Number::from_f64(*value).unwrap()),
+            Prop::Bool(value) => Value::Bool(*value),
+            Prop::List(value) => {
+                let vec: Vec<Value> = value.iter().map(|v| v.to_json()).collect();
+                Value::Array(vec)
+            }
+            Prop::Map(value) => {
+                let map: serde_json::Map<String, Value> = value
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_json()))
+                    .collect();
+                Value::Object(map)
+            }
+            Prop::DTime(value) => Value::String(value.to_string()),
+            Prop::Graph(_) => Value::String("Graph cannot be converted to JSON".to_string()),
+        }
+    }
+
     pub fn dtype(&self) -> PropType {
         match self {
             Prop::Str(_) => PropType::Str,

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -304,6 +304,36 @@ mod db_tests {
     }
 
     #[test]
+    fn prop_json_test() {
+        let g = Graph::new();
+        let _ = g.add_node(0, "A", NO_PROPS).unwrap();
+        let _ = g.add_node(0, "B", NO_PROPS).unwrap();
+        let e = g.add_edge(0, "A", "B", NO_PROPS, None).unwrap();
+        e.add_constant_properties(vec![("aprop".to_string(), Prop::Bool(true))], None)
+            .unwrap();
+        assert_eq!(
+            e.properties().constant().get("aprop").unwrap().to_json(),
+            true
+        );
+        let ee = g.add_edge(0, "A", "B", NO_PROPS, Some(&"LAYERA")).unwrap();
+        ee.add_constant_properties(
+            vec![("aprop".to_string(), Prop::Bool(false))],
+            Some(&"LAYERA"),
+        )
+        .unwrap();
+        println!(
+            "{:?}",
+            g.edge("A", "B")
+                .unwrap()
+                .properties()
+                .constant()
+                .get("aprop")
+                .unwrap()
+                .to_json()
+        );
+    }
+
+    #[test]
     fn import_from_another_graph() {
         let g = Graph::new();
         let g_a = g.add_node(0, "A", NO_PROPS).unwrap();
@@ -353,6 +383,20 @@ mod db_tests {
         let gg = Graph::new();
         let res = gg.import_edges(vec![&e_a_b, &e_c_d], None).unwrap();
         assert_eq!(res.len(), 2);
+    }
+
+    #[test]
+    fn props_with_layers() {
+        let g = Graph::new();
+        g.add_edge(0, "A", "B", NO_PROPS, None).unwrap();
+        let ed = g.edge("A", "B").unwrap();
+        ed.add_constant_properties(vec![("CCC", Prop::str("RED"))], None)
+            .unwrap();
+        println!("{:?}", ed.properties().constant().as_map());
+        g.add_edge(0, "A", "B", NO_PROPS, Some("LAYERONE")).unwrap();
+        ed.add_constant_properties(vec![("CCC", Prop::str("BLUE"))], Some("LAYERONE"))
+            .unwrap();
+        println!("{:?}", ed.properties().constant().as_map());
     }
 
     #[test]


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Allows props to be returned as a JSON object via the `to_json` function in both rust and graphql
- Upgraded rust env to all use 1.75

### Why are the changes needed?

For GQLProps via GraphQL

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

Multiple tests

### Issues

### Are there any further changes required?


