### PR TITLE
fix latest_time for exploded edge on PersistentGraph for edges that are deleted at the same time as created

### DIFF
--- a/raphtory-api/src/core/storage/timeindex.rs
+++ b/raphtory-api/src/core/storage/timeindex.rs
@@ -41,6 +41,16 @@ impl TimeIndexEntry {
         Self(t, 0)
     }
 
+    pub fn next(&self) -> Self {
+        if self.1 < usize::MAX {
+            Self(self.0, self.1 + 1)
+        } else if self.0 < i64::MAX {
+            Self(self.0 + 1, 0)
+        } else {
+            *self
+        }
+    }
+
     pub fn end(t: i64) -> Self {
         Self(t.saturating_add(1), 0)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

fixes:

```
G1 = PersistentGraph()

G1.add_edge(1, 1, 2, properties={"message":"hi"})
G1.delete_edge(1, 1, 2)

print(f"G1's edges are {G1.edges.explode()}")
```

which was returning

```
G1's edges are Edges(Edge(source=1, target=2, earliest_time=1, latest_time=9223372036854775807, properties={message: hi}))
```

but the `latest_time` should have been `1`.

### How was this patch tested?

Added test for this case


