### PR TITLE
fix the `to_df` in AlgorithmResult and Edges

### DIFF
--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -5656,14 +5656,6 @@ class PropertyFilter:
     def __init__(self):
         """Initialize self.  See help(type(self)) for accurate signature."""
 
-class PyDirection:
-    """A direction used by an edge, being incoming or outgoing"""
-
-    def __init__(self, direction):
-        """Initialize self.  See help(type(self)) for accurate signature."""
-
-    def as_str(self): ...
-
 class PyGraphEncoder:
     def __init__(self):
         """Initialize self.  See help(type(self)) for accurate signature."""

--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -100,12 +100,12 @@ class AlgorithmResult:
             A sorted vector of tuples containing keys of type `H` and values of type `Y`.
         """
 
-    def to_df(self):
+    def to_df(self) -> DataFrame:
         """
         Creates a dataframe from the result
 
         Returns:
-            A `pandas.DataFrame` containing the result
+            DataFrame: A `pandas.DataFrame` containing the result
         """
 
     def to_string(self):

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -46,7 +46,7 @@ def average_degree(g: GraphView):
 def balance(
     g: GraphView,
     name: str = "weight",
-    direction: Direction = "BOTH",
+    direction: Direction = "both",
     threads: Optional[int] = None,
 ) -> AlgorithmResult:
     """
@@ -57,7 +57,7 @@ def balance(
     Arguments:
         g (GraphView): The graph view on which the operation is to be performed.
         name (str): The name of the edge property used as the weight. Defaults to "weight".
-        direction (Direction): Specifies the direction of the edges to be considered for summation. Defaults to "BOTH".
+        direction (Direction): Specifies the direction of the edges to be considered for summation. Defaults to "both".
                 * "OUT": Only consider outgoing edges.
                 * "IN": Only consider incoming edges.
                 * "BOTH": Consider both outgoing and incoming edges. This is the default.
@@ -108,7 +108,7 @@ def dijkstra_single_source_shortest_paths(
     g: GraphView,
     source: InputNode,
     targets: list[InputNode],
-    direction: Direction = "BOTH",
+    direction: Direction = "both",
     weight: str = "weight",
 ) -> dict:
     """
@@ -118,7 +118,7 @@ def dijkstra_single_source_shortest_paths(
         g (GraphView): The graph to search in.
         source (InputNode): The source node.
         targets (list[InputNode]): A list of target nodes.
-        direction (Direction): The direction of the edges to be considered for the shortest path. Defaults to "BOTH".
+        direction (Direction): The direction of the edges to be considered for the shortest path. Defaults to "both".
         weight (str): The name of the weight property for the edges. Defaults to "weight".
 
     Returns:

--- a/python/python/raphtory/typing.py
+++ b/python/python/raphtory/typing.py
@@ -13,7 +13,7 @@ Prop = Union[
     dict[str, "Prop"],
 ]
 
-Direction = Literal["IN", "OUT", "BOTH"]
+Direction = Literal["in", "out", "both"]
 
 InputNode = Union[int, str, "Node"]
 

--- a/python/tests/test_algorithms.py
+++ b/python/tests/test_algorithms.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 import pandas.core.frame
-from raphtory import Graph, PersistentGraph, PyDirection
+from raphtory import Graph, PersistentGraph
 from raphtory import algorithms
 from raphtory import graph_loader
 
@@ -223,8 +223,8 @@ def test_algo_result():
     assert len(actual.group_by()[1]) == 8
     assert type(actual.to_df()) == pandas.core.frame.DataFrame
     df = actual.to_df()
-    expected_result = pd.DataFrame({"Key": [1], "Value": [1]})
-    row_with_one = df[df["Key"] == 1]
+    expected_result = pd.DataFrame({"Node": g.node("1"), "Value": [1]})
+    row_with_one = df[df["Node"] == g.node("1")]
     row_with_one.reset_index(inplace=True, drop=True)
     assert row_with_one.equals(expected_result)
     # Algo Str u64
@@ -254,7 +254,7 @@ def test_algo_result():
         "8": 0.11786468661230831,
     }
     assert actual.get_all_with_names() == expected_result
-    assert actual.get("Not a node") == None
+    assert actual.get("Not a node") is None
     assert len(actual.to_df()) == 8
     # algo str vector
     actual = algorithms.temporally_reachable_nodes(g, 20, 11, [1, 2], [4, 5])
@@ -463,19 +463,13 @@ def test_balance_algorithm():
     ]
     for src, dst, val, time in edges_str:
         g.add_edge(time, src, dst, {"value_dec": val})
-    result = algorithms.balance(
-        g, "value_dec", PyDirection("BOTH"), None
-    ).get_all_with_names()
+    result = algorithms.balance(g, "value_dec", "both", None).get_all_with_names()
     assert result == {"1": -26.0, "2": 7.0, "3": 12.0, "4": 5.0, "5": 2.0}
 
-    result = algorithms.balance(
-        g, "value_dec", PyDirection("IN"), None
-    ).get_all_with_names()
+    result = algorithms.balance(g, "value_dec", "in", None).get_all_with_names()
     assert result == {"1": 6.0, "2": 12.0, "3": 15.0, "4": 20.0, "5": 2.0}
 
-    result = algorithms.balance(
-        g, "value_dec", PyDirection("OUT"), None
-    ).get_all_with_names()
+    result = algorithms.balance(g, "value_dec", "out", None).get_all_with_names()
     assert result == {"1": -32.0, "2": -5.0, "3": -3.0, "4": -15.0, "5": 0.0}
 
 

--- a/python/tests/test_algorithms.py
+++ b/python/tests/test_algorithms.py
@@ -223,8 +223,8 @@ def test_algo_result():
     assert len(actual.group_by()[1]) == 8
     assert type(actual.to_df()) == pandas.core.frame.DataFrame
     df = actual.to_df()
-    expected_result = pd.DataFrame({"Node": g.node("1"), "Value": [1]})
-    row_with_one = df[df["Node"] == g.node("1")]
+    expected_result = pd.DataFrame({"Node": 1, "Value": [1]})
+    row_with_one = df[df["Node"] == 1]
     row_with_one.reset_index(inplace=True, drop=True)
     assert row_with_one.equals(expected_result)
     # Algo Str u64

--- a/python/tests/test_graph_conversions.py
+++ b/python/tests/test_graph_conversions.py
@@ -1124,6 +1124,11 @@ def test_to_df():
         pd.read_json(base_dir / "expected/dataframe_output/edge_df_explode.json"),
     )
 
+    compare_df(
+        g.edges.explode().to_df(),
+        pd.read_json(base_dir / "expected/dataframe_output/edge_df_explode.json"),
+    )
+
     # compare_df(
     #     g.edges.to_df(explode=True, convert_datetime=True),
     #     pd.read_json(base_dir / "expected/dataframe_output/edge_df_explode_datetime.json")

--- a/python/tests/test_graphdb/test_graphdb.py
+++ b/python/tests/test_graphdb/test_graphdb.py
@@ -7,7 +7,7 @@ import re
 import pandas as pd
 import pandas.core.frame
 import pytest
-from raphtory import Graph, PersistentGraph, PyDirection
+from raphtory import Graph, PersistentGraph
 from raphtory import algorithms
 from raphtory import graph_loader
 import tempfile

--- a/python/tests/test_graphdb/test_iterables.py
+++ b/python/tests/test_graphdb/test_iterables.py
@@ -4,7 +4,7 @@ import sys
 import pandas as pd
 import pandas.core.frame
 import pytest
-from raphtory import Graph, PersistentGraph, PyDirection
+from raphtory import Graph, PersistentGraph
 from raphtory import algorithms
 from raphtory import graph_loader
 import tempfile

--- a/python/tests/test_loaders/test_load_from_pandas.py
+++ b/python/tests/test_loaders/test_load_from_pandas.py
@@ -6,7 +6,7 @@ import numpy
 import pandas as pd
 import pandas.core.frame
 import pytest
-from raphtory import Graph, PersistentGraph, PyDirection
+from raphtory import Graph, PersistentGraph
 from raphtory import algorithms
 from raphtory import graph_loader
 import tempfile

--- a/raphtory-api/src/python/direction.rs
+++ b/raphtory-api/src/python/direction.rs
@@ -1,0 +1,16 @@
+use crate::core::Direction;
+use pyo3::{exceptions::PyTypeError, FromPyObject, PyAny, PyResult};
+
+impl<'source> FromPyObject<'source> for Direction {
+    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+        let value: &str = ob.extract()?;
+        match value {
+            "out" => Ok(Direction::OUT),
+            "in" => Ok(Direction::IN),
+            "both" => Ok(Direction::BOTH),
+            _ => Err(PyTypeError::new_err(PyTypeError::new_err(
+                "Direction must be one of { 'out', 'in', 'both' }",
+            ))),
+        }
+    }
+}

--- a/raphtory-api/src/python/mod.rs
+++ b/raphtory-api/src/python/mod.rs
@@ -1,2 +1,3 @@
 mod arcstr;
+mod direction;
 mod gid;

--- a/raphtory/src/python/algorithm/epidemics.rs
+++ b/raphtory/src/python/algorithm/epidemics.rs
@@ -3,7 +3,10 @@ use crate::{
         Infected, IntoSeeds, Number, Probability, SeedError,
     },
     core::entities::{nodes::node_ref::NodeRef, VID},
-    db::api::view::{DynamicGraph, StaticGraphViewOps},
+    db::{
+        api::view::{DynamicGraph, StaticGraphViewOps},
+        graph::node::NodeView,
+    },
     py_algorithm_result, py_algorithm_result_new_ord_hash_eq,
     python::{
         types::repr::{Repr, StructReprBuilder},

--- a/raphtory/src/python/algorithm/epidemics.rs
+++ b/raphtory/src/python/algorithm/epidemics.rs
@@ -3,10 +3,7 @@ use crate::{
         Infected, IntoSeeds, Number, Probability, SeedError,
     },
     core::entities::{nodes::node_ref::NodeRef, VID},
-    db::{
-        api::view::{DynamicGraph, StaticGraphViewOps},
-        graph::node::NodeView,
-    },
+    db::api::view::{DynamicGraph, StaticGraphViewOps},
     py_algorithm_result, py_algorithm_result_new_ord_hash_eq,
     python::{
         types::repr::{Repr, StructReprBuilder},

--- a/raphtory/src/python/graph/algorithm_result.rs
+++ b/raphtory/src/python/graph/algorithm_result.rs
@@ -1,10 +1,7 @@
 use crate::{
     algorithms::algorithm_result::AlgorithmResult as AlgorithmResultRs,
     core::entities::VID,
-    db::{
-        api::view::{internal::DynamicGraph, StaticGraphViewOps},
-        graph::node::NodeView,
-    },
+    db::api::view::{internal::DynamicGraph, StaticGraphViewOps},
     python::types::repr::{Repr, StructReprBuilder},
 };
 use ordered_float::OrderedFloat;
@@ -132,7 +129,10 @@ macro_rules! py_algorithm_result_base {
                 let mut values = Vec::new();
                 Python::with_gil(|py| {
                     for (key, value) in hashmap.iter() {
-                        let node = NodeView::new_internal(self.0.graph.clone(), VID(*key));
+                        let node = $crate::db::api::view::internal::core_ops::CoreGraphOps::node_id(
+                            &self.0.graph,
+                            VID(*key),
+                        );
                         keys.push(node.into_py(py));
                         values.push(value.to_object(py));
                     }

--- a/raphtory/src/python/graph/edge.rs
+++ b/raphtory/src/python/graph/edge.rs
@@ -5,7 +5,7 @@
 //! edge as it existed at a particular point in time, or as it existed over a particular time range.
 //!
 use crate::{
-    core::{utils::errors::GraphError, Direction},
+    core::utils::errors::GraphError,
     db::{
         api::{
             properties::Properties,
@@ -428,68 +428,5 @@ impl PyMutableEdge {
 
     fn __repr__(&self) -> String {
         self.repr()
-    }
-}
-
-/// A direction used by an edge, being incoming or outgoing
-#[pyclass]
-#[derive(Clone)]
-pub struct PyDirection {
-    inner: Direction,
-}
-
-#[pymethods]
-impl PyDirection {
-    #[new]
-    pub fn new(direction: &str) -> Self {
-        match direction {
-            "OUT" => PyDirection {
-                inner: Direction::OUT,
-            },
-            "IN" => PyDirection {
-                inner: Direction::IN,
-            },
-            "BOTH" => PyDirection {
-                inner: Direction::BOTH,
-            },
-            _ => panic!("Invalid direction"),
-        }
-    }
-
-    fn as_str(&self) -> &str {
-        match self.inner {
-            Direction::OUT => "OUT",
-            Direction::IN => "IN",
-            Direction::BOTH => "BOTH",
-        }
-    }
-}
-
-impl Into<Direction> for PyDirection {
-    fn into(self) -> Direction {
-        self.inner
-    }
-}
-
-impl From<Direction> for PyDirection {
-    fn from(d: Direction) -> Self {
-        PyDirection { inner: d }
-    }
-}
-
-impl From<String> for PyDirection {
-    fn from(s: String) -> Self {
-        match s.to_uppercase().as_str() {
-            "OUT" => PyDirection {
-                inner: Direction::OUT,
-            },
-            "IN" => PyDirection {
-                inner: Direction::IN,
-            },
-            "BOTH" => PyDirection {
-                inner: Direction::BOTH,
-            },
-            _ => panic!("Invalid direction string"),
-        }
     }
 }

--- a/raphtory/src/python/graph/edges.rs
+++ b/raphtory/src/python/graph/edges.rs
@@ -270,7 +270,7 @@ impl PyEdges {
         &self,
         include_property_history: bool,
         convert_datetime: bool,
-        explode: bool,
+        mut explode: bool,
     ) -> PyResult<PyObject> {
         let mut column_names = vec![
             String::from("src"),
@@ -284,6 +284,13 @@ impl PyEdges {
         if explode == true {
             edges = self.edges.explode_layers().explode();
         }
+
+        explode = explode
+            || edges
+                .iter()
+                .next()
+                .filter(|e| e.edge.time().is_some())
+                .is_some();
 
         let edge_tuples: Vec<_> = edges
             .collect()

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -541,9 +541,9 @@ pub fn hits(
 ///     g (GraphView): The graph view on which the operation is to be performed.
 ///     name (str): The name of the edge property used as the weight. Defaults to "weight".
 ///     direction (Direction): Specifies the direction of the edges to be considered for summation. Defaults to "both".
-///             * "OUT": Only consider outgoing edges.
-///             * "IN": Only consider incoming edges.
-///             * "BOTH": Consider both outgoing and incoming edges. This is the default.
+///             * "out": Only consider outgoing edges.
+///             * "in": Only consider incoming edges.
+///             * "both": Consider both outgoing and incoming edges. This is the default.
 ///     threads (int, optional): The number of threads to be used for parallel execution.
 ///
 /// Returns:

--- a/raphtory/src/python/packages/base_modules.rs
+++ b/raphtory/src/python/packages/base_modules.rs
@@ -7,7 +7,7 @@ use crate::{
     python::{
         graph::{
             algorithm_result::AlgorithmResult,
-            edge::{PyDirection, PyEdge, PyMutableEdge},
+            edge::{PyEdge, PyMutableEdge},
             edges::PyEdges,
             graph::{PyGraph, PyGraphEncoder},
             graph_with_deletions::PyPersistentGraph,
@@ -48,7 +48,6 @@ pub fn add_raphtory_classes(m: &PyModule) -> PyResult<()> {
         PyConstProperties,
         PyTemporalProperties,
         PyTemporalProp,
-        PyDirection,
         PyPropertyRef,
         PyPropertyFilter,
         AlgorithmResult,


### PR DESCRIPTION
### What changes were proposed in this pull request?

- `to_df` in `AlgorithmResult` no longer returns internal ids
- `Graph.edges.explode().to_df()` is now equivalent to `Graph.edges.to_df(explode=True)`, in particular the history is no longer duplicated for each exploded edge.
- `PyDirection` is no more and direction arguments now take strings as input directly (The only way to construct a `PyDirection` was via passing in a string anyway so this seemed entirely confusing and useless)

### Why are the changes needed?

- internal ids are useless
- Direction input in python was confusing
- `to_df()` on exploded edges was broken

### Does this PR introduce any user-facing change? If yes is this documented?


### How was this patch tested?

extended data frame conversion tests to include exploded edges

### Are there any further changes required?


