### PR TITLE
Feature/latest and active

### DIFF
--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -2925,6 +2925,7 @@ class MutableNode:
         An iterator over the neighbours of this node that point into this node.
         """
 
+    def is_active(self): ...
     def latest(self):
         """
          Create a view of the Node including all events at the latest time.
@@ -3402,6 +3403,7 @@ class Node:
         An iterator over the neighbours of this node that point into this node.
         """
 
+    def is_active(self): ...
     def latest(self):
         """
          Create a view of the Node including all events at the latest time.

--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -437,6 +437,13 @@ class Edge:
     def id(self):
         """The id of the edge."""
 
+    def is_active(self):
+        """
+        Check if the edge is currently active (i.e., has at least one update within this period)
+        Returns:
+            bool
+        """
+
     def is_deleted(self):
         """
         Check if the edge is currently deleted
@@ -456,6 +463,14 @@ class Edge:
         Check if the edge is currently valid (i.e., not deleted)
         Returns:
             bool
+        """
+
+    def latest(self):
+        """
+         Create a view of the Edge including all events at the latest time.
+
+        Returns:
+             A Edge object.
         """
 
     @property
@@ -882,6 +897,7 @@ class Edges:
     def id(self):
         """Returns all ids of the edges."""
 
+    def is_active(self): ...
     def is_deleted(self):
         """Check if the edges are deleted"""
 
@@ -890,6 +906,14 @@ class Edges:
 
     def is_valid(self):
         """Check if the edges are valid (i.e. not deleted)"""
+
+    def latest(self):
+        """
+         Create a view of the Edges including all events at the latest time.
+
+        Returns:
+             A Edges object.
+        """
 
     @property
     def latest_date_time(self):
@@ -1517,6 +1541,14 @@ class Graph:
         # Returns:
         Graph: sub-graph of the graph `g` containing the largest connected component
 
+        """
+
+    def latest(self):
+        """
+         Create a view of the GraphView including all events at the latest time.
+
+        Returns:
+             A GraphView object.
         """
 
     @property
@@ -2394,6 +2426,13 @@ class MutableEdge:
     def id(self):
         """The id of the edge."""
 
+    def is_active(self):
+        """
+        Check if the edge is currently active (i.e., has at least one update within this period)
+        Returns:
+            bool
+        """
+
     def is_deleted(self):
         """
         Check if the edge is currently deleted
@@ -2413,6 +2452,14 @@ class MutableEdge:
         Check if the edge is currently valid (i.e., not deleted)
         Returns:
             bool
+        """
+
+    def latest(self):
+        """
+         Create a view of the Edge including all events at the latest time.
+
+        Returns:
+             A Edge object.
         """
 
     @property
@@ -2876,6 +2923,14 @@ class MutableNode:
         Returns:
 
         An iterator over the neighbours of this node that point into this node.
+        """
+
+    def latest(self):
+        """
+         Create a view of the Node including all events at the latest time.
+
+        Returns:
+             A Node object.
         """
 
     @property
@@ -3347,6 +3402,14 @@ class Node:
         An iterator over the neighbours of this node that point into this node.
         """
 
+    def latest(self):
+        """
+         Create a view of the Node including all events at the latest time.
+
+        Returns:
+             A Node object.
+        """
+
     @property
     def latest_date_time(self):
         """
@@ -3793,6 +3856,14 @@ class Nodes:
         Returns:
 
         An iterator over the neighbours of this node that point into this node.
+        """
+
+    def latest(self):
+        """
+         Create a view of the Nodes including all events at the latest time.
+
+        Returns:
+             A Nodes object.
         """
 
     @property
@@ -4441,6 +4512,14 @@ class PersistentGraph:
 
         Returns:
            GraphIndex - Returns a GraphIndex
+        """
+
+    def latest(self):
+        """
+         Create a view of the GraphView including all events at the latest time.
+
+        Returns:
+             A GraphView object.
         """
 
     @property

--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -1299,6 +1299,7 @@ class Graph:
              The latest datetime that this GraphView is valid or None if the GraphView is valid for all times.
         """
 
+    def event_graph(self): ...
     def exclude_layer(self, name):
         """
          Return a view of GraphView containing all layers except the excluded `name`
@@ -4894,6 +4895,7 @@ class PersistentGraph:
          the nodes in the graph
         """
 
+    def persistent_graph(self): ...
     @property
     def properties(self):
         """

--- a/python/tests/graphql/misc/test_latest.py
+++ b/python/tests/graphql/misc/test_latest.py
@@ -1,0 +1,117 @@
+from raphtory.graphql import RaphtoryClient
+
+
+def test_latest_and_active():
+    from raphtory.graphql import GraphServer
+    from raphtory import Graph
+    import tempfile
+
+    query = """
+        {
+          graph(path: "graph") {
+            node(name: "1") {
+              name
+              isActive
+              latest {
+                history
+              }
+            }
+            e12: edge(src: "1", dst: "2") {
+              isActive
+              latest {
+                history
+              }
+            }
+            e13: edge(src: "1", dst: "3") {
+              latest {
+                isActive
+                history
+              }
+            }
+            nodes {
+              list {
+                name
+                edges {
+                  latest {
+                    list {
+                      history
+                    }
+                  }
+                }
+              }
+              latest {
+                list {
+                  name
+                  history
+                }
+              }
+            }
+            edges {
+              latest {
+                list {
+                  history
+                }
+              }
+            }
+          }
+        }
+    """
+
+    result = {
+        "graph": {
+            "node": {"name": "1", "isActive": True, "latest": {"history": [3]}},
+            "e12": {"isActive": True, "latest": {"history": [3]}},
+            "e13": {"latest": {"isActive": False, "history": []}},
+            "nodes": {
+                "list": [
+                    {
+                        "name": "1",
+                        "edges": {
+                            "latest": {
+                                "list": [
+                                    {"history": [3]},
+                                    {"history": []},
+                                    {"history": [3]},
+                                ]
+                            }
+                        },
+                    },
+                    {"name": "2", "edges": {"latest": {"list": [{"history": [3]}]}}},
+                    {"name": "3", "edges": {"latest": {"list": [{"history": []}]}}},
+                    {"name": "4", "edges": {"latest": {"list": [{"history": [3]}]}}},
+                ],
+                "latest": {
+                    "list": [
+                        {"name": "1", "history": [3]},
+                        {"name": "2", "history": [3]},
+                        {"name": "4", "history": [3]},
+                    ]
+                },
+            },
+            "edges": {
+                "latest": {
+                    "list": [{"history": [3]}, {"history": []}, {"history": [3]}]
+                }
+            },
+        }
+    }
+
+    work_dir = tempfile.mkdtemp()
+    g = Graph()
+    g.add_edge(1, 1, 2, {"int_prop": 123})
+    g.add_edge(2, 1, 2, {"int_prop": 124})
+    g.add_edge(3, 1, 2, {"int_prop": 125})
+
+    g.add_edge(1, 1, 3, {"int_prop": 123})
+    g.add_edge(2, 1, 3, {"int_prop": 124})
+    g.add_edge(3, 1, 4, {"int_prop": 125})
+
+    g.add_node(1, 1, {"int_prop": 123})
+    g.add_node(2, 1, {"int_prop": 124})
+    g.add_node(1, 2, {"int_prop": 125})
+    g.add_node(2, 2, {"int_prop": 125})
+
+    g.save_to_file(work_dir + "/graph")
+    with GraphServer(work_dir).start():
+        client = RaphtoryClient("http://localhost:1736")
+        assert client.query(query) == result

--- a/python/tests/test_graphdb/test_latest_graph.py
+++ b/python/tests/test_graphdb/test_latest_graph.py
@@ -1,0 +1,36 @@
+from raphtory import Graph, PersistentGraph
+
+
+def test_graph_latest():
+    g = Graph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 3)
+    g.add_edge(3, 1, 4)
+    assert g.latest_time == 3
+    assert g.latest().latest_time == 3
+    assert g.latest().earliest_time == 3
+    assert g.latest().edges.id.collect() == [(1, 4)]
+
+    assert g.window(1,2).latest().edges.id.collect() == [(1, 2)]
+
+def test_edge_latest():
+    g = Graph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 2)
+    g.add_edge(3, 1, 2)
+
+    g.add_edge(4, 1, 3)
+    g.add_edge(5, 1, 3)
+    g.add_edge(6, 1, 3)
+
+    assert g.edge(1, 2).latest().latest_time is None
+    assert not g.edge(1, 2).latest().is_active()
+    assert g.edge(1, 3).latest().is_active()
+
+    wg = g.window(2,4)
+    assert wg.edge(1, 2).latest().latest_time is 3
+    assert wg.edge(1, 2).latest().is_active()
+
+
+def test_vertex_latest():
+    g = Graph()

--- a/python/tests/test_graphdb/test_latest_graph.py
+++ b/python/tests/test_graphdb/test_latest_graph.py
@@ -32,6 +32,22 @@ def test_edge_latest():
     assert wg.edge(1, 2).latest().latest_time is 3
     assert wg.edge(1, 2).latest().is_active()
 
+    assert g.edges.latest().earliest_time.collect() == [None, 6]
+    assert g.edges.latest().is_active().collect() == [False, True]
+
+    assert wg.edges.latest().earliest_time.collect() == [3]
+    assert wg.edges.latest().is_active().collect() == [True]
+
+    assert g.nodes.edges.latest().earliest_time.collect() == [[None, 6], [None], [6]]
+    assert g.nodes.edges.latest().is_active().collect() == [
+        [False, True],
+        [False],
+        [True],
+    ]
+
+    assert wg.nodes.edges.latest().earliest_time.collect() == [[3], [3]]
+    assert wg.nodes.edges.latest().is_active().collect() == [[True], [True]]
+
 
 def test_node_latest():
     g = Graph()
@@ -41,10 +57,106 @@ def test_node_latest():
     assert g.node(1).latest().is_active()
     assert not g.node(2).latest().is_active()
 
-    wg = g.window(5,12)
-    print()
-    print(wg.node(1).latest().history())
-    print(wg.node(1).latest().earliest_time)
-    print(wg.node(1).latest().latest_time)
-    #assert wg.node(1).latest().is_active()
-    #assert not wg.node(2).latest().is_active()
+    wg = g.window(5, 12)
+    assert wg.node(1).latest().history() == [10]
+
+    assert g.nodes.latest().id.collect() == [1, 3]
+    assert wg.nodes.latest().id.collect() == [1, 2]
+
+
+def test_persistent_graph_latest():
+    g = PersistentGraph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 3)
+    g.add_edge(3, 1, 4)
+    g.delete_edge(3, 1, 3)
+    assert g.latest_time == 3
+    assert g.latest().latest_time == 3
+    assert g.latest().earliest_time == 3
+    assert g.latest().edges.id.collect() == [(1, 2), (1, 4)]
+
+    wg = g.window(1, 2)
+
+    assert wg.latest().latest_time == 1
+    assert wg.latest().earliest_time == 1
+
+    assert wg.latest().edges.id.collect() == [(1, 2)]
+    assert wg.latest().edges.id.collect() == [(1, 2)]
+
+
+def test_persistent_edge_latest():
+    g = PersistentGraph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 2)
+    g.add_edge(3, 1, 2)
+
+    g.add_edge(4, 1, 3)
+    g.add_edge(5, 1, 3)
+    g.add_edge(6, 1, 3)
+
+    g.add_edge(4, 1, 4)
+    g.add_edge(5, 1, 4)
+    g.delete_edge(6, 1, 4)
+
+    assert g.edge(1, 2).latest().latest_time is 6
+    assert g.edge(1, 2).latest().is_active()
+    assert g.edge(1, 3).latest().is_active()
+    assert not g.edge(1, 4).latest().is_active()
+
+    wg = g.window(3, 6)
+    assert wg.edge(1, 2).latest().latest_time is 5
+    assert wg.edge(1, 2).latest().is_active()
+    assert wg.edge(1, 4).latest().is_active()
+
+    assert g.edges.latest().earliest_time.collect() == [6, 6, None]
+    assert g.edges.latest().latest_time.collect() == [6, 6, None]
+    assert g.edges.latest().is_active().collect() == [True, True, False]
+
+    assert wg.edges.latest().earliest_time.collect() == [5, 5, 5]
+    assert wg.edges.latest().latest_time.collect() == [5, 5, 5]
+    assert wg.edges.latest().is_active().collect() == [True, True, True]
+
+    assert g.nodes.edges.latest().earliest_time.collect() == [
+        [6, 6, None],
+        [6],
+        [6],
+        [None],
+    ]
+    assert g.nodes.edges.latest().latest_time.collect() == [
+        [6, 6, None],
+        [6],
+        [6],
+        [None],
+    ]
+    assert g.nodes.edges.latest().is_active().collect() == [
+        [True, True, False],
+        [True],
+        [True],
+        [False],
+    ]
+
+    assert wg.nodes.edges.latest().earliest_time.collect() == [[5, 5, 5], [5], [5], [5]]
+    assert wg.nodes.edges.latest().latest_time.collect() == [[5, 5, 5], [5], [5], [5]]
+    assert wg.nodes.edges.latest().is_active().collect() == [
+        [True, True, True],
+        [True],
+        [True],
+        [True],
+    ]
+
+
+def test_persistent_node_latest():
+    g = PersistentGraph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(10, 1, 2)
+    g.add_edge(30, 1, 3)
+    assert g.node(1).latest().is_active()
+    assert not g.node(2).latest().is_active()
+
+    wg = g.window(5, 12)
+    assert wg.latest_time == 11
+    assert wg.earliest_time == 5
+    assert wg.node(1).latest().history() == []
+
+    assert g.nodes.latest().id.collect() == [1, 2, 3]
+    assert wg.nodes.latest().id.collect() == [1, 2]

--- a/python/tests/test_graphdb/test_latest_graph.py
+++ b/python/tests/test_graphdb/test_latest_graph.py
@@ -11,7 +11,8 @@ def test_graph_latest():
     assert g.latest().earliest_time == 3
     assert g.latest().edges.id.collect() == [(1, 4)]
 
-    assert g.window(1,2).latest().edges.id.collect() == [(1, 2)]
+    assert g.window(1, 2).latest().edges.id.collect() == [(1, 2)]
+
 
 def test_edge_latest():
     g = Graph()
@@ -27,10 +28,23 @@ def test_edge_latest():
     assert not g.edge(1, 2).latest().is_active()
     assert g.edge(1, 3).latest().is_active()
 
-    wg = g.window(2,4)
+    wg = g.window(2, 4)
     assert wg.edge(1, 2).latest().latest_time is 3
     assert wg.edge(1, 2).latest().is_active()
 
 
-def test_vertex_latest():
+def test_node_latest():
     g = Graph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(10, 1, 2)
+    g.add_edge(30, 1, 3)
+    assert g.node(1).latest().is_active()
+    assert not g.node(2).latest().is_active()
+
+    wg = g.window(5,12)
+    print()
+    print(wg.node(1).latest().history())
+    print(wg.node(1).latest().earliest_time)
+    print(wg.node(1).latest().latest_time)
+    #assert wg.node(1).latest().is_active()
+    #assert not wg.node(2).latest().is_active()

--- a/python/tests/test_graphdb/test_persistent_graph.py
+++ b/python/tests/test_graphdb/test_persistent_graph.py
@@ -1,4 +1,4 @@
-from raphtory import PersistentGraph
+from raphtory import PersistentGraph, Graph
 
 
 def test_basics():
@@ -159,6 +159,27 @@ def test_window_boundaries():
 
     assert G.window(6, 10).count_nodes() == 2
     assert G.window(6, 10).count_edges() == 0
+
+
+def test_graph_type_swap():
+    g = PersistentGraph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 3)
+    g.add_edge(30, 1, 4)
+    eg = Graph()
+    eg.add_edge(1, 1, 2)
+    eg.add_edge(2, 1, 3)
+    eg.add_edge(30, 1, 4)
+    assert type(g.persistent_graph()) == PersistentGraph
+    assert type(g.event_graph()) == Graph
+    assert g.persistent_graph().at(15).count_edges() == 2
+    assert g.event_graph().at(2).count_edges() == 1
+
+    assert type(eg.persistent_graph()) == PersistentGraph
+    assert type(eg.event_graph()) == Graph
+    assert eg.persistent_graph().count_edges() == 3
+    assert eg.persistent_graph().at(15).count_edges() == 2
+    assert eg.event_graph().at(2).count_edges() == 1
 
 
 # TODO this will not pass until we fix hanging edges

--- a/raphtory-graphql/src/model/graph/edge.rs
+++ b/raphtory-graphql/src/model/graph/edge.rs
@@ -70,6 +70,10 @@ impl Edge {
         self.ee.at(time).into()
     }
 
+    async fn latest(&self) -> Edge {
+        self.ee.latest().into()
+    }
+
     async fn before(&self, time: i64) -> Edge {
         self.ee.before(time).into()
     }
@@ -164,6 +168,10 @@ impl Edge {
 
     async fn is_valid(&self) -> bool {
         self.ee.is_valid()
+    }
+
+    async fn is_active(&self) -> bool {
+        self.ee.is_active()
     }
 
     async fn is_deleted(&self) -> bool {

--- a/raphtory-graphql/src/model/graph/edges.rs
+++ b/raphtory-graphql/src/model/graph/edges.rs
@@ -56,6 +56,9 @@ impl GqlEdges {
     async fn at(&self, time: i64) -> Self {
         self.update(self.ee.at(time))
     }
+    async fn latest(&self) -> Self {
+        self.update(self.ee.latest())
+    }
 
     async fn before(&self, time: i64) -> Self {
         self.update(self.ee.before(time))

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -156,6 +156,14 @@ impl GqlGraph {
         )
     }
 
+    async fn latest(&self) -> GqlGraph {
+        GqlGraph::new(
+            self.work_dir.clone(),
+            self.path.clone(),
+            self.graph.latest(),
+        )
+    }
+
     async fn before(&self, time: i64) -> GqlGraph {
         GqlGraph::new(
             self.work_dir.clone(),

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -64,6 +64,10 @@ impl Node {
         self.vv.at(time).into()
     }
 
+    async fn latest(&self) -> Node {
+        self.vv.latest().into()
+    }
+
     async fn before(&self, time: i64) -> Node {
         self.vv.before(time).into()
     }
@@ -114,6 +118,10 @@ impl Node {
 
     async fn history(&self) -> Vec<i64> {
         self.vv.history()
+    }
+
+    async fn is_active(&self) -> bool {
+        self.vv.is_active()
     }
 
     ////////////////////////

--- a/raphtory-graphql/src/model/graph/nodes.rs
+++ b/raphtory-graphql/src/model/graph/nodes.rs
@@ -57,6 +57,10 @@ impl GqlNodes {
         self.update(self.nn.at(time))
     }
 
+    async fn latest(&self) -> Self {
+        self.update(self.nn.latest())
+    }
+
     async fn before(&self, time: i64) -> Self {
         self.update(self.nn.before(time))
     }

--- a/raphtory-graphql/src/model/graph/path_from_node.rs
+++ b/raphtory-graphql/src/model/graph/path_from_node.rs
@@ -58,6 +58,9 @@ impl GqlPathFromNode {
     async fn at(&self, time: i64) -> Self {
         self.update(self.nn.at(time))
     }
+    async fn latest(&self) -> Self {
+        self.update(self.nn.latest())
+    }
 
     async fn before(&self, time: i64) -> Self {
         self.update(self.nn.before(time))

--- a/raphtory-graphql/src/python/server/running_server.rs
+++ b/raphtory-graphql/src/python/server/running_server.rs
@@ -3,7 +3,7 @@ use crate::python::{
     server::{is_online, wait_server, BridgeCommand},
     RUNNING_SERVER_CONSUMED_MSG, WAIT_CHECK_INTERVAL_MILLIS,
 };
-use crossbeam_channel::{SendError, Sender as CrossbeamSender};
+use crossbeam_channel::Sender as CrossbeamSender;
 use pyo3::{exceptions::PyException, pyclass, pymethods, Py, PyObject, PyResult, Python};
 use std::{
     thread::{sleep, JoinHandle},

--- a/raphtory/src/core/storage/timeindex.rs
+++ b/raphtory/src/core/storage/timeindex.rs
@@ -231,8 +231,8 @@ impl<'a, T: AsTime, Ops: TimeIndexOps<IndexType = T>, V: AsRef<Vec<Ops>> + Send 
 {
     type IndexType = Ops::IndexType;
     type RangeType<'b>
-
-    = LayeredTimeIndexWindow<'b, Ops::RangeType<'b>> where
+        = LayeredTimeIndexWindow<'b, Ops::RangeType<'b>>
+    where
         Self: 'b;
 
     #[inline(always)]
@@ -339,7 +339,10 @@ pub trait TimeIndexIntoOps: Sized {
 
 impl<T: AsTime> TimeIndexOps for TimeIndex<T> {
     type IndexType = T;
-    type RangeType<'a> = TimeIndexWindow<'a, T> where Self: 'a,;
+    type RangeType<'a>
+        = TimeIndexWindow<'a, T>
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn active(&self, w: Range<T>) -> bool {
@@ -419,7 +422,10 @@ where
     Self: 'b,
 {
     type IndexType = T;
-    type RangeType<'a> = TimeIndexWindow<'a, T> where Self: 'a;
+    type RangeType<'a>
+        = TimeIndexWindow<'a, T>
+    where
+        Self: 'a;
 
     #[inline(always)]
     fn active(&self, w: Range<T>) -> bool {
@@ -504,7 +510,10 @@ where
 
 impl<'a, Ops: TimeIndexOps + 'a> TimeIndexOps for LayeredTimeIndexWindow<'a, Ops> {
     type IndexType = Ops::IndexType;
-    type RangeType<'b> = LayeredTimeIndexWindow<'b, Ops::RangeType<'b>> where Self: 'b;
+    type RangeType<'b>
+        = LayeredTimeIndexWindow<'b, Ops::RangeType<'b>>
+    where
+        Self: 'b;
 
     #[inline(always)]
     fn active(&self, w: Range<Self::IndexType>) -> bool {

--- a/raphtory/src/db/api/state/lazy_node_state.rs
+++ b/raphtory/src/db/api/state/lazy_node_state.rs
@@ -111,7 +111,11 @@ impl<
 {
     type Graph = GH;
     type BaseGraph = G;
-    type Value<'a> = V where 'graph: 'a, Self: 'a;
+    type Value<'a>
+        = V
+    where
+        'graph: 'a,
+        Self: 'a;
     type OwnedValue = V;
 
     fn graph(&self) -> &Self::Graph {

--- a/raphtory/src/db/api/state/node_state.rs
+++ b/raphtory/src/db/api/state/node_state.rs
@@ -118,7 +118,10 @@ impl<
 {
     type Graph = GH;
     type BaseGraph = G;
-    type Value<'a> = &'a V where 'graph: 'a;
+    type Value<'a>
+        = &'a V
+    where
+        'graph: 'a;
     type OwnedValue = V;
 
     fn graph(&self) -> &Self::Graph {

--- a/raphtory/src/db/api/storage/graph/edges/edge_storage_ops.rs
+++ b/raphtory/src/db/api/storage/graph/edges/edge_storage_ops.rs
@@ -43,7 +43,10 @@ impl<'a> TimeIndexRef<'a> {
 
 impl<'a> TimeIndexOps for TimeIndexRef<'a> {
     type IndexType = TimeIndexEntry;
-    type RangeType<'b> = TimeIndexRef<'b> where Self: 'b;
+    type RangeType<'b>
+        = TimeIndexRef<'b>
+    where
+        Self: 'b;
 
     #[inline(always)]
     fn active(&self, w: Range<TimeIndexEntry>) -> bool {

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -96,7 +96,7 @@ pub trait EdgeViewOps<'graph>: TimeOps<'graph> + LayerOps<'graph> + Clone {
     fn nbr(&self) -> Self::Nodes;
 
     /// Check if edge is active at a given time point
-    fn active(&self, t: i64) -> Self::ValueType<bool>;
+    fn is_active(&self) -> Self::ValueType<bool>;
 
     /// Returns the id of the edge.
     fn id(&self) -> Self::ValueType<(GID, GID)>;
@@ -202,19 +202,12 @@ impl<'graph, E: BaseEdgeViewOps<'graph>> EdgeViewOps<'graph> for E {
         self.map_nodes(|_, e| e.remote())
     }
 
-    /// Check if edge is active at a given time point
-    fn active(&self, t: i64) -> Self::ValueType<bool> {
-        self.map(move |g, e| match e.time() {
-            Some(tt) => {
-                tt.t() <= t
-                    && t <= g
-                        .edge_latest_time(e, &g.layer_ids().constrain_from_edge(e))
-                        .unwrap_or(tt.t())
-            }
-            None => {
-                let edge = g.core_edge(e.into());
-                g.include_edge_window(edge.as_ref(), t..t.saturating_add(1), g.layer_ids())
-            }
+    /// Check if edge is active (i.e. has some update within the current bound)
+    fn is_active(&self) -> Self::ValueType<bool> {
+        self.map(move |g, e| {
+            g.edge_exploded(e, &g.layer_ids().constrain_from_edge(e))
+                .next()
+                .is_some()
         })
     }
 

--- a/raphtory/src/db/api/view/edge.rs
+++ b/raphtory/src/db/api/view/edge.rs
@@ -132,7 +132,10 @@ pub trait EdgeViewOps<'graph>: TimeOps<'graph> + LayerOps<'graph> + Clone {
 }
 
 impl<'graph, E: BaseEdgeViewOps<'graph>> EdgeViewOps<'graph> for E {
-    type ValueType<T> = E::ValueType<T> where T: 'graph;
+    type ValueType<T>
+        = E::ValueType<T>
+    where
+        T: 'graph;
     type PropType = E::PropType;
     type Graph = E::Graph;
     type BaseGraph = E::BaseGraph;

--- a/raphtory/src/db/api/view/internal/core_ops.rs
+++ b/raphtory/src/db/api/view/internal/core_ops.rs
@@ -351,7 +351,10 @@ pub enum NodeAdditions<'a> {
 
 impl<'b> TimeIndexOps for NodeAdditions<'b> {
     type IndexType = i64;
-    type RangeType<'a> = NodeAdditions<'a> where Self: 'a;
+    type RangeType<'a>
+        = NodeAdditions<'a>
+    where
+        Self: 'a;
 
     #[inline]
     fn active(&self, w: Range<i64>) -> bool {

--- a/raphtory/src/db/api/view/node.rs
+++ b/raphtory/src/db/api/view/node.rs
@@ -98,6 +98,9 @@ pub trait NodeViewOps<'graph>: Clone + TimeOps<'graph> + LayerOps<'graph> {
     /// Gets the history of the node (time that the node was added and times when changes were made to the node) as `DateTime<Utc>` objects if parseable
     fn history_date_time(&self) -> Self::ValueType<Option<Vec<DateTime<Utc>>>>;
 
+    //Returns true if the node has any updates within the current window, otherwise false
+    fn is_active(&self) -> Self::ValueType<bool>;
+
     /// Get a view of the temporal properties of this node.
     ///
     /// Returns:
@@ -225,6 +228,10 @@ impl<'graph, V: BaseNodeViewOps<'graph> + 'graph> NodeViewOps<'graph> for V {
                 .map(|t| t.dt())
                 .collect::<Option<Vec<_>>>()
         })
+    }
+
+    fn is_active(&self) -> Self::ValueType<bool> {
+        self.map(|_cg, g, v| !g.node_history(v).is_empty())
     }
 
     #[inline]

--- a/raphtory/src/db/graph/edge.rs
+++ b/raphtory/src/db/graph/edge.rs
@@ -451,7 +451,7 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> OneHopFilter<'gr
 #[cfg(test)]
 mod test_edge {
     use crate::{
-        core::IntoPropMap, db::api::view::time::internal::TimeOps, prelude::*, test_storage,
+        core::IntoPropMap, db::api::view::time::TimeOps, prelude::*, test_storage,
         test_utils::test_graph,
     };
     use itertools::Itertools;

--- a/raphtory/src/db/graph/edge.rs
+++ b/raphtory/src/db/graph/edge.rs
@@ -144,7 +144,8 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> BaseEdgeViewOps<
     type BaseGraph = G;
     type Graph = GH;
 
-    type ValueType<T> = T
+    type ValueType<T>
+        = T
     where
         T: 'graph;
     type PropType = Self;

--- a/raphtory/src/db/graph/edge.rs
+++ b/raphtory/src/db/graph/edge.rs
@@ -449,7 +449,10 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> OneHopFilter<'gr
 
 #[cfg(test)]
 mod test_edge {
-    use crate::{core::IntoPropMap, prelude::*, test_storage, test_utils::test_graph};
+    use crate::{
+        core::IntoPropMap, db::api::view::time::internal::TimeOps, prelude::*, test_storage,
+        test_utils::test_graph,
+    };
     use itertools::Itertools;
     use raphtory_api::core::storage::arc_str::ArcStr;
     use std::collections::HashMap;

--- a/raphtory/src/db/graph/edges.rs
+++ b/raphtory/src/db/graph/edges.rs
@@ -108,7 +108,10 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> BaseEdgeViewOps<
 {
     type BaseGraph = G;
     type Graph = GH;
-    type ValueType<T> = BoxedLIter<'graph, T> where T: 'graph;
+    type ValueType<T>
+        = BoxedLIter<'graph, T>
+    where
+        T: 'graph;
     type PropType = EdgeView<GH>;
     type Nodes = PathFromNode<'graph, G, G>;
     type Exploded = Self;
@@ -249,7 +252,10 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> BaseEdgeViewOps<
 {
     type BaseGraph = G;
     type Graph = GH;
-    type ValueType<T> = BoxedLIter<'graph, BoxedLIter<'graph, T>> where T: 'graph;
+    type ValueType<T>
+        = BoxedLIter<'graph, BoxedLIter<'graph, T>>
+    where
+        T: 'graph;
     type PropType = EdgeView<GH>;
     type Nodes = PathFromGraph<'graph, G, G>;
     type Exploded = Self;

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -52,7 +52,7 @@ pub fn graph_equal<'graph1, 'graph2, G1: GraphViewOps<'graph1>, G2: GraphViewOps
             g1.edges().explode().iter().all(|e| { // all exploded edges exist in other
                 g2
                     .edge(e.src().id(), e.dst().id())
-                    .filter(|ee| ee.active(e.time().expect("exploded")))
+                    .filter(|ee| ee.at(e.time().expect("exploded")).is_active())
                     .is_some()
             })
     } else {
@@ -2292,17 +2292,20 @@ mod db_tests {
                             ); // times are the same for exploded edge
                             let t = ee.earliest_time().unwrap();
                             check(
-                                ee.active(t),
+                                ee.at(t).is_active(),
                                 format!("exploded edge {:?} inactive at {}", ee, t),
                             );
                             if t < i64::MAX {
                                 // window is broken at MAX!
-                                check(e.active(t), format!("edge {:?} inactive at {}", e, t));
+                                check(
+                                    e.at(t).is_active(),
+                                    format!("edge {:?} inactive at {}", e, t),
+                                );
                             }
                             let t_test = t.saturating_add(offset);
                             if t_test != t && t_test < i64::MAX && t_test > i64::MIN {
                                 check(
-                                    !ee.active(t_test),
+                                    !ee.at(t_test).is_active(),
                                     format!("exploded edge {:?} active at {}", ee, t_test),
                                 );
                             }

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -327,6 +327,10 @@ impl Graph {
         Self { inner }
     }
 
+    pub fn event_graph(&self) -> Graph {
+        self.clone()
+    }
+
     /// Get persistent graph
     pub fn persistent_graph(&self) -> PersistentGraph {
         PersistentGraph::from_storage(self.inner.clone())

--- a/raphtory/src/db/graph/node.rs
+++ b/raphtory/src/db/graph/node.rs
@@ -275,7 +275,10 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> BaseNodeViewOps<
 {
     type BaseGraph = G;
     type Graph = GH;
-    type ValueType<T> = T where T: 'graph;
+    type ValueType<T>
+        = T
+    where
+        T: 'graph;
     type PropType = Self;
     type PathType = PathFromNode<'graph, G, G>;
     type Edges = Edges<'graph, G, GH>;

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -127,6 +127,9 @@ impl PersistentGraph {
     pub fn event_graph(&self) -> Graph {
         Graph::from_storage(self.0.clone())
     }
+    pub fn persistent_graph(&self) -> PersistentGraph {
+        self.clone()
+    }
 }
 
 impl<'graph, G: GraphViewOps<'graph>> PartialEq<G> for PersistentGraph {

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -205,7 +205,7 @@ impl TimeSemantics for PersistentGraph {
     fn latest_time_window(&self, start: i64, end: i64) -> Option<i64> {
         self.latest_time_global()
             .map(|t| t.min(end.saturating_sub(1)))
-            .filter(|&t| t > start)
+            .filter(|&t| t >= start)
     }
 
     fn node_earliest_time_window(&self, v: VID, start: i64, end: i64) -> Option<i64> {

--- a/raphtory/src/db/task/edge/eval_edge.rs
+++ b/raphtory/src/db/task/edge/eval_edge.rs
@@ -77,7 +77,10 @@ impl<
 {
     type BaseGraph = &'graph G;
     type Graph = GH;
-    type ValueType<T> = T where T: 'graph;
+    type ValueType<T>
+        = T
+    where
+        T: 'graph;
     type PropType = EdgeView<&'graph G, GH>;
     type Nodes = EvalNodeView<'graph, 'a, G, S, &'graph G, CS>;
     type Exploded = EvalEdges<'graph, 'a, G, GH, CS, S>;

--- a/raphtory/src/db/task/edge/eval_edges.rs
+++ b/raphtory/src/db/task/edge/eval_edges.rs
@@ -153,7 +153,10 @@ impl<
 {
     type BaseGraph = &'graph G;
     type Graph = GH;
-    type ValueType<T> = BoxedLIter<'graph, T> where T: 'graph;
+    type ValueType<T>
+        = BoxedLIter<'graph, T>
+    where
+        T: 'graph;
     type PropType = <Edges<'graph, &'graph G, GH> as BaseEdgeViewOps<'graph>>::PropType;
     type Nodes = EvalPathFromNode<'graph, 'a, G, &'graph G, CS, S>;
     type Exploded = EvalEdges<'graph, 'a, G, GH, CS, S>;

--- a/raphtory/src/db/task/node/eval_node.rs
+++ b/raphtory/src/db/task/node/eval_node.rs
@@ -495,7 +495,10 @@ impl<
 {
     type BaseGraph = &'graph G;
     type Graph = GH;
-    type ValueType<T>  = T where T: 'graph;
+    type ValueType<T>
+        = T
+    where
+        T: 'graph;
     type PropType = NodeView<GH>;
     type PathType = EvalPathFromNode<'graph, 'a, G, &'graph G, CS, S>;
     type Edges = EvalEdges<'graph, 'a, G, GH, CS, S>;

--- a/raphtory/src/disk_graph/graph_impl/time_index_into_ops.rs
+++ b/raphtory/src/disk_graph/graph_impl/time_index_into_ops.rs
@@ -55,7 +55,10 @@ impl<'a> TimeIndexIntoOps for TimeStamps<'a, i64> {
 
 impl<'a> TimeIndexOps for TimeStamps<'a, TimeIndexEntry> {
     type IndexType = TimeIndexEntry;
-    type RangeType<'b> = TimeStamps<'b, TimeIndexEntry> where Self: 'b;
+    type RangeType<'b>
+        = TimeStamps<'b, TimeIndexEntry>
+    where
+        Self: 'b;
 
     fn len(&self) -> usize {
         self.timestamps().len()
@@ -125,7 +128,10 @@ impl<'a> TimeIndexOps for TimeStamps<'a, TimeIndexEntry> {
 }
 impl<'a> TimeIndexOps for TimeStamps<'a, i64> {
     type IndexType = i64;
-    type RangeType<'b> = TimeStamps<'b, i64> where Self: 'b;
+    type RangeType<'b>
+        = TimeStamps<'b, i64>
+    where
+        Self: 'b;
 
     fn len(&self) -> usize {
         self.timestamps().len()

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -213,6 +213,13 @@ impl PyEdge {
         self.edge.is_valid()
     }
 
+    /// Check if the edge is currently active (i.e., has at least one update within this period)
+    /// Returns:
+    ///     bool
+    pub fn is_active(&self) -> bool {
+        self.edge.is_active()
+    }
+
     /// Check if the edge is currently deleted
     /// Returns:
     ///     bool

--- a/raphtory/src/python/graph/edges.rs
+++ b/raphtory/src/python/graph/edges.rs
@@ -208,6 +208,12 @@ impl PyEdges {
         (move || edges.is_valid()).into()
     }
 
+    ////Check if the edges are active (i.e. there is at least one update during this time)
+    fn is_active(&self) -> BoolIterable {
+        let edges = self.edges.clone();
+        (move || edges.is_active()).into()
+    }
+
     /// Check if the edges are on the same node
     fn is_self_loop(&self) -> BoolIterable {
         let edges = self.edges.clone();
@@ -517,6 +523,12 @@ impl PyNestedEdges {
     fn is_valid(&self) -> NestedBoolIterable {
         let edges = self.edges.clone();
         (move || edges.is_valid()).into()
+    }
+
+    ////Check if the edges are active (i.e. there is at least one update during this time)
+    fn is_active(&self) -> NestedBoolIterable {
+        let edges = self.edges.clone();
+        (move || edges.is_active()).into()
     }
 
     /// Check if the edges are on the same node

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -373,6 +373,10 @@ impl PyGraph {
         PyPersistentGraph::py_from_db_graph(self.graph.persistent_graph())
     }
 
+    pub fn event_graph<'py>(&'py self) -> PyResult<Py<PyGraph>> {
+        PyGraph::py_from_db_graph(self.graph.event_graph())
+    }
+
     /// Load nodes from a Pandas DataFrame into the graph.
     ///
     /// Arguments:

--- a/raphtory/src/python/graph/graph_with_deletions.rs
+++ b/raphtory/src/python/graph/graph_with_deletions.rs
@@ -339,6 +339,10 @@ impl PyPersistentGraph {
         PyGraph::py_from_db_graph(self.graph.event_graph())
     }
 
+    pub fn persistent_graph<'py>(&'py self) -> PyResult<Py<PyPersistentGraph>> {
+        PyPersistentGraph::py_from_db_graph(self.graph.persistent_graph())
+    }
+
     /// Load nodes from a Pandas DataFrame into the graph.
     ///
     /// Arguments:

--- a/raphtory/src/python/graph/node.rs
+++ b/raphtory/src/python/graph/node.rs
@@ -236,6 +236,10 @@ impl PyNode {
         self.node.history_date_time()
     }
 
+    pub fn is_active(&self) -> bool {
+        self.node.is_active()
+    }
+
     //******  Python  ******//
     pub fn __getitem__(&self, name: &str) -> PyResult<Prop> {
         self.node

--- a/raphtory/src/python/types/macros/trait_impl/timeops.rs
+++ b/raphtory/src/python/types/macros/trait_impl/timeops.rs
@@ -111,6 +111,14 @@ macro_rules! impl_timeops {
                 self.$field.at(time)
             }
 
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events at the latest time.")]
+            ///
+            /// Returns:
+            #[doc = concat!(r"     A ", $name, r" object.")]
+            pub fn latest(&self) -> <$base_type as TimeOps<'static>>::WindowedViewType {
+                self.$field.latest()
+            }
+
             #[doc = concat!(r" Create a view of the ", $name, r" including all events before `end` (exclusive).")]
             ///
             /// Arguments:


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Added a `latest()` function on all classes which equates to `x.at(graph.latest_time)` 
2. Exposed `is_active` on edge, edges,  and node as a short hand to see if the entitiy has any updates within the window - this is not added only nodes as they are filtered through windows so it would basically always return true.
3. Add event_graph function to Graph and persistent_graph function to PersistentGraph - these are basically just noops, but make it so in python you can call them without knowing what type you current have.

TODO:

- [x] Need to add all of the above to graphql

### Why are the changes needed?

- It is a massive pain (expecially in graphql) to always look up the current time or latest time in the graph
- It can often be the case (say when doing a rolling) that you end up with an 'Empty' edge/node - this is done becuase dealing with Nones is a pain in the ass - so is_active() allows you to check this.

### Does this PR introduce any user-facing change? If yes is this documented?
Yes and yes

### How was this patch tested?
New tests

### Issues
Created #1787

### Are there any further changes required?
This has opened a couple of questions on if other filters should apply a window, and how should the DSL filtering be read.

