### PR TITLE
fix issue with path while saving and loading graphs

### DIFF
--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -962,12 +962,12 @@ def test_save_load_graph():
     g.add_edge(5, 12, 13, {"prop1": 1321, "prop2": 9.8, "prop3": "test"})
     g.add_edge(6, 13, 11, {"prop1": 645, "prop2": 9.8, "prop3": "test"})
 
-    graph_file_name = "graph"
-    g.save_to_file(graph_file_name)
+    graph_rel_path = "graph"
+    g.save_to_file(graph_rel_path)
 
     del g
 
-    g = Graph.load_from_file(graph_file_name)
+    g = Graph.load_from_file(graph_rel_path)
 
     view = g.window(0, 10)
     assert g.has_node(13)
@@ -983,7 +983,21 @@ def test_save_load_graph():
     v = view.node(11)
     assert v.properties.temporal == {"type": [(1, "wallet")], "balance": [(1, 99.5)]}
 
-    os.remove(graph_file_name)
+    os.remove(graph_rel_path)
+    
+    tmpdirname = tempfile.TemporaryDirectory()
+    graph_abs_path = tmpdirname.name + "/test_graph.bin"
+    g.save_to_file(graph_abs_path)
+
+    del g
+
+    g = Graph.load_from_file(graph_abs_path)
+
+    view = g.window(0, 10)
+    assert g.has_node(13)
+    assert view.node(13).in_degree() == 1
+    
+    tmpdirname.cleanup()
 
 
 def test_graph_at():

--- a/python/tests/test_graphdb.py
+++ b/python/tests/test_graphdb.py
@@ -962,13 +962,12 @@ def test_save_load_graph():
     g.add_edge(5, 12, 13, {"prop1": 1321, "prop2": 9.8, "prop3": "test"})
     g.add_edge(6, 13, 11, {"prop1": 645, "prop2": 9.8, "prop3": "test"})
 
-    tmpdirname = tempfile.TemporaryDirectory()
-    graph_path = tmpdirname.name + "/test_graph.bin"
-    g.save_to_file(graph_path)
+    graph_file_name = "graph"
+    g.save_to_file(graph_file_name)
 
     del g
 
-    g = Graph.load_from_file(graph_path)
+    g = Graph.load_from_file(graph_file_name)
 
     view = g.window(0, 10)
     assert g.has_node(13)
@@ -984,7 +983,7 @@ def test_save_load_graph():
     v = view.node(11)
     assert v.properties.temporal == {"type": [(1, "wallet")], "balance": [(1, 99.5)]}
 
-    tmpdirname.cleanup()
+    os.remove(graph_file_name)
 
 
 def test_graph_at():

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -338,8 +338,7 @@ impl PyGraph {
     #[staticmethod]
     #[pyo3(signature = (path, force = false))]
     pub fn load_from_file(path: &str, force: bool) -> Result<Graph, GraphError> {
-        let file_path: PathBuf = [env!("CARGO_MANIFEST_DIR"), path].iter().collect();
-        Graph::load_from_file(file_path, force)
+        Graph::load_from_file(path, force)
     }
 
     /// Saves the graph to the given path.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Saving graph to a relative path was not getting loaded from the same path

### Why are the changes needed?
Same as above

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
No

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?
No
