### PR TITLE
Require higher version of maturin

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1.4.0"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Requiring a higher version of maturin

### Why are the changes needed?

Maturin's current highest version is 1.4.0, which is what I have tested with the python build. While I'm sure the very latest version of Maturin is required, I've tried installing with the currently listed version (0.13), and that did not seem to work as it was too old.

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

Tested with Maturin 1.4.0 (for the proposed change) and 0.13 (for the current version).

### Issues

N/A

### Are there any further changes required?

No
