### PR TITLE
make the benchmark names consistent again

### DIFF
--- a/raphtory-benchmark/benches/base.rs
+++ b/raphtory-benchmark/benches/base.rs
@@ -43,7 +43,7 @@ pub fn base(c: &mut Criterion) {
         }
     }
 
-    run_graph_ops_benches(c, "lotr", graph, layered_graph)
+    run_graph_ops_benches(c, "lotr_graph", graph, layered_graph)
 }
 
 criterion_group!(benches, base);

--- a/raphtory-benchmark/benches/common/mod.rs
+++ b/raphtory-benchmark/benches/common/mod.rs
@@ -472,7 +472,7 @@ pub fn run_graph_ops_benches(
     bench_materialise(&format!("{graph_name}_materialise"), c, make_graph);
 
     // graph windowed
-    let group_name = format!("{graph_name}_graph_window_10");
+    let group_name = format!("{graph_name}_window_10");
     let mut graph_window_group_10 = c.benchmark_group(group_name);
     let latest = graph.latest_time().expect("non-empty graph");
     let earliest = graph.earliest_time().expect("non-empty graph");
@@ -513,7 +513,7 @@ pub fn run_graph_ops_benches(
 
     // layered graph windowed
     let graph = layered_graph;
-    let group_name = format!("{graph_name}_graph_window_50_layered");
+    let group_name = format!("{graph_name}_window_50_layered");
     let mut graph_window_layered_group_50 = c.benchmark_group(group_name);
     let latest = graph.latest_time().expect("non-empty graph");
     let earliest = graph.earliest_time().expect("non-empty graph");


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the benchmark names so they are consistent with past results

### Why are the changes needed?

Some benchmarks had changed names by accident

### Does this PR introduce any user-facing change? If yes is this documented?

no

