### PR TITLE
Write-locked graph storage implementation for faster bulk loaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4344,6 +4344,7 @@ dependencies = [
  "async-openai",
  "async-trait",
  "bincode",
+ "bytemuck",
  "bzip2",
  "chrono",
  "csv",
@@ -4402,6 +4403,7 @@ dependencies = [
 name = "raphtory-api"
 version = "0.11.2"
 dependencies = [
+ "bytemuck",
  "chrono",
  "dashmap 6.0.1",
  "lock_api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,9 +840,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ wasm-bindgen-test = "0.3.41"
 memmap2 = { version = "0.9.4" }
 ahash = { version = "0.8.3", features = ["serde"] }
 strum = { version = "0.26.1", features = ["derive"] }
-bytemuck = { version = "1.15.0" }
+bytemuck = { version = "1.15.0", features = ["derive"] }
 ouroboros = "0.18.3"
 url = "2.2"
 base64-compat = { package = "base64-compat", version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ wasm-bindgen-test = "0.3.41"
 memmap2 = { version = "0.9.4" }
 ahash = { version = "0.8.3", features = ["serde"] }
 strum = { version = "0.26.1", features = ["derive"] }
-bytemuck = { version = "1.15.0", features = ["derive"] }
+bytemuck = { version = "1.18.0", features = ["derive"] }
 ouroboros = "0.18.3"
 url = "2.2"
 base64-compat = { package = "base64-compat", version = "1.0.0" }

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ python-fmt:
 
 tidy: rust-fmt stubs python-fmt
 
-build-python:
+build-python: activate-storage
 	cd python && maturin develop -r --features storage
 
 python-docs:

--- a/raphtory-api/Cargo.toml
+++ b/raphtory-api/Cargo.toml
@@ -16,6 +16,7 @@ edition.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
+bytemuck = { workspace = true }
 chrono.workspace = true
 dashmap = { workspace = true }
 rustc-hash = { workspace = true }

--- a/raphtory-api/src/atomic_extra/mod.rs
+++ b/raphtory-api/src/atomic_extra/mod.rs
@@ -1,0 +1,24 @@
+use std::sync::atomic::{AtomicU64, AtomicUsize};
+
+/// Construct atomic slice from mut slice (reimplementation of currently unstable feature)
+#[inline]
+pub fn atomic_usize_from_mut_slice(v: &mut [usize]) -> &mut [AtomicUsize] {
+    use std::mem::align_of;
+    let [] = [(); align_of::<AtomicUsize>() - align_of::<usize>()];
+    // SAFETY:
+    //  - the mutable reference guarantees unique ownership.
+    //  - the alignment of `usize` and `AtomicUsize` is the
+    //    same, as verified above.
+    unsafe { &mut *(v as *mut [usize] as *mut [AtomicUsize]) }
+}
+
+#[inline]
+pub fn atomic_u64_from_mut_slice(v: &mut [u64]) -> &mut [AtomicU64] {
+    use std::mem::align_of;
+    let [] = [(); align_of::<AtomicU64>() - align_of::<u64>()];
+    // SAFETY:
+    //  - the mutable reference guarantees unique ownership.
+    //  - the alignment of `u64` and `AtomicU64` is the
+    //    same, as verified above.
+    unsafe { &mut *(v as *mut [u64] as *mut [AtomicU64]) }
+}

--- a/raphtory-api/src/core/entities/mod.rs
+++ b/raphtory-api/src/core/entities/mod.rs
@@ -119,6 +119,12 @@ impl Display for GID {
 }
 
 impl GID {
+    pub fn dtype(&self) -> GidType {
+        match self {
+            GID::U64(_) => GidType::U64,
+            GID::Str(_) => GidType::Str,
+        }
+    }
     pub fn into_str(self) -> Option<String> {
         match self {
             GID::Str(v) => Some(v),
@@ -202,6 +208,25 @@ pub enum GidRef<'a> {
     Str(&'a str),
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GidType {
+    U64,
+    Str,
+}
+
+impl Display for GidType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GidType::U64 => {
+                write!(f, "Numeric")
+            }
+            GidType::Str => {
+                write!(f, "String")
+            }
+        }
+    }
+}
+
 impl Display for GidRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -221,6 +246,12 @@ impl<'a> From<&'a GID> for GidRef<'a> {
 }
 
 impl<'a> GidRef<'a> {
+    pub fn dtype(self) -> GidType {
+        match self {
+            GidRef::U64(_) => GidType::U64,
+            GidRef::Str(_) => GidType::Str,
+        }
+    }
     pub fn as_str(self) -> Option<&'a str> {
         match self {
             GidRef::Str(s) => Some(s),

--- a/raphtory-api/src/core/entities/mod.rs
+++ b/raphtory-api/src/core/entities/mod.rs
@@ -1,5 +1,6 @@
 use self::edges::edge_ref::EdgeRef;
 use super::input::input_node::parse_u64_strict;
+use bytemuck::{Pod, Zeroable};
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -12,9 +13,15 @@ pub mod edges;
 // the only reason this is public is because the physical ids of the nodes don't move
 #[repr(transparent)]
 #[derive(
-    Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize, Default,
+    Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize, Pod, Zeroable,
 )]
 pub struct VID(pub usize);
+
+impl Default for VID {
+    fn default() -> Self {
+        VID(usize::MAX)
+    }
+}
 
 impl VID {
     pub fn index(&self) -> usize {
@@ -40,9 +47,15 @@ impl From<VID> for usize {
 
 #[repr(transparent)]
 #[derive(
-    Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize, Default,
+    Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize, Pod, Zeroable,
 )]
 pub struct EID(pub usize);
+
+impl Default for EID {
+    fn default() -> Self {
+        EID(usize::MAX)
+    }
+}
 
 impl EID {
     pub fn as_u64(self) -> u64 {
@@ -105,7 +118,7 @@ pub enum GID {
 
 impl Default for GID {
     fn default() -> Self {
-        GID::U64(0)
+        GID::U64(u64::MAX)
     }
 }
 

--- a/raphtory-api/src/core/entities/mod.rs
+++ b/raphtory-api/src/core/entities/mod.rs
@@ -147,7 +147,7 @@ impl GID {
         }
     }
 
-    pub fn to_str(&self) -> Cow<String> {
+    pub fn to_str(&self) -> Cow<str> {
         match self {
             GID::U64(v) => Cow::Owned(v.to_string()),
             GID::Str(v) => Cow::Borrowed(v),

--- a/raphtory-api/src/lib.rs
+++ b/raphtory-api/src/lib.rs
@@ -1,4 +1,4 @@
+pub mod atomic_extra;
 pub mod core;
-
 #[cfg(feature = "python")]
 pub mod python;

--- a/raphtory/Cargo.toml
+++ b/raphtory/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = { workspace = true }
 ouroboros = { workspace = true }
 either = { workspace = true }
 kdam = { workspace = true }
-
+bytemuck = { workspace = true }
 
 # io optional dependencies
 csv = { workspace = true, optional = true }
@@ -72,6 +72,7 @@ pometry-storage = { workspace = true, optional = true }
 
 prost = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }
+
 
 [target.'cfg(target_os = "macos")'.dependencies]
 snmalloc-rs = { workspace = true }

--- a/raphtory/src/core/entities/edges/edge_store.rs
+++ b/raphtory/src/core/entities/edges/edge_store.rs
@@ -115,6 +115,10 @@ impl EdgeStore {
         }
     }
 
+    pub fn initialised(&self) -> bool {
+        self.eid != EID::default()
+    }
+
     pub fn as_edge_ref(&self) -> EdgeRef {
         EdgeRef::new_outgoing(self.eid, self.src, self.dst)
     }

--- a/raphtory/src/core/entities/graph/logical_to_physical.rs
+++ b/raphtory/src/core/entities/graph/logical_to_physical.rs
@@ -7,7 +7,7 @@ use dashmap::mapref::entry::Entry;
 use either::Either;
 use once_cell::sync::OnceCell;
 use raphtory_api::core::{
-    entities::{GidRef, VID},
+    entities::{GidRef, GidType, VID},
     storage::{dict_mapper::MaybeNew, FxDashMap},
 };
 use serde::{Deserialize, Deserializer, Serialize};
@@ -47,6 +47,12 @@ pub(crate) struct Mapping {
 }
 
 impl Mapping {
+    pub fn dtype(&self) -> Option<GidType> {
+        self.map.get().map(|map| match map {
+            Map::U64(_) => GidType::U64,
+            Map::Str(_) => GidType::Str,
+        })
+    }
     pub fn new() -> Self {
         Mapping {
             map: OnceCell::new(),

--- a/raphtory/src/core/entities/graph/logical_to_physical.rs
+++ b/raphtory/src/core/entities/graph/logical_to_physical.rs
@@ -85,17 +85,13 @@ impl Mapping {
             GidRef::Str(_) => Map::Str(FxDashMap::default()),
         });
         let vid = match gid {
-            GidRef::U64(id) => map.as_u64().map(|m| {
-                m.get(&id)
-                    .map(|id| MaybeNew::Existing(*id))
-                    .unwrap_or_else(|| match m.entry(id) {
-                        Entry::Occupied(id) => MaybeNew::Existing(*id.get()),
-                        Entry::Vacant(entry) => {
-                            let vid = next_id();
-                            entry.insert(vid);
-                            MaybeNew::New(vid)
-                        }
-                    })
+            GidRef::U64(id) => map.as_u64().map(|m| match m.entry(id) {
+                Entry::Occupied(id) => MaybeNew::Existing(*id.get()),
+                Entry::Vacant(entry) => {
+                    let vid = next_id();
+                    entry.insert(vid);
+                    MaybeNew::New(vid)
+                }
             }),
             GidRef::Str(id) => map.as_str().map(|m| {
                 m.get(id)

--- a/raphtory/src/core/entities/graph/logical_to_physical.rs
+++ b/raphtory/src/core/entities/graph/logical_to_physical.rs
@@ -69,7 +69,48 @@ impl Mapping {
         .ok_or_else(|| MutateGraphError::InvalidNodeId(gid.into()).into())
     }
 
-    pub fn get_or_init<'a>(
+    pub fn get_or_init(
+        &self,
+        gid: GidRef,
+        next_id: impl FnOnce() -> VID,
+    ) -> Result<MaybeNew<VID>, GraphError> {
+        let map = self.map.get_or_init(|| match &gid {
+            GidRef::U64(_) => Map::U64(FxDashMap::default()),
+            GidRef::Str(_) => Map::Str(FxDashMap::default()),
+        });
+        let vid = match gid {
+            GidRef::U64(id) => map.as_u64().map(|m| {
+                m.get(&id)
+                    .map(|id| MaybeNew::Existing(*id))
+                    .unwrap_or_else(|| match m.entry(id) {
+                        Entry::Occupied(id) => MaybeNew::Existing(*id.get()),
+                        Entry::Vacant(entry) => {
+                            let vid = next_id();
+                            entry.insert(vid);
+                            MaybeNew::New(vid)
+                        }
+                    })
+            }),
+            GidRef::Str(id) => map.as_str().map(|m| {
+                m.get(id)
+                    .map(|vid| MaybeNew::Existing(*vid))
+                    .unwrap_or_else(|| match m.entry(id.to_owned()) {
+                        Entry::Occupied(entry) => MaybeNew::Existing(*entry.get()),
+                        Entry::Vacant(entry) => {
+                            let vid = next_id();
+                            entry.insert(vid);
+                            MaybeNew::New(vid)
+                        }
+                    })
+            }),
+        };
+
+        vid.ok_or_else(|| GraphError::FailedToMutateGraph {
+            source: MutateGraphError::InvalidNodeId(gid.into()),
+        })
+    }
+
+    pub fn get_or_init_node<'a>(
         &self,
         gid: GidRef,
         f_init: impl FnOnce() -> UninitialisedEntry<'a, NodeStore>,

--- a/raphtory/src/core/entities/graph/tgraph.rs
+++ b/raphtory/src/core/entities/graph/tgraph.rs
@@ -12,7 +12,7 @@ use crate::{
             LayerIds, EID, VID,
         },
         storage::{
-            raw_edges::{EdgeWGuard, MutEdge},
+            raw_edges::MutEdge,
             timeindex::{AsTime, TimeIndexEntry},
             PairEntryMut,
         },

--- a/raphtory/src/core/entities/graph/tgraph.rs
+++ b/raphtory/src/core/entities/graph/tgraph.rs
@@ -20,7 +20,6 @@ use crate::{
         Direction, Prop,
     },
     db::api::{storage::graph::edges::edge_storage_ops::EdgeStorageOps, view::Layer},
-    DEFAULT_NUM_SHARDS,
 };
 use dashmap::DashSet;
 use either::Either;
@@ -81,7 +80,7 @@ impl std::fmt::Display for TemporalGraph {
 
 impl Default for TemporalGraph {
     fn default() -> Self {
-        Self::new(DEFAULT_NUM_SHARDS)
+        Self::new(rayon::current_num_threads())
     }
 }
 

--- a/raphtory/src/core/entities/graph/tgraph_storage.rs
+++ b/raphtory/src/core/entities/graph/tgraph_storage.rs
@@ -5,7 +5,7 @@ use crate::core::{
         raw_edges::{
             EdgeArcGuard, EdgeRGuard, EdgeWGuard, EdgesStorage, LockedEdges, UninitialisedEdge,
         },
-        Entry, EntryMut, PairEntryMut, UninitialisedEntry,
+        Entry, EntryMut, NodeStorage, PairEntryMut, UninitialisedEntry,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub(crate) struct GraphStorage {
     // node storage with having (id, time_index, properties, adj list for each layer)
-    pub(crate) nodes: storage::RawStorage<NodeStore, VID>,
+    pub(crate) nodes: NodeStorage,
 
     pub(crate) edges: EdgesStorage,
 }
@@ -21,7 +21,7 @@ pub(crate) struct GraphStorage {
 impl GraphStorage {
     pub(crate) fn new(num_locks: usize) -> Self {
         Self {
-            nodes: storage::RawStorage::new(num_locks),
+            nodes: storage::NodeStorage::new(num_locks),
             edges: EdgesStorage::new(num_locks),
         }
     }
@@ -48,7 +48,7 @@ impl GraphStorage {
 
     #[inline]
     pub(crate) fn push_node(&self, node: NodeStore) -> UninitialisedEntry<NodeStore> {
-        self.nodes.push(node, |vid, node| node.vid = vid.into())
+        self.nodes.push(node)
     }
     #[inline]
     pub(crate) fn push_edge(&self, edge: EdgeStore) -> UninitialisedEdge {

--- a/raphtory/src/core/entities/nodes/node_store.rs
+++ b/raphtory/src/core/entities/nodes/node_store.rs
@@ -36,16 +36,6 @@ impl NodeStore {
     pub fn is_initialised(&self) -> bool {
         self.vid != VID::default()
     }
-    pub fn new(vid: VID) -> Self {
-        Self {
-            global_id: Default::default(),
-            vid,
-            timestamps: Default::default(),
-            layers: vec![],
-            props: None,
-            node_type: 0,
-        }
-    }
 
     #[inline]
     pub fn init(&mut self, vid: VID, gid: GidRef) {

--- a/raphtory/src/core/entities/nodes/node_store.rs
+++ b/raphtory/src/core/entities/nodes/node_store.rs
@@ -14,6 +14,7 @@ use crate::core::{
     Direction, Prop,
 };
 use itertools::Itertools;
+use raphtory_api::core::entities::GidRef;
 use serde::{Deserialize, Serialize};
 use std::{iter, ops::Deref};
 
@@ -31,23 +32,11 @@ pub struct NodeStore {
 }
 
 impl NodeStore {
-    pub fn new(global_id: GID, t: TimeIndexEntry) -> Self {
-        let mut layers = Vec::with_capacity(1);
-        layers.push(Adj::Solo);
-        Self {
-            global_id,
-            vid: 0.into(),
-            timestamps: TimeIndex::one(t.t()),
-            layers,
-            props: None,
-            node_type: 0,
-        }
-    }
-
+    #[inline]
     pub fn is_initialised(&self) -> bool {
-        self.global_id != GID::default()
+        self.vid != VID::default()
     }
-    pub fn init(vid: VID) -> Self {
+    pub fn new(vid: VID) -> Self {
         Self {
             global_id: Default::default(),
             vid,
@@ -55,6 +44,14 @@ impl NodeStore {
             layers: vec![],
             props: None,
             node_type: 0,
+        }
+    }
+
+    #[inline]
+    pub fn init(&mut self, vid: VID, gid: GidRef) {
+        if !self.is_initialised() {
+            self.vid = vid;
+            self.global_id = gid.to_owned();
         }
     }
 

--- a/raphtory/src/core/entities/nodes/node_store.rs
+++ b/raphtory/src/core/entities/nodes/node_store.rs
@@ -44,6 +44,20 @@ impl NodeStore {
         }
     }
 
+    pub fn is_initialised(&self) -> bool {
+        self.global_id != GID::default()
+    }
+    pub fn init(vid: VID) -> Self {
+        Self {
+            global_id: Default::default(),
+            vid,
+            timestamps: Default::default(),
+            layers: vec![],
+            props: None,
+            node_type: 0,
+        }
+    }
+
     pub fn empty(global_id: GID) -> Self {
         let mut layers = Vec::with_capacity(1);
         layers.push(Adj::Solo);
@@ -52,6 +66,17 @@ impl NodeStore {
             vid: VID(0),
             timestamps: TimeIndex::Empty,
             layers,
+            props: None,
+            node_type: 0,
+        }
+    }
+
+    pub fn resolved(global_id: GID, vid: VID) -> Self {
+        Self {
+            global_id,
+            vid,
+            timestamps: Default::default(),
+            layers: vec![],
             props: None,
             node_type: 0,
         }

--- a/raphtory/src/core/storage/mod.rs
+++ b/raphtory/src/core/storage/mod.rs
@@ -334,7 +334,7 @@ impl<'a> NodeShardWriter<'a> {
     }
 
     pub fn shard_id(&self) -> usize {
-        self.num_shards
+        self.shard_id
     }
 
     fn resize(&mut self, new_global_len: usize) {

--- a/raphtory/src/core/storage/mod.rs
+++ b/raphtory/src/core/storage/mod.rs
@@ -1,6 +1,5 @@
 use crate::core::entities::nodes::node_store::NodeStore;
 use lock_api;
-use num_integer::Integer;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use raphtory_api::core::entities::{GidRef, VID};
 use rayon::prelude::*;

--- a/raphtory/src/core/storage/mod.rs
+++ b/raphtory/src/core/storage/mod.rs
@@ -1,5 +1,4 @@
 use crate::core::entities::nodes::node_store::NodeStore;
-use itertools::Itertools;
 use lock_api;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use raphtory_api::core::entities::VID;

--- a/raphtory/src/core/storage/mod.rs
+++ b/raphtory/src/core/storage/mod.rs
@@ -333,6 +333,10 @@ impl<'a> NodeShardWriter<'a> {
         }
     }
 
+    pub fn shard_id(&self) -> usize {
+        self.num_shards
+    }
+
     fn resize(&mut self, new_global_len: usize) {
         let mut new_len = new_global_len / self.num_shards;
         if self.shard_id < new_global_len % self.num_shards {
@@ -365,6 +369,10 @@ impl<'a> WriteLockedNodes<'a> {
     pub fn resize(&mut self, new_len: usize) {
         self.par_iter_mut()
             .for_each(|mut shard| shard.resize(new_len))
+    }
+
+    pub fn num_shards(&self) -> usize {
+        self.guards.len()
     }
 }
 

--- a/raphtory/src/core/storage/raw_edges.rs
+++ b/raphtory/src/core/storage/raw_edges.rs
@@ -7,7 +7,6 @@ use crate::{
     db::api::storage::graph::edges::edge_storage_ops::{EdgeStorageOps, MemEdge},
     DEFAULT_NUM_SHARDS,
 };
-use itertools::Itertools;
 use lock_api::ArcRwLockReadGuard;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use raphtory_api::core::{entities::EID, storage::timeindex::TimeIndexEntry};

--- a/raphtory/src/core/storage/raw_edges.rs
+++ b/raphtory/src/core/storage/raw_edges.rs
@@ -402,6 +402,10 @@ impl<'a> EdgeShardWriter<'a> {
             i: offset,
         })
     }
+
+    pub fn shard_id(&self) -> usize {
+        self.shard_id
+    }
 }
 
 pub struct WriteLockedEdges<'a> {
@@ -424,5 +428,9 @@ impl<'a> WriteLockedEdges<'a> {
                 shard_id,
                 num_shards,
             })
+    }
+
+    pub fn num_shards(&self) -> usize {
+        self.shards.len()
     }
 }

--- a/raphtory/src/core/storage/raw_edges.rs
+++ b/raphtory/src/core/storage/raw_edges.rs
@@ -5,7 +5,6 @@ use crate::{
         LayerIds,
     },
     db::api::storage::graph::edges::edge_storage_ops::{EdgeStorageOps, MemEdge},
-    DEFAULT_NUM_SHARDS,
 };
 use lock_api::ArcRwLockReadGuard;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -108,7 +107,7 @@ impl PartialEq for EdgesStorage {
 
 impl Default for EdgesStorage {
     fn default() -> Self {
-        Self::new(DEFAULT_NUM_SHARDS)
+        Self::new(rayon::current_num_threads())
     }
 }
 

--- a/raphtory/src/core/utils/errors.rs
+++ b/raphtory/src/core/utils/errors.rs
@@ -5,7 +5,10 @@ use polars_arrow::{datatypes::ArrowDataType, legacy::error};
 use pometry_storage::RAError;
 #[cfg(feature = "python")]
 use pyo3::PyErr;
-use raphtory_api::core::{entities::GID, storage::arc_str::ArcStr};
+use raphtory_api::core::{
+    entities::{GidType, GID},
+    storage::arc_str::ArcStr,
+};
 use std::{io, path::PathBuf};
 #[cfg(feature = "search")]
 use tantivy;
@@ -59,6 +62,10 @@ pub enum LoadError {
     MissingNodeError,
     #[error("Missing value for timestamp")]
     MissingTimeError,
+    #[error("Node IDs have the wrong type, expected {existing}, got {new}")]
+    NodeIdTypeError { existing: GidType, new: GidType },
+    #[error("Fatal load error, graph may be in a dirty state.")]
+    FatalError,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/raphtory/src/db/api/mutation/internal/internal_addition_ops.rs
+++ b/raphtory/src/db/api/mutation/internal/internal_addition_ops.rs
@@ -8,10 +8,7 @@ use crate::{
     db::api::{storage::graph::locked::WriteLockedGraph, view::internal::Base},
 };
 use enum_dispatch::enum_dispatch;
-use raphtory_api::core::{
-    entities::{GidRef, GidType},
-    storage::dict_mapper::MaybeNew,
-};
+use raphtory_api::core::{entities::GidType, storage::dict_mapper::MaybeNew};
 
 #[enum_dispatch]
 pub trait InternalAdditionOps {
@@ -28,9 +25,6 @@ pub trait InternalAdditionOps {
 
     /// map external node id to internal id, allocating a new empty node if needed
     fn resolve_node<V: AsNodeRef>(&self, id: V) -> Result<MaybeNew<VID>, GraphError>;
-
-    /// map external node id to internal id, creating a new mapping if the node does not exist without allocating the node storage
-    fn resolve_node_no_init(&self, id: GidRef) -> Result<MaybeNew<VID>, GraphError>;
 
     /// resolve a node and corresponding type, outer MaybeNew tracks whether the type assignment is new for the node even if both node and type already existed.
     fn resolve_node_and_type<V: AsNodeRef>(
@@ -143,11 +137,6 @@ impl<G: DelegateAdditionOps> InternalAdditionOps for G {
     #[inline]
     fn resolve_node<V: AsNodeRef>(&self, n: V) -> Result<MaybeNew<VID>, GraphError> {
         self.graph().resolve_node(n)
-    }
-
-    #[inline]
-    fn resolve_node_no_init(&self, id: GidRef) -> Result<MaybeNew<VID>, GraphError> {
-        self.graph().resolve_node_no_init(id)
     }
 
     #[inline]

--- a/raphtory/src/db/api/mutation/internal/internal_addition_ops.rs
+++ b/raphtory/src/db/api/mutation/internal/internal_addition_ops.rs
@@ -8,10 +8,14 @@ use crate::{
     db::api::{storage::graph::locked::WriteLockedGraph, view::internal::Base},
 };
 use enum_dispatch::enum_dispatch;
-use raphtory_api::core::{entities::GidRef, storage::dict_mapper::MaybeNew};
+use raphtory_api::core::{
+    entities::{GidRef, GidType},
+    storage::dict_mapper::MaybeNew,
+};
 
 #[enum_dispatch]
 pub trait InternalAdditionOps {
+    fn id_type(&self) -> Option<GidType>;
     fn write_lock(&self) -> Result<WriteLockedGraph, GraphError>;
     fn num_shards(&self) -> Result<usize, GraphError>;
     /// get the sequence id for the next event
@@ -106,6 +110,12 @@ pub trait DelegateAdditionOps {
 }
 
 impl<G: DelegateAdditionOps> InternalAdditionOps for G {
+    #[inline]
+    fn id_type(&self) -> Option<GidType> {
+        self.graph().id_type()
+    }
+
+    #[inline]
     fn write_lock(&self) -> Result<WriteLockedGraph, GraphError> {
         self.graph().write_lock()
     }

--- a/raphtory/src/db/api/storage/graph/locked.rs
+++ b/raphtory/src/db/api/storage/graph/locked.rs
@@ -4,8 +4,9 @@ use crate::core::{
         raw_edges::{LockedEdges, WriteLockedEdges},
         ReadLockedStorage, WriteLockedNodes,
     },
+    utils::errors::GraphError,
 };
-use raphtory_api::core::entities::EID;
+use raphtory_api::core::{entities::GidRef, storage::dict_mapper::MaybeNew};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -72,8 +73,13 @@ impl<'a> WriteLockedGraph<'a> {
         }
     }
 
-    pub fn next_edge_id(&self) -> EID {
-        self.graph.storage.edges.next_id()
+    pub fn num_nodes(&self) -> usize {
+        self.graph.storage.nodes.len()
+    }
+    pub fn resolve_node(&self, gid: GidRef) -> Result<MaybeNew<VID>, GraphError> {
+        self.graph
+            .logical_to_physical
+            .get_or_init(gid, || self.graph.storage.nodes.next_id())
     }
 
     pub fn edges_mut(&mut self) -> &mut WriteLockedEdges<'a> {

--- a/raphtory/src/db/api/storage/graph/locked.rs
+++ b/raphtory/src/db/api/storage/graph/locked.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use crate::core::{
     entities::{graph::tgraph::TemporalGraph, nodes::node_store::NodeStore, VID},
-    storage::{raw_edges::LockedEdges, ReadLockedStorage},
+    storage::{
+        raw_edges::{LockedEdges, WriteLockedEdges},
+        ReadLockedStorage, WriteLockedNodes,
+    },
 };
 
 #[derive(Debug)]
@@ -49,5 +52,34 @@ impl Clone for LockedGraph {
             edges: self.edges.clone(),
             graph: self.graph.clone(),
         }
+    }
+}
+
+pub struct WriteLockedGraph<'a> {
+    nodes: WriteLockedNodes<'a>,
+    edges: WriteLockedEdges<'a>,
+    graph: &'a TemporalGraph,
+}
+
+impl<'a> WriteLockedGraph<'a> {
+    pub(crate) fn new(graph: &'a TemporalGraph) -> Self {
+        let nodes = graph.storage.nodes.write_lock();
+        let edges = graph.storage.edges.write_lock();
+        Self {
+            nodes,
+            edges,
+            graph,
+        }
+    }
+    pub fn nodes_mut(&'a mut self) -> &'a mut WriteLockedNodes<'a> {
+        &mut self.nodes
+    }
+
+    pub fn edges_mut(&'a mut self) -> &'a mut WriteLockedEdges<'a> {
+        &mut self.edges
+    }
+
+    pub fn graph(&self) -> &TemporalGraph {
+        &self.graph
     }
 }

--- a/raphtory/src/db/api/storage/graph/locked.rs
+++ b/raphtory/src/db/api/storage/graph/locked.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::core::{
     entities::{graph::tgraph::TemporalGraph, nodes::node_store::NodeStore, VID},
     storage::{
@@ -7,6 +5,7 @@ use crate::core::{
         ReadLockedStorage, WriteLockedNodes,
     },
 };
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct LockedGraph {

--- a/raphtory/src/db/api/storage/graph/locked.rs
+++ b/raphtory/src/db/api/storage/graph/locked.rs
@@ -82,6 +82,10 @@ impl<'a> WriteLockedGraph<'a> {
             .get_or_init(gid, || self.graph.storage.nodes.next_id())
     }
 
+    pub fn num_shards(&self) -> usize {
+        self.nodes.num_shards().max(self.edges.num_shards())
+    }
+
     pub fn edges_mut(&mut self) -> &mut WriteLockedEdges<'a> {
         &mut self.edges
     }

--- a/raphtory/src/db/api/storage/graph/locked.rs
+++ b/raphtory/src/db/api/storage/graph/locked.rs
@@ -5,6 +5,7 @@ use crate::core::{
         ReadLockedStorage, WriteLockedNodes,
     },
 };
+use raphtory_api::core::entities::EID;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -55,9 +56,9 @@ impl Clone for LockedGraph {
 }
 
 pub struct WriteLockedGraph<'a> {
-    nodes: WriteLockedNodes<'a>,
-    edges: WriteLockedEdges<'a>,
-    graph: &'a TemporalGraph,
+    pub nodes: WriteLockedNodes<'a>,
+    pub edges: WriteLockedEdges<'a>,
+    pub graph: &'a TemporalGraph,
 }
 
 impl<'a> WriteLockedGraph<'a> {
@@ -70,11 +71,12 @@ impl<'a> WriteLockedGraph<'a> {
             graph,
         }
     }
-    pub fn nodes_mut(&'a mut self) -> &'a mut WriteLockedNodes<'a> {
-        &mut self.nodes
+
+    pub fn next_edge_id(&self) -> EID {
+        self.graph.storage.edges.next_id()
     }
 
-    pub fn edges_mut(&'a mut self) -> &'a mut WriteLockedEdges<'a> {
+    pub fn edges_mut(&mut self) -> &mut WriteLockedEdges<'a> {
         &mut self.edges
     }
 

--- a/raphtory/src/db/api/storage/graph/storage_ops/additions.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/additions.rs
@@ -13,12 +13,16 @@ use crate::{
 };
 use either::Either;
 use raphtory_api::core::{
-    entities::{GidRef, EID, VID},
+    entities::{GidRef, GidType, EID, VID},
     storage::{dict_mapper::MaybeNew, timeindex::TimeIndexEntry},
 };
 use std::sync::atomic::Ordering;
 
 impl InternalAdditionOps for TemporalGraph {
+    fn id_type(&self) -> Option<GidType> {
+        self.logical_to_physical.dtype()
+    }
+
     fn write_lock(&self) -> Result<WriteLockedGraph, GraphError> {
         Ok(WriteLockedGraph::new(self))
     }
@@ -177,6 +181,14 @@ impl InternalAdditionOps for TemporalGraph {
 }
 
 impl InternalAdditionOps for GraphStorage {
+    fn id_type(&self) -> Option<GidType> {
+        match self {
+            GraphStorage::Unlocked(storage) => storage.id_type(),
+            GraphStorage::Mem(storage) => storage.graph.id_type(),
+            GraphStorage::Disk(storage) => Some(storage.inner().id_type()),
+        }
+    }
+
     fn write_lock(&self) -> Result<WriteLockedGraph, GraphError> {
         match self {
             GraphStorage::Unlocked(storage) => storage.write_lock(),

--- a/raphtory/src/db/api/storage/graph/storage_ops/additions.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/additions.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use either::Either;
 use raphtory_api::core::{
-    entities::{GidRef, GidType, EID, VID},
+    entities::{GidType, EID, VID},
     storage::{dict_mapper::MaybeNew, timeindex::TimeIndexEntry},
 };
 use std::sync::atomic::Ordering;
@@ -56,11 +56,6 @@ impl InternalAdditionOps for TemporalGraph {
             }
             Either::Right(vid) => Ok(MaybeNew::Existing(vid)),
         }
-    }
-
-    fn resolve_node_no_init(&self, id: GidRef) -> Result<MaybeNew<VID>, GraphError> {
-        self.logical_to_physical
-            .get_or_init(id, || self.storage.nodes.next_id())
     }
 
     fn resolve_node_and_type<V: AsNodeRef>(
@@ -228,13 +223,6 @@ impl InternalAdditionOps for GraphStorage {
     fn resolve_node<V: AsNodeRef>(&self, n: V) -> Result<MaybeNew<VID>, GraphError> {
         match self {
             GraphStorage::Unlocked(storage) => storage.resolve_node(n),
-            _ => Err(GraphError::AttemptToMutateImmutableGraph),
-        }
-    }
-
-    fn resolve_node_no_init(&self, id: GidRef) -> Result<MaybeNew<VID>, GraphError> {
-        match self {
-            GraphStorage::Unlocked(storage) => storage.resolve_node_no_init(id),
             _ => Err(GraphError::AttemptToMutateImmutableGraph),
         }
     }

--- a/raphtory/src/db/api/storage/graph/storage_ops/additions.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/additions.rs
@@ -185,6 +185,7 @@ impl InternalAdditionOps for GraphStorage {
         match self {
             GraphStorage::Unlocked(storage) => storage.id_type(),
             GraphStorage::Mem(storage) => storage.graph.id_type(),
+            #[cfg(feature = "storage")]
             GraphStorage::Disk(storage) => Some(storage.inner().id_type()),
         }
     }

--- a/raphtory/src/db/api/storage/graph/storage_ops/deletions.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/deletions.rs
@@ -16,7 +16,7 @@ impl InternalDeletionOps for TemporalGraph {
         dst: VID,
         layer: usize,
     ) -> Result<MaybeNew<EID>, GraphError> {
-        self.link_nodes(src, dst, t, layer, |new_edge| {
+        self.link_nodes(src, dst, t, layer, |mut new_edge| {
             new_edge.deletions_mut(layer).insert(t);
             Ok(())
         })
@@ -28,7 +28,7 @@ impl InternalDeletionOps for TemporalGraph {
         eid: EID,
         layer: usize,
     ) -> Result<(), GraphError> {
-        self.link_edge(eid, t, layer, |edge| {
+        self.link_edge(eid, t, layer, |mut edge| {
             edge.deletions_mut(layer).insert(t);
             Ok(())
         })

--- a/raphtory/src/db/api/storage/graph/storage_ops/mod.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/mod.rs
@@ -41,6 +41,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{iter, sync::Arc};
 
+use crate::{core::utils::errors::GraphError, db::api::storage::graph::locked::WriteLockedGraph};
 #[cfg(feature = "storage")]
 use crate::{
     db::api::storage::graph::variants::storage_variants::StorageVariants,
@@ -122,6 +123,16 @@ impl GraphStorage {
                 GraphStorage::Mem(locked)
             }
             _ => self.clone(),
+        }
+    }
+
+    pub fn write_lock(&self) -> Result<WriteLockedGraph, GraphError> {
+        match self {
+            GraphStorage::Unlocked(storage) => {
+                let locked = WriteLockedGraph::new(storage);
+                Ok(locked)
+            }
+            _ => Err(GraphError::AttemptToMutateImmutableGraph),
         }
     }
 

--- a/raphtory/src/db/api/storage/graph/storage_ops/mod.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/mod.rs
@@ -13,6 +13,7 @@ use crate::{
             properties::{graph_meta::GraphMeta, props::Meta},
             LayerIds, EID, VID,
         },
+        utils::errors::GraphError,
         Direction,
     },
     db::api::{
@@ -22,7 +23,7 @@ use crate::{
                 edge_storage_ops::EdgeStorageOps,
                 edges::{EdgesStorage, EdgesStorageRef},
             },
-            locked::LockedGraph,
+            locked::{LockedGraph, WriteLockedGraph},
             nodes::{
                 node_owned_entry::NodeOwnedEntry,
                 node_storage_ops::{NodeStorageIntoOps, NodeStorageOps},
@@ -41,7 +42,6 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{iter, sync::Arc};
 
-use crate::{core::utils::errors::GraphError, db::api::storage::graph::locked::WriteLockedGraph};
 #[cfg(feature = "storage")]
 use crate::{
     db::api::storage::graph::variants::storage_variants::StorageVariants,

--- a/raphtory/src/db/api/storage/graph/storage_ops/prop_add.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/prop_add.rs
@@ -84,6 +84,7 @@ impl InternalPropertyAdditionOps for TemporalGraph {
         props: &[(usize, Prop)],
     ) -> Result<(), GraphError> {
         let mut edge = self.storage.get_edge_mut(eid);
+        let mut edge = edge.as_mut();
         let edge_layer = edge.layer_mut(layer);
         for (prop_id, prop) in props {
             let prop = self.process_prop_value(prop);
@@ -110,6 +111,7 @@ impl InternalPropertyAdditionOps for TemporalGraph {
         props: &[(usize, Prop)],
     ) -> Result<(), GraphError> {
         let mut edge = self.storage.get_edge_mut(eid);
+        let mut edge = edge.as_mut();
         let edge_layer = edge.layer_mut(layer);
         for (prop_id, prop) in props {
             let prop = self.process_prop_value(prop);

--- a/raphtory/src/db/api/storage/storage.rs
+++ b/raphtory/src/db/api/storage/storage.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use once_cell::sync::OnceCell;
 use raphtory_api::core::{
-    entities::{GidRef, GidType, EID, VID},
+    entities::{GidType, EID, VID},
     storage::{dict_mapper::MaybeNew, timeindex::TimeIndexEntry},
 };
 use serde::{Deserialize, Serialize};
@@ -129,15 +129,6 @@ impl InternalAdditionOps for Storage {
                 Ok(id)
             }
         }
-    }
-
-    fn resolve_node_no_init(&self, id: GidRef) -> Result<MaybeNew<VID>, GraphError> {
-        let vid = self.graph.resolve_node_no_init(id)?;
-
-        #[cfg(feature = "proto")]
-        self.if_cache(|cache| cache.resolve_node(vid, id));
-
-        Ok(vid)
     }
 
     fn resolve_node_and_type<V: AsNodeRef>(

--- a/raphtory/src/db/api/storage/storage.rs
+++ b/raphtory/src/db/api/storage/storage.rs
@@ -37,6 +37,8 @@ pub struct Storage {
     #[cfg(feature = "proto")]
     #[serde(skip)]
     pub(crate) cache: OnceCell<GraphWriter>,
+    // search index (tantivy)
+    // vector index
 }
 
 impl Display for Storage {

--- a/raphtory/src/db/api/storage/storage.rs
+++ b/raphtory/src/db/api/storage/storage.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use once_cell::sync::OnceCell;
 use raphtory_api::core::{
-    entities::{GidRef, EID, VID},
+    entities::{GidRef, GidType, EID, VID},
     storage::{dict_mapper::MaybeNew, timeindex::TimeIndexEntry},
 };
 use serde::{Deserialize, Serialize};
@@ -82,6 +82,11 @@ impl Storage {
 impl InheritViewOps for Storage {}
 
 impl InternalAdditionOps for Storage {
+    #[inline]
+    fn id_type(&self) -> Option<GidType> {
+        self.graph.id_type()
+    }
+
     fn write_lock(&self) -> Result<WriteLockedGraph, GraphError> {
         self.graph.write_lock()
     }

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -39,7 +39,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use enum_dispatch::enum_dispatch;
 use raphtory_api::core::{
-    entities::{GidRef, GidType},
+    entities::GidType,
     storage::{arc_str::ArcStr, dict_mapper::MaybeNew},
 };
 use serde::{Deserialize, Serialize};

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -23,6 +23,7 @@ use crate::{
                     edge_entry::EdgeStorageEntry, edge_owned_entry::EdgeOwnedEntry,
                     edge_ref::EdgeStorageRef, edges::EdgesStorage,
                 },
+                locked::WriteLockedGraph,
                 nodes::{
                     node_entry::NodeStorageEntry, node_owned_entry::NodeOwnedEntry,
                     nodes::NodesStorage,
@@ -37,7 +38,10 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use enum_dispatch::enum_dispatch;
-use raphtory_api::core::storage::{arc_str::ArcStr, dict_mapper::MaybeNew};
+use raphtory_api::core::{
+    entities::GidRef,
+    storage::{arc_str::ArcStr, dict_mapper::MaybeNew},
+};
 use serde::{Deserialize, Serialize};
 
 #[enum_dispatch(CoreGraphOps)]

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -39,7 +39,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use enum_dispatch::enum_dispatch;
 use raphtory_api::core::{
-    entities::GidRef,
+    entities::{GidRef, GidType},
     storage::{arc_str::ArcStr, dict_mapper::MaybeNew},
 };
 use serde::{Deserialize, Serialize};

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -546,13 +546,13 @@ mod db_tests {
             g.add_edge(*t, *src, *dst, NO_PROPS, None).unwrap();
         }
 
-        let tmp_raphtory_path: TempDir = TempDir::new().expect("Failed to create tempdir");
+        let tmp_raphtory_path: TempDir = TempDir::new().unwrap();
 
         let graph_path = format!("{}/graph.bin", tmp_raphtory_path.path().display());
-        g.encode(&graph_path).expect("Failed to save graph");
+        g.encode(&graph_path).unwrap();
 
         // Load from files
-        let g2 = Graph::decode(&graph_path).expect("Failed to load graph");
+        let g2 = Graph::decode(&graph_path).unwrap();
 
         assert_eq!(g, g2);
 

--- a/raphtory/src/io/arrow/dataframe.rs
+++ b/raphtory/src/io/arrow/dataframe.rs
@@ -74,6 +74,10 @@ impl TimeCol {
         (0..self.0.len()).into_par_iter().map(|i| self.get(i))
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = i64> + '_ {
+        self.0.values_iter().copied()
+    }
+
     pub fn get(&self, i: usize) -> Option<i64> {
         self.0.get(i)
     }

--- a/raphtory/src/io/arrow/dataframe.rs
+++ b/raphtory/src/io/arrow/dataframe.rs
@@ -48,6 +48,9 @@ impl TimeCol {
             .as_any()
             .downcast_ref::<PrimitiveArray<i64>>()
             .ok_or_else(|| LoadError::InvalidTimestamp(arr.data_type().clone()))?;
+        if arr.null_count() > 0 {
+            return Err(LoadError::MissingTimeError);
+        }
         let arr = if let DataType::Timestamp(_, _) = arr.data_type() {
             let array = cast::cast(
                 arr,
@@ -63,6 +66,7 @@ impl TimeCol {
         } else {
             arr.clone()
         };
+
         Ok(Self(arr))
     }
 

--- a/raphtory/src/io/arrow/dataframe.rs
+++ b/raphtory/src/io/arrow/dataframe.rs
@@ -9,11 +9,21 @@ use polars_arrow::{
     datatypes::{ArrowDataType as DataType, TimeUnit},
 };
 use rayon::prelude::*;
+use std::fmt::{Debug, Formatter};
 
 pub(crate) struct DFView<I> {
     pub names: Vec<String>,
     pub(crate) chunks: I,
     pub num_rows: usize,
+}
+
+impl<I> Debug for DFView<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DFView")
+            .field("names", &self.names)
+            .field("num_rows", &self.num_rows)
+            .finish()
+    }
 }
 
 impl<I, E> DFView<I>
@@ -83,7 +93,7 @@ impl TimeCol {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct DFChunk {
     pub(crate) chunk: Vec<Box<dyn Array>>,
 }

--- a/raphtory/src/io/arrow/df_loaders.rs
+++ b/raphtory/src/io/arrow/df_loaders.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use bytemuck::checked::cast_slice_mut;
 use kdam::{Bar, BarBuilder, BarExt};
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use raphtory_api::{
     atomic_extra::atomic_usize_from_mut_slice,
     core::{

--- a/raphtory/src/io/arrow/df_loaders.rs
+++ b/raphtory/src/io/arrow/df_loaders.rs
@@ -15,9 +15,7 @@ use crate::{
     serialise::incremental::InternalCache,
 };
 use bytemuck::checked::cast_slice_mut;
-use itertools::Itertools;
 use kdam::{Bar, BarBuilder, BarExt};
-use polars_arrow::array::{MutableArray, MutablePrimitiveArray, MutableUtf8Array, PrimitiveArray};
 use raphtory_api::{
     atomic_extra::atomic_usize_from_mut_slice,
     core::{
@@ -610,10 +608,7 @@ mod tests {
         prelude::*,
     };
     use itertools::Itertools;
-    use polars_arrow::array::{
-        MutableArray, MutablePrimitiveArray, MutableUtf8Array, PrimitiveArray, StaticArray,
-        Utf8Array,
-    };
+    use polars_arrow::array::{MutableArray, MutablePrimitiveArray, MutableUtf8Array};
     use proptest::{
         prelude::{any, Strategy},
         proptest,

--- a/raphtory/src/io/arrow/df_loaders.rs
+++ b/raphtory/src/io/arrow/df_loaders.rs
@@ -192,6 +192,7 @@ pub(crate) fn load_edges_from_df<
     let mut dst_col_resolved = vec![];
     let mut eid_col_resolved = vec![];
 
+    let mut write_locked_graph = graph.write_lock()?;
     for chunk in df_view.chunks {
         let df = chunk?;
         let prop_cols = combine_properties(properties, &properties_indices, &df, |key, dtype| {
@@ -215,7 +216,6 @@ pub(crate) fn load_edges_from_df<
         let time_col = df.time_col(time_index)?;
 
         // It's our graph, no one else can change it
-        let mut write_locked_graph = graph.write_lock()?;
         src_col_resolved.resize_with(df.len(), Default::default);
         src_col
             .par_iter()

--- a/raphtory/src/io/arrow/layer_col.rs
+++ b/raphtory/src/io/arrow/layer_col.rs
@@ -101,7 +101,7 @@ impl<'a> LayerCol<'a> {
                 Ok(vec![layer; len])
             }
             col => {
-                let mut iter = col.par_iter();
+                let iter = col.par_iter();
                 let mut res = vec![0usize; iter.len()];
                 iter.zip(res.par_iter_mut())
                     .try_for_each(|(layer, entry)| {

--- a/raphtory/src/io/arrow/node_col.rs
+++ b/raphtory/src/io/arrow/node_col.rs
@@ -12,7 +12,7 @@ use rayon::prelude::{IndexedParallelIterator, *};
 
 trait NodeColOps: Array + Send + Sync {
     fn has_missing_values(&self) -> bool {
-        self.null_count() == 0
+        self.null_count() != 0
     }
     fn get(&self, i: usize) -> Option<GidRef>;
 
@@ -144,6 +144,10 @@ impl<'a> TryFrom<&'a dyn Array> for NodeCol {
 impl NodeCol {
     pub fn par_iter(&self) -> impl IndexedParallelIterator<Item = Option<GidRef<'_>>> + '_ {
         (0..self.0.len()).into_par_iter().map(|i| self.0.get(i))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = Option<GidRef>> + '_ {
+        (0..self.0.len()).map(|i| self.0.get(i))
     }
 
     pub fn validate(

--- a/raphtory/src/io/arrow/node_col.rs
+++ b/raphtory/src/io/arrow/node_col.rs
@@ -20,18 +20,12 @@ trait NodeColOps: Array + Send + Sync {
     }
     fn get(&self, i: usize) -> Option<GidRef>;
 
-    fn iter(&self) -> BoxedLIter<GidRef>;
-
     fn dtype(&self) -> GidType;
 }
 
 impl NodeColOps for PrimitiveArray<u64> {
     fn get(&self, i: usize) -> Option<GidRef> {
         StaticArray::get(self, i).map(GidRef::U64)
-    }
-
-    fn iter(&self) -> BoxedLIter<GidRef> {
-        self.values_iter().map(|v| GidRef::U64(*v)).into_dyn_boxed()
     }
 
     fn dtype(&self) -> GidType {
@@ -44,12 +38,6 @@ impl NodeColOps for PrimitiveArray<u32> {
         StaticArray::get(self, i).map(|v| GidRef::U64(v as u64))
     }
 
-    fn iter(&self) -> BoxedLIter<GidRef> {
-        self.values_iter()
-            .map(|v| GidRef::U64(*v as u64))
-            .into_dyn_boxed()
-    }
-
     fn dtype(&self) -> GidType {
         GidType::U64
     }
@@ -60,12 +48,6 @@ impl NodeColOps for PrimitiveArray<i64> {
         StaticArray::get(self, i).map(|v| GidRef::U64(v as u64))
     }
 
-    fn iter(&self) -> BoxedLIter<GidRef> {
-        self.values_iter()
-            .map(|v| GidRef::U64(*v as u64))
-            .into_dyn_boxed()
-    }
-
     fn dtype(&self) -> GidType {
         GidType::U64
     }
@@ -74,12 +56,6 @@ impl NodeColOps for PrimitiveArray<i64> {
 impl NodeColOps for PrimitiveArray<i32> {
     fn get(&self, i: usize) -> Option<GidRef> {
         StaticArray::get(self, i).map(|v| GidRef::U64(v as u64))
-    }
-
-    fn iter(&self) -> BoxedLIter<GidRef> {
-        self.values_iter()
-            .map(|v| GidRef::U64(*v as u64))
-            .into_dyn_boxed()
     }
 
     fn dtype(&self) -> GidType {
@@ -103,11 +79,6 @@ impl<O: Offset> NodeColOps for Utf8Array<O> {
             }
         }
     }
-
-    fn iter(&self) -> BoxedLIter<GidRef> {
-        self.values_iter().map(|v| GidRef::Str(v)).into_dyn_boxed()
-    }
-
     fn dtype(&self) -> GidType {
         GidType::Str
     }

--- a/raphtory/src/io/arrow/node_col.rs
+++ b/raphtory/src/io/arrow/node_col.rs
@@ -1,6 +1,5 @@
 use crate::{
-    core::utils::errors::LoadError,
-    db::api::mutation::internal::InternalAdditionOps,
+    core::utils::errors::LoadError, db::api::mutation::internal::InternalAdditionOps,
     io::arrow::dataframe::DFChunk,
 };
 use polars_arrow::{

--- a/raphtory/src/io/arrow/node_col.rs
+++ b/raphtory/src/io/arrow/node_col.rs
@@ -1,9 +1,6 @@
 use crate::{
     core::utils::errors::LoadError,
-    db::api::{
-        mutation::internal::InternalAdditionOps,
-        view::{BoxedLIter, IntoDynBoxed},
-    },
+    db::api::mutation::internal::InternalAdditionOps,
     io::arrow::dataframe::DFChunk,
 };
 use polars_arrow::{

--- a/raphtory/src/io/parquet_loaders.rs
+++ b/raphtory/src/io/parquet_loaders.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     io::arrow::{dataframe::*, df_loaders::*},
     prelude::DeletionOps,
+    serialise::incremental::InternalCache,
 };
 use itertools::Itertools;
 use polars_arrow::datatypes::{ArrowDataType as DataType, ArrowSchema, Field};
@@ -63,8 +64,8 @@ pub fn load_nodes_from_parquet<
     Ok(())
 }
 
-pub fn load_edges_from_parquet<
-    G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps,
+pub(crate) fn load_edges_from_parquet<
+    G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps + InternalCache,
 >(
     graph: &G,
     parquet_path: impl AsRef<Path>,

--- a/raphtory/src/lib.rs
+++ b/raphtory/src/lib.rs
@@ -91,8 +91,6 @@ pub mod graphgen;
 #[cfg(target_os = "macos")]
 use snmalloc_rs;
 
-pub const DEFAULT_NUM_SHARDS: usize = 128;
-
 #[cfg(target_os = "macos")]
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -399,7 +399,7 @@ impl PyGraph {
         shared_constant_properties: Option<HashMap<String, Prop>>,
     ) -> Result<(), GraphError> {
         load_nodes_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             time,
             id,
@@ -477,7 +477,7 @@ impl PyGraph {
         layer_col: Option<&str>,
     ) -> Result<(), GraphError> {
         load_edges_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             time,
             src,
@@ -551,7 +551,7 @@ impl PyGraph {
         shared_constant_properties: Option<HashMap<String, Prop>>,
     ) -> Result<(), GraphError> {
         load_node_props_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             id,
             node_type,
@@ -615,7 +615,7 @@ impl PyGraph {
         layer_col: Option<&str>,
     ) -> Result<(), GraphError> {
         load_edge_props_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             src,
             dst,

--- a/raphtory/src/python/graph/graph_with_deletions.rs
+++ b/raphtory/src/python/graph/graph_with_deletions.rs
@@ -368,7 +368,7 @@ impl PyPersistentGraph {
         shared_constant_properties: Option<HashMap<String, Prop>>,
     ) -> Result<(), GraphError> {
         load_nodes_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             time,
             id,
@@ -452,7 +452,7 @@ impl PyPersistentGraph {
         layer_col: Option<&str>,
     ) -> Result<(), GraphError> {
         load_edges_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             time,
             src,
@@ -533,15 +533,7 @@ impl PyPersistentGraph {
         layer: Option<&str>,
         layer_col: Option<&str>,
     ) -> Result<(), GraphError> {
-        load_edge_deletions_from_pandas(
-            self.graph.core_graph(),
-            df,
-            time,
-            src,
-            dst,
-            layer,
-            layer_col,
-        )
+        load_edge_deletions_from_pandas(&self.graph, df, time, src, dst, layer, layer_col)
     }
 
     /// Load edges deletions from a Parquet file into the graph.
@@ -605,7 +597,7 @@ impl PyPersistentGraph {
         shared_constant_properties: Option<HashMap<String, Prop>>,
     ) -> Result<(), GraphError> {
         load_node_props_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             id,
             node_type,
@@ -679,7 +671,7 @@ impl PyPersistentGraph {
         layer_col: Option<&str>,
     ) -> Result<(), GraphError> {
         load_edge_props_from_pandas(
-            self.graph.core_graph(),
+            &self.graph,
             df,
             src,
             dst,

--- a/raphtory/src/python/graph/io/pandas_loaders.rs
+++ b/raphtory/src/python/graph/io/pandas_loaders.rs
@@ -1,8 +1,12 @@
 use crate::{
     core::{utils::errors::GraphError, Prop},
-    db::api::{storage::graph::storage_ops::GraphStorage, view::internal::CoreGraphOps},
+    db::api::{
+        mutation::internal::{InternalAdditionOps, InternalPropertyAdditionOps},
+        view::StaticGraphViewOps,
+    },
     io::arrow::{dataframe::*, df_loaders::*},
     python::graph::io::*,
+    serialise::incremental::InternalCache,
 };
 use polars_arrow::{array::Array, ffi};
 use pyo3::{
@@ -12,8 +16,10 @@ use pyo3::{
 };
 use std::collections::HashMap;
 
-pub fn load_nodes_from_pandas(
-    graph: &GraphStorage,
+pub fn load_nodes_from_pandas<
+    G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps,
+>(
+    graph: &G,
     df: &PyAny,
     time: &str,
     id: &str,
@@ -47,8 +53,10 @@ pub fn load_nodes_from_pandas(
     })
 }
 
-pub fn load_edges_from_pandas(
-    graph: &GraphStorage,
+pub(crate) fn load_edges_from_pandas<
+    G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps + InternalCache,
+>(
+    graph: &G,
     df: &PyAny,
     time: &str,
     src: &str,
@@ -84,8 +92,10 @@ pub fn load_edges_from_pandas(
     })
 }
 
-pub fn load_node_props_from_pandas(
-    graph: &GraphStorage,
+pub(crate) fn load_node_props_from_pandas<
+    G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps,
+>(
+    graph: &G,
     df: &PyAny,
     id: &str,
     node_type: Option<&str>,
@@ -113,8 +123,10 @@ pub fn load_node_props_from_pandas(
     })
 }
 
-pub fn load_edge_props_from_pandas(
-    graph: &GraphStorage,
+pub(crate) fn load_edge_props_from_pandas<
+    G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps,
+>(
+    graph: &G,
     df: &PyAny,
     src: &str,
     dst: &str,
@@ -144,8 +156,10 @@ pub fn load_edge_props_from_pandas(
     })
 }
 
-pub fn load_edge_deletions_from_pandas(
-    graph: &GraphStorage,
+pub fn load_edge_deletions_from_pandas<
+    G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps,
+>(
+    graph: &G,
     df: &PyAny,
     time: &str,
     src: &str,

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     prelude::*,
 };
 use raphtory_api::core::{
-    entities::GidRef,
+    entities::{GidRef, GidType},
     storage::{arc_str::ArcStr, dict_mapper::MaybeNew},
 };
 use rayon::{prelude::ParallelIterator, slice::ParallelSlice};
@@ -759,6 +759,11 @@ impl<'graph, G: GraphViewOps<'graph>> IndexedGraph<G> {
 }
 
 impl<G: StaticGraphViewOps + InternalAdditionOps> InternalAdditionOps for IndexedGraph<G> {
+    #[inline]
+    fn id_type(&self) -> Option<GidType> {
+        self.graph.id_type()
+    }
+
     fn write_lock(&self) -> Result<WriteLockedGraph, GraphError> {
         self.graph.write_lock()
     }

--- a/raphtory/src/search/mod.rs
+++ b/raphtory/src/search/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     prelude::*,
 };
 use raphtory_api::core::{
-    entities::{GidRef, GidType},
+    entities::GidType,
     storage::{arc_str::ArcStr, dict_mapper::MaybeNew},
 };
 use rayon::{prelude::ParallelIterator, slice::ParallelSlice};
@@ -791,11 +791,6 @@ impl<G: StaticGraphViewOps + InternalAdditionOps> InternalAdditionOps for Indexe
     #[inline]
     fn resolve_node<V: AsNodeRef>(&self, n: V) -> Result<MaybeNew<VID>, GraphError> {
         self.graph.resolve_node(n)
-    }
-
-    #[inline]
-    fn resolve_node_no_init(&self, id: GidRef) -> Result<MaybeNew<VID>, GraphError> {
-        self.graph.resolve_node_no_init(id)
     }
 
     fn resolve_node_and_type<V: AsNodeRef>(

--- a/raphtory/src/serialise/incremental.rs
+++ b/raphtory/src/serialise/incremental.rs
@@ -23,21 +23,31 @@ use std::{
     mem,
     ops::DerefMut,
     path::Path,
+    sync::Arc,
 };
 
 #[derive(Debug)]
 pub struct GraphWriter {
-    writer: Mutex<File>,
+    writer: Arc<Mutex<File>>,
     proto_delta: Mutex<ProtoGraph>,
 }
 
 impl GraphWriter {
     pub fn new(file: File) -> Self {
         Self {
-            writer: Mutex::new(file),
+            writer: Arc::new(Mutex::new(file)),
             proto_delta: Default::default(),
         }
     }
+
+    /// Get an independent writer pointing at the same underlying cache file
+    pub fn fork(&self) -> Self {
+        GraphWriter {
+            writer: self.writer.clone(),
+            proto_delta: Default::default(),
+        }
+    }
+
     pub fn write(&self) -> Result<(), GraphError> {
         let mut proto = mem::take(self.proto_delta.lock().deref_mut());
         let bytes = proto.encode_to_vec();
@@ -188,11 +198,13 @@ impl GraphWriter {
     }
 
     pub fn add_edge_cprops(&self, edge: EID, layer: usize, props: &[(usize, Prop)]) {
-        self.proto_delta.lock().update_edge_cprops(
-            edge,
-            layer,
-            props.iter().map(|(id, prop)| (*id, prop)),
-        )
+        if !props.is_empty() {
+            self.proto_delta.lock().update_edge_cprops(
+                edge,
+                layer,
+                props.iter().map(|(id, prop)| (*id, prop)),
+            )
+        }
     }
 
     pub fn delete_edge(&self, edge: EID, t: TimeIndexEntry, layer: usize) {

--- a/raphtory/src/serialise/serialise.rs
+++ b/raphtory/src/serialise/serialise.rs
@@ -712,7 +712,7 @@ impl StableDecode for TemporalGraph {
             let mut node_store = NodeStore::empty(gid.to_owned());
             node_store.vid = vid;
             node_store.node_type = node.type_id as usize;
-            storage.storage.nodes.set(vid, node_store).init();
+            storage.storage.nodes.set(node_store);
             Ok::<(), GraphError>(())
         })?;
         graph.edges.par_iter().for_each(|edge| {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds write-locked views for the underlying graph storage which should enable faster bulk loaders

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


