### PR TITLE
Edge repr layers

### DIFF
--- a/python/tests/test_repr.py
+++ b/python/tests/test_repr.py
@@ -12,6 +12,12 @@ G.add_edge(1, "A", "B", layer = "layer 1")
 G.add_edge(1, "A", "B", layer = "layer 2")
 print(G.edge("A","B"))
 
+# edge with more than 11 layers
+G = Graph()
+for i in range(20):
+    G.add_edge(i, "A", "B", layer = f"layer {i}")
+print(G.edge("A","B"))
+
 # event graph with two layers and properties
 G = Graph()
 G.add_edge(1, "A", "B", layer = "layer 1", properties={"greeting":"howdy"})

--- a/python/tests/test_repr.py
+++ b/python/tests/test_repr.py
@@ -1,0 +1,34 @@
+from raphtory import Graph, PersistentGraph
+
+# event graph with no layers
+G = Graph()
+G.add_edge(1, "A", "B")
+G.add_edge(1, "A", "B")
+print(G.edge("A","B"))
+
+# event graph with two layers
+G = Graph()
+G.add_edge(1, "A", "B", layer = "layer 1")
+G.add_edge(1, "A", "B", layer = "layer 2")
+print(G.edge("A","B"))
+
+# event graph with two layers and properties
+G = Graph()
+G.add_edge(1, "A", "B", layer = "layer 1", properties={"greeting":"howdy"})
+G.add_edge(2, "A", "B", layer = "layer 2", properties={"greeting":"yo"})
+print(G.edge("A","B"))
+print(G.edge("A","B").explode())
+
+# event graph with one layer and one non-layer
+G = Graph()
+G.add_edge(1, "A", "B", layer = "layer 1", properties={"greeting":"howdy"})
+G.add_edge(2, "A", "B", properties={"greeting":"yo"})
+print(G.edge("A","B"))
+
+# persistent graph with layers
+G = PersistentGraph()
+G.add_edge(1, "A", "B", layer = "layer 1", properties={"greeting":"howdy"})
+G.delete_edge(5, "A", "B", layer = "layer 1")
+G.add_edge(2, "A", "B", layer = "layer 2", properties={"greeting":"yo"})
+G.delete_edge(6, "A", "B", layer = "layer 2")
+print(G.edge("A","B"))

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -334,7 +334,11 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> Repr for EdgeVie
         let earliest_time = self.earliest_time().repr();
         let latest_time = self.latest_time().repr();
         let layer_names = self.layer_names().into_iter().take(11).collect_vec();
-        let layer_names_prev = if layer_names.len() < 11 {layer_names.join(", ") } else { layer_names[0..10].join(",")+"..."};
+        let layer_names_prev = if layer_names.len() < 11 {
+            layer_names.join(", ")
+        } else {
+            layer_names[0..10].join(",") + "..."
+        };
 
         if properties.is_empty() {
             format!(

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -351,12 +351,13 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> Repr for EdgeVie
             )
         } else {
             format!(
-                "Edge(source={}, target={}, earliest_time={}, latest_time={}, properties={})",
+                "Edge(source={}, target={}, earliest_time={}, latest_time={}, properties={}, layer(s)={})",
                 source.trim_matches('"'),
                 target.trim_matches('"'),
                 earliest_time,
                 latest_time,
-                format!("{{{properties}}}")
+                format!("{{{properties}}}"),
+                layer_names_prev
             )
         }
     }

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -342,7 +342,7 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> Repr for EdgeVie
 
         if properties.is_empty() {
             format!(
-                "Edge(source={}, target={}, earliest_time={}, latest_time={}, layer(s)={})",
+                "Edge(source={}, target={}, earliest_time={}, latest_time={}, layer(s)=[{}])",
                 source.trim_matches('"'),
                 target.trim_matches('"'),
                 earliest_time,
@@ -351,7 +351,7 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> Repr for EdgeVie
             )
         } else {
             format!(
-                "Edge(source={}, target={}, earliest_time={}, latest_time={}, properties={}, layer(s)={})",
+                "Edge(source={}, target={}, earliest_time={}, latest_time={}, properties={}, layer(s)=[{}])",
                 source.trim_matches('"'),
                 target.trim_matches('"'),
                 earliest_time,

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -337,7 +337,7 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> Repr for EdgeVie
         let layer_names_prev = if layer_names.len() < 11 {
             layer_names.join(", ")
         } else {
-            layer_names[0..10].join(",") + "..."
+            layer_names[0..10].join(",") + ", ..."
         };
 
         if properties.is_empty() {

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -333,13 +333,17 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> Repr for EdgeVie
         let target = self.dst().name();
         let earliest_time = self.earliest_time().repr();
         let latest_time = self.latest_time().repr();
+        let layer_names = self.layer_names().into_iter().take(11).collect_vec();
+        let layer_names_prev = if layer_names.len() < 11 {layer_names.join(", ") } else { layer_names[0..10].join(",")+"..."};
+
         if properties.is_empty() {
             format!(
-                "Edge(source={}, target={}, earliest_time={}, latest_time={})",
+                "Edge(source={}, target={}, earliest_time={}, latest_time={}, layer(s)={})",
                 source.trim_matches('"'),
                 target.trim_matches('"'),
                 earliest_time,
                 latest_time,
+                layer_names_prev
             )
         } else {
             format!(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add layers to the edge repr to show what layers an edge/exploded edge is present in, e.g.
```
Edge(source=A, target=B, earliest_time=1, latest_time=6, properties={greeting: yo, greeting: yo}, layer(s)=[layer 1, layer 2])
```

### Why are the changes needed?

Useful to be displayed in the edge summary.

### Does this PR introduce any user-facing change? If yes is this documented?

No.

### How was this patch tested?

Added a python test file to check the output seems sane on the two types of graph.

### Are there any further changes required?

Issue #1808 is a bit related since it involves how properties are displayed across layers. Could do a two-in-one if the solution is not too hard.