### PR TITLE
supported empty node types while node type filtering

### DIFF
--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -2092,6 +2092,9 @@ def test_type_filter():
     g.add_node(1, 4, node_type="a")
     g.add_node(1, 5, node_type="c")
     g.add_node(1, 6, node_type="e")
+    g.add_node(1, 7)
+    g.add_node(1, 8)
+    g.add_node(1, 9)
     g.add_edge(2, 1, 2, layer="a")
     g.add_edge(2, 3, 2, layer="a")
     g.add_edge(2, 2, 4, layer="a")
@@ -2104,12 +2107,12 @@ def test_type_filter():
     assert g.nodes.type_filter(["a", "c"]).name.collect() == ['1', '4', '5']
     assert g.nodes.type_filter(["a"]).neighbours.name.collect() == [['2'], ['2', '5']]
 
-    assert g.nodes.degree().collect() == [1, 3, 2, 2, 2, 2]
+    assert g.nodes.degree().collect() == [1, 3, 2, 2, 2, 2, 0, 0, 0]
     assert g.nodes.type_filter(['a']).degree().collect() == [1, 2]
     assert g.nodes.type_filter(['d']).degree().collect() == []
     assert g.nodes.type_filter([]).name.collect() == []
 
-    assert len(g.nodes) == 6
+    assert len(g.nodes) == 9
     assert len(g.nodes.type_filter(['b'])) == 2
     assert len(g.nodes.type_filter(['d'])) == 0
 

--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -2103,6 +2103,8 @@ def test_type_filter():
     g.add_edge(2, 5, 6, layer="a")
     g.add_edge(2, 3, 6, layer="a")
 
+    assert g.nodes.type_filter([""]).name.collect() == ['7', '8', '9']
+
     assert g.nodes.type_filter(["a"]).name.collect() == ['1', '4']
     assert g.nodes.type_filter(["a", "c"]).name.collect() == ['1', '4', '5']
     assert g.nodes.type_filter(["a"]).neighbours.name.collect() == [['2'], ['2', '5']]

--- a/raphtory/src/db/api/view/node.rs
+++ b/raphtory/src/db/api/view/node.rs
@@ -77,7 +77,7 @@ pub trait NodeViewOps<'graph>: Clone + TimeOps<'graph> + LayerOps<'graph> {
 
     /// Returns the type of node
     fn node_type(&self) -> Self::ValueType<Option<ArcStr>>;
-
+    fn node_type_id(&self) -> Self::ValueType<usize>;
     /// Get the timestamp for the earliest activity of the node
     fn earliest_time(&self) -> Self::ValueType<Option<i64>>;
 
@@ -184,6 +184,10 @@ impl<'graph, V: BaseNodeViewOps<'graph> + 'graph> NodeViewOps<'graph> for V {
     #[inline]
     fn node_type(&self) -> Self::ValueType<Option<ArcStr>> {
         self.map(|_cg, g, v| g.node_type(v))
+    }
+    #[inline]
+    fn node_type_id(&self) -> Self::ValueType<usize> {
+        self.map(|_cg, g, v| g.node_type_id(v))
     }
     #[inline]
     fn earliest_time(&self) -> Self::ValueType<Option<i64>> {

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -200,6 +200,7 @@ mod db_tests {
     use super::*;
     use crate::{
         algorithms::components::weakly_connected_components,
+        arrow::graph_impl::ArrowGraph,
         core::{
             utils::time::{error::ParseTimeError, TryIntoTime},
             ArcStr, OptionAsStr, Prop,
@@ -2510,6 +2511,9 @@ mod db_tests {
         g.add_node(1, 4, NO_PROPS, Some("a")).unwrap();
         g.add_node(1, 5, NO_PROPS, Some("c")).unwrap();
         g.add_node(1, 6, NO_PROPS, Some("e")).unwrap();
+        g.add_node(1, 7, NO_PROPS, None).unwrap();
+        g.add_node(1, 8, NO_PROPS, None).unwrap();
+        g.add_node(1, 9, NO_PROPS, None).unwrap();
         g.add_edge(2, 1, 2, NO_PROPS, Some("a")).unwrap();
         g.add_edge(2, 3, 2, NO_PROPS, Some("a")).unwrap();
         g.add_edge(2, 2, 4, NO_PROPS, Some("a")).unwrap();
@@ -2517,6 +2521,27 @@ mod db_tests {
         g.add_edge(2, 4, 5, NO_PROPS, Some("a")).unwrap();
         g.add_edge(2, 5, 6, NO_PROPS, Some("a")).unwrap();
         g.add_edge(2, 3, 6, NO_PROPS, Some("a")).unwrap();
+
+        assert_eq!(
+            g.nodes()
+                .type_filter(&vec!["a", "b", "c", "e"])
+                .name()
+                .collect_vec(),
+            vec!["1", "2", "3", "4", "5", "6"]
+        );
+
+        assert_eq!(
+            g.nodes()
+                .type_filter(&Vec::<String>::new())
+                .name()
+                .collect_vec(),
+            Vec::<String>::new()
+        );
+
+        assert_eq!(
+            g.nodes().type_filter(&vec![""]).name().collect_vec(),
+            vec!["7", "8", "9"]
+        );
 
         let w = g.window(1, 4);
         assert_eq!(
@@ -2580,7 +2605,7 @@ mod db_tests {
 
         assert_eq!(
             g.nodes().iter().map(|v| v.degree()).collect::<Vec<_>>(),
-            vec![1, 3, 2, 2, 2, 2]
+            vec![1, 3, 2, 2, 2, 2, 0, 0, 0]
         );
         assert_eq!(
             g.nodes()
@@ -2634,7 +2659,7 @@ mod db_tests {
             Vec::<&str>::new()
         );
 
-        assert_eq!(g.nodes().len(), 6);
+        assert_eq!(g.nodes().len(), 9);
         assert_eq!(g.nodes().type_filter(&vec!["b"]).len(), 2);
         assert_eq!(g.nodes().type_filter(&vec!["d"]).len(), 0);
 
@@ -2756,6 +2781,9 @@ mod db_tests {
                 vec!["1", "3", "4", "4", "6"],
                 vec!["2", "5", "3", "5"],
                 vec!["2", "6", "4", "6"],
+                vec![],
+                vec![],
+                vec![],
             ]
         );
 
@@ -3037,7 +3065,7 @@ mod db_tests {
                 (2, "open".to_string()),
                 (3, "review".to_string()),
                 (4, "open".to_string()),
-                (10, "in-progress".to_string())
+                (10, "in-progress".to_string()),
             ]
         );
 
@@ -3059,7 +3087,7 @@ mod db_tests {
                 (1, "open".to_string()),
                 (3, "review".to_string()),
                 (4, "open".to_string()),
-                (5, "in-progress".to_string())
+                (5, "in-progress".to_string()),
             ]
         );
     }

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -200,7 +200,6 @@ mod db_tests {
     use super::*;
     use crate::{
         algorithms::components::weakly_connected_components,
-        arrow::graph_impl::ArrowGraph,
         core::{
             utils::time::{error::ParseTimeError, TryIntoTime},
             ArcStr, OptionAsStr, Prop,

--- a/raphtory/src/db/graph/mod.rs
+++ b/raphtory/src/db/graph/mod.rs
@@ -1,4 +1,5 @@
 use crate::core::entities::properties::props::DictMapper;
+use itertools::Itertools;
 use std::sync::Arc;
 
 pub mod edge;
@@ -17,10 +18,12 @@ pub(crate) fn create_node_type_filter(
     let mut bool_arr = vec![false; len];
 
     for nt in node_types {
-        if let Some(id) = dict_mapper.get_id(nt.as_ref()) {
+        let nt = nt.as_ref();
+        if nt.is_empty() {
+            bool_arr[0] = true;
+        } else if let Some(id) = dict_mapper.get_id(nt) {
             bool_arr[id] = true;
         }
     }
-
     bool_arr.into()
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support empty node type filter. For example, node_types = ["a", ""]

### Why are the changes needed?
Same as above

### Does this PR introduce any user-facing change? If yes is this documented?
Yes

### How was this patch tested?
Unit test

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?
No

