### PR TITLE
much cleaner and easier way to test all the features compile

### DIFF
--- a/.github/workflows/test_rust_disk_storage_workflow.yml
+++ b/.github/workflows/test_rust_disk_storage_workflow.yml
@@ -62,11 +62,11 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - name: Activate pometry-storage in Cargo.toml
         run: make pull-storage
-      - name: Check features combinations
+      - name: Check all features
         env:
           RUSTFLAGS: -Awarnings
         run: |
-          cargo hack check --workspace --all-targets --feature-powerset --depth 2  --skip extension-module,default
+          cargo hack check --workspace --all-targets --each-feature  --skip extension-module,default
       - name: Run all Tests (disk_graph)
         env:
           RUSTFLAGS: -Awarnings ${{ matrix.flags }}

--- a/.github/workflows/test_rust_disk_storage_workflow.yml
+++ b/.github/workflows/test_rust_disk_storage_workflow.yml
@@ -62,15 +62,16 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - name: Activate pometry-storage in Cargo.toml
         run: make pull-storage
-      - name: Check all features
-        env:
-          RUSTFLAGS: -Awarnings
-        run: |
-          cargo hack check --workspace --all-targets --each-feature  --skip extension-module,default
       - name: Run all Tests (disk_graph)
         env:
           RUSTFLAGS: -Awarnings ${{ matrix.flags }}
           TEMPDIR: ${{ runner.temp }}
         run: |
           cargo nextest run --all --no-default-features --features "storage"
+      - name: Check all features
+        env:
+          RUSTFLAGS: -Awarnings
+        run: |
+          cargo hack check --workspace --all-targets --each-feature  --skip extension-module,default
+
 

--- a/.github/workflows/test_rust_disk_storage_workflow.yml
+++ b/.github/workflows/test_rust_disk_storage_workflow.yml
@@ -58,6 +58,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - name: Activate pometry-storage in Cargo.toml
         run: make pull-storage
       - name: Run all Tests (disk_graph)
@@ -66,28 +68,8 @@ jobs:
           TEMPDIR: ${{ runner.temp }}
         run: |
           cargo nextest run --all --no-default-features --features "storage"
-      - name: Run Tests (features=io)
+      - name: Check features combinations
         env:
           RUSTFLAGS: -Awarnings
         run: |
-          cargo check -p raphtory --no-default-features --features "io"
-      - name: Run Tests (features=python)
-        env:
-          RUSTFLAGS: -Awarnings
-        run: |
-          cargo check -p raphtory --no-default-features --features "python"
-      - name: Run Tests (features=search)
-        env:
-          RUSTFLAGS: -Awarnings
-        run: |
-          cargo check -p raphtory --no-default-features --features "search"
-      - name: Run Tests (features=vectors)
-        env:
-          RUSTFLAGS: -Awarnings
-        run: |
-          cargo check -p raphtory --no-default-features --features "vectors"
-      - name: Run Tests (features=storage)
-        env:
-          RUSTFLAGS: -Awarnings
-        run: |
-          cargo check -p raphtory --no-default-features --features "storage"
+          cargo hack check --workspace --all-targets --feature-powerset --depth 2  --skip extension-module,default

--- a/.github/workflows/test_rust_disk_storage_workflow.yml
+++ b/.github/workflows/test_rust_disk_storage_workflow.yml
@@ -62,14 +62,15 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - name: Activate pometry-storage in Cargo.toml
         run: make pull-storage
+      - name: Check features combinations
+        env:
+          RUSTFLAGS: -Awarnings
+        run: |
+          cargo hack check --workspace --all-targets --feature-powerset --depth 2  --skip extension-module,default
       - name: Run all Tests (disk_graph)
         env:
           RUSTFLAGS: -Awarnings ${{ matrix.flags }}
           TEMPDIR: ${{ runner.temp }}
         run: |
           cargo nextest run --all --no-default-features --features "storage"
-      - name: Check features combinations
-        env:
-          RUSTFLAGS: -Awarnings
-        run: |
-          cargo hack check --workspace --all-targets --feature-powerset --depth 2  --skip extension-module,default
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 homepage = "https://github.com/Raphtory/raphtory/"
 keywords = ["graph", "temporal-graph", "temporal"]
 authors = ["Pometry"]
-rust-version = "1.80"
+rust-version = "1.80.0"
 edition = "2021"
 
 [profile.dev]


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Tweaks the CI workflow for the features check to use `cargo hack` instead of manually testing each feature
- Specify minimum rust version as 1.80.0 so caches aren't invalidated on point updates

### Why are the changes needed?

Future-proof way to test all features actually compile even if we add new features in the future

### Does this PR introduce any user-facing change? If yes is this documented?

No, just tweaks the CI workflows



