### PR TITLE
Use PathBuf for python path input

### DIFF
--- a/raphtory/src/disk_graph/mod.rs
+++ b/raphtory/src/disk_graph/mod.rs
@@ -328,10 +328,10 @@ impl DiskGraphStorage {
         Ok(Self::new(inner))
     }
 
-    pub fn load_from_parquets<P: AsRef<Path>>(
-        graph_dir: P,
+    pub fn load_from_parquets(
+        graph_dir: impl AsRef<Path>,
         layer_parquet_cols: Vec<ParquetLayerCols>,
-        node_properties: Option<P>,
+        node_properties: Option<impl AsRef<Path>>,
         chunk_size: usize,
         t_props_chunk_size: usize,
         read_chunk_size: Option<usize>,

--- a/raphtory/src/disk_graph/mod.rs
+++ b/raphtory/src/disk_graph/mod.rs
@@ -328,10 +328,10 @@ impl DiskGraphStorage {
         Ok(Self::new(inner))
     }
 
-    pub fn load_from_parquets(
-        graph_dir: impl AsRef<Path>,
+    pub fn load_from_parquets<P: AsRef<Path>>(
+        graph_dir: P,
         layer_parquet_cols: Vec<ParquetLayerCols>,
-        node_properties: Option<impl AsRef<Path>>,
+        node_properties: Option<P>,
         chunk_size: usize,
         t_props_chunk_size: usize,
         read_chunk_size: Option<usize>,

--- a/raphtory/src/python/graph/disk_graph.rs
+++ b/raphtory/src/python/graph/disk_graph.rs
@@ -17,7 +17,7 @@ use pyo3::{
     prelude::*,
     types::{PyDict, PyList, PyString},
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Clone)]
 #[pyclass(name = "DiskGraphStorage")]
@@ -158,9 +158,12 @@ impl PyDiskGraph {
     }
 
     #[staticmethod]
-    fn load_from_dir(graph_dir: &str) -> Result<DiskGraphStorage, GraphError> {
-        DiskGraphStorage::load_from_dir(graph_dir).map_err(|err| {
-            GraphError::LoadFailure(format!("Failed to load graph {err:?} from dir {graph_dir}"))
+    fn load_from_dir(graph_dir: PathBuf) -> Result<DiskGraphStorage, GraphError> {
+        DiskGraphStorage::load_from_dir(&graph_dir).map_err(|err| {
+            GraphError::LoadFailure(format!(
+                "Failed to load graph {err:?} from dir {}",
+                graph_dir.display()
+            ))
         })
     }
 

--- a/raphtory/src/python/graph/graph.rs
+++ b/raphtory/src/python/graph/graph.rs
@@ -155,7 +155,7 @@ impl PyGraph {
     }
 
     #[cfg(feature = "storage")]
-    pub fn to_disk_graph(&self, graph_dir: String) -> Result<Graph, GraphError> {
+    pub fn to_disk_graph(&self, graph_dir: PathBuf) -> Result<Graph, GraphError> {
         use crate::db::api::storage::graph::storage_ops::GraphStorage;
         use std::sync::Arc;
 

--- a/raphtory/src/python/types/macros/trait_impl/serialise.rs
+++ b/raphtory/src/python/types/macros/trait_impl/serialise.rs
@@ -16,7 +16,7 @@ macro_rules! impl_serialise {
             ///
             /// Arguments:
             ///     path (str): The path to the cache file
-            fn cache(&self, path: &str) -> Result<(), GraphError> {
+            fn cache(&self, path: std::path::PathBuf) -> Result<(), GraphError> {
                 $crate::serialise::CacheOps::cache(&self.$field, path)
             }
 
@@ -36,7 +36,7 @@ macro_rules! impl_serialise {
             /// Returns:
             #[doc = concat!("   ", $name)]
             #[staticmethod]
-            fn load_cached(path: &str) -> Result<$base_type, GraphError> {
+            fn load_cached(path: PathBuf) -> Result<$base_type, GraphError> {
                 <$base_type as $crate::serialise::CacheOps>::load_cached(path)
             }
 
@@ -48,7 +48,7 @@ macro_rules! impl_serialise {
             /// Returns:
             #[doc = concat!("   ", $name)]
             #[staticmethod]
-            fn load_from_file(path: &str) -> Result<$base_type, GraphError> {
+            fn load_from_file(path: PathBuf) -> Result<$base_type, GraphError> {
                 <$base_type as $crate::serialise::StableDecode>::decode(path)
             }
 
@@ -56,7 +56,7 @@ macro_rules! impl_serialise {
             ///
             /// Arguments:
             ///  path (str): The path to the file.
-            fn save_to_file(&self, path: &str) -> Result<(), GraphError> {
+            fn save_to_file(&self, path: PathBuf) -> Result<(), GraphError> {
                 $crate::serialise::StableEncode::encode(&self.$field, path)
             }
 
@@ -64,7 +64,7 @@ macro_rules! impl_serialise {
             ///
             /// Arguments:
             ///  path (str): The path to the file.
-            fn save_to_zip(&self, path: &str) -> Result<(), GraphError> {
+            fn save_to_zip(&self, path: PathBuf) -> Result<(), GraphError> {
                 let folder = $crate::serialise::GraphFolder::new_as_zip(path);
                 $crate::serialise::StableEncode::encode(&self.$field, folder)
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `&str` and `String` by `PathBuf` for python path input

### Why are the changes needed?

This allows passing in `pathlib.Path` as well as strings on the python side for the path and avoids unnecessary errors. 

### Does this PR introduce any user-facing change? If yes is this documented?

Less nonsense exceptions in python :)

### How was this patch tested?

The tests

### Are there any further changes required?

- Double-check there aren't any other places where this change needs to happen.
- Make sure we use `PathBuf` for path input in the future.


