### PR TITLE
Don't drop the update in the Cache if the write fails

### DIFF
--- a/raphtory/src/core/utils/errors.rs
+++ b/raphtory/src/core/utils/errors.rs
@@ -6,7 +6,7 @@ use pometry_storage::RAError;
 #[cfg(feature = "python")]
 use pyo3::PyErr;
 use raphtory_api::core::{entities::GID, storage::arc_str::ArcStr};
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 #[cfg(feature = "search")]
 use tantivy;
 #[cfg(feature = "search")]
@@ -194,6 +194,15 @@ pub enum GraphError {
     #[cfg(feature = "proto")]
     #[error("Protobuf encode error{0}")]
     DecodeError(#[from] prost::DecodeError),
+
+    #[cfg(feature = "proto")]
+    #[error(
+        "Cannot recover from write failure {write_err}, new updates are invalid: {decode_err}"
+    )]
+    FatalDecodeError {
+        write_err: io::Error,
+        decode_err: prost::DecodeError,
+    },
 
     #[cfg(feature = "proto")]
     #[error("Protobuf decode error{0}")]

--- a/raphtory/src/serialise/incremental.rs
+++ b/raphtory/src/serialise/incremental.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use parking_lot::Mutex;
-use prost::{ Message};
+use prost::Message;
 use raphtory_api::core::{
     entities::{GidRef, EID, VID},
     storage::{dict_mapper::MaybeNew, timeindex::TimeIndexEntry},

--- a/raphtory/src/serialise/incremental.rs
+++ b/raphtory/src/serialise/incremental.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use parking_lot::Mutex;
-use prost::Message;
+use prost::{ Message};
 use raphtory_api::core::{
     entities::{GidRef, EID, VID},
     storage::{dict_mapper::MaybeNew, timeindex::TimeIndexEntry},
@@ -39,10 +39,25 @@ impl GraphWriter {
         }
     }
     pub fn write(&self) -> Result<(), GraphError> {
-        let proto = mem::take(self.proto_delta.lock().deref_mut());
+        let mut proto = mem::take(self.proto_delta.lock().deref_mut());
         let bytes = proto.encode_to_vec();
         if !bytes.is_empty() {
-            self.writer.lock().write_all(&bytes)?;
+            if let Err(write_err) = self.writer.lock().write_all(&bytes) {
+                // If the write fails, try to put the updates back
+                let mut new_delta = self.proto_delta.lock();
+                let bytes = new_delta.encode_to_vec();
+                match proto.merge(&*bytes) {
+                    Ok(_) => *new_delta = proto,
+                    Err(decode_err) => {
+                        // This should never happen, it means that the new delta was an invalid Graph
+                        return Err(GraphError::FatalDecodeError {
+                            write_err,
+                            decode_err,
+                        });
+                    }
+                }
+                return Err(write_err.into());
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve the error recovery in the GraphWriter

### Why are the changes needed?

Currently, if the write fails the updates in the cache are lost.

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

Existing tests, need to figure out how to make this failure actually occur.



