### PR TITLE
internal property apis are not supposed to be public

### DIFF
--- a/raphtory/src/db/api/properties/mod.rs
+++ b/raphtory/src/db/api/properties/mod.rs
@@ -1,6 +1,6 @@
 mod constant_props;
 pub mod dyn_props;
-pub mod internal;
+pub(crate) mod internal;
 mod props;
 mod temporal_props;
 


### PR DESCRIPTION
Internal properties apis were accidentally marked as `pub` instead of `pub(crate)` which makes it easy to accidentally use them instead of the public apis.


