### PR TITLE
load_from_pandas is scrambling node order

### DIFF
--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -424,6 +424,16 @@ impl PyGraph {
         let graph = PyGraph {
             graph: Graph::new(),
         };
+        if let (Some(node_df), Some(node_id), Some(node_time)) = (node_df, node_id, node_time) {
+            graph.load_nodes_from_pandas(
+                node_df,
+                node_id,
+                node_time,
+                node_type,
+                node_props,
+                node_const_props,
+                node_shared_const_props,
+            )?;
         graph.load_edges_from_pandas(
             edge_df,
             edge_src,
@@ -435,16 +445,6 @@ impl PyGraph {
             edge_layer,
             layer_in_df,
         )?;
-        if let (Some(node_df), Some(node_id), Some(node_time)) = (node_df, node_id, node_time) {
-            graph.load_nodes_from_pandas(
-                node_df,
-                node_id,
-                node_time,
-                node_type,
-                node_props,
-                node_const_props,
-                node_shared_const_props,
-            )?;
         }
         Ok(graph.graph)
     }

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -434,17 +434,17 @@ impl PyGraph {
                 node_const_props,
                 node_shared_const_props,
             )?;
-        graph.load_edges_from_pandas(
-            edge_df,
-            edge_src,
-            edge_dst,
-            edge_time,
-            edge_props,
-            edge_const_props,
-            edge_shared_const_props,
-            edge_layer,
-            layer_in_df,
-        )?;
+            graph.load_edges_from_pandas(
+                edge_df,
+                edge_src,
+                edge_dst,
+                edge_time,
+                edge_props,
+                edge_const_props,
+                edge_shared_const_props,
+                edge_layer,
+                layer_in_df,
+            )?;
         }
         Ok(graph.graph)
     }

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -434,18 +434,18 @@ impl PyGraph {
                 node_const_props,
                 node_shared_const_props,
             )?;
-            graph.load_edges_from_pandas(
-                edge_df,
-                edge_src,
-                edge_dst,
-                edge_time,
-                edge_props,
-                edge_const_props,
-                edge_shared_const_props,
-                edge_layer,
-                layer_in_df,
-            )?;
         }
+        graph.load_edges_from_pandas(
+            edge_df,
+            edge_src,
+            edge_dst,
+            edge_time,
+            edge_props,
+            edge_const_props,
+            edge_shared_const_props,
+            edge_layer,
+            layer_in_df,
+        )?;
         Ok(graph.graph)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make sure nodes are added to the graph in the same order as the node df when provided

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


