### PR TITLE
Fixed documentation to state nodes instead of edges for find_nodes

### DIFF
--- a/raphtory/src/python/graph/views/graph_view.rs
+++ b/raphtory/src/python/graph/views/graph_view.rs
@@ -218,11 +218,11 @@ impl PyGraphView {
         self.graph.node(id)
     }
 
-    /// Get the edges that match the properties name and value
+    /// Get the nodes that match the properties name and value
     /// Arguments:
     ///     property_dict (dict): the properties name and value
     /// Returns:
-    ///    the edges that match the properties name and value
+    ///    the nodes that match the properties name and value
     #[pyo3(signature = (properties_dict))]
     pub fn find_nodes(&self, properties_dict: HashMap<String, Prop>) -> Vec<PyNode> {
         let iter = self.nodes().into_iter().par_bridge();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Documentation fix

### Why are the changes needed?

The documentation currently states that `find_nodes` returns `edges` which is wrong.

```python
find_nodes(properties_dict)
Get the edges that match the properties name and value :param property_dict: the properties name and value :type property_dict: dict
```

This PR corrects the documentation so it says `nodes` instead of `edges`.


### Does this PR introduce any user-facing change? If yes is this documented?

No, it just updates documentation strings so they use the correct object for the function being described

### How was this patch tested?

Unfortunately, I have not been able to get the documentation to build locally yet...

### Issues

None

### Are there any further changes required?

No

