### PR TITLE
GrapQL improvements for disk graph

### DIFF
--- a/raphtory-graphql/src/graph.rs
+++ b/raphtory-graphql/src/graph.rs
@@ -15,7 +15,7 @@ use raphtory::{
         },
         graph::{edge::EdgeView, node::NodeView},
     },
-    prelude::{CacheOps, DeletionOps, EdgeViewOps, NodeViewOps},
+    prelude::{CacheOps, DeletionOps, EdgeViewOps, GraphViewOps, NodeViewOps},
     search::IndexedGraph,
     serialise::GraphFolder,
     vectors::{

--- a/raphtory/src/disk_graph/graph_impl/tprops.rs
+++ b/raphtory/src/disk_graph/graph_impl/tprops.rs
@@ -222,7 +222,11 @@ pub fn read_tprop_column(id: usize, field: Field, edge: Edge) -> Option<DiskTPro
             let timestamps = TimeStamps::new(edge.timestamp_slice(), None);
             Some(DiskTProp::Str64(TPropColumn::new(props, timestamps)))
         }
-        _ => todo!(),
+        DataType::Date64 => new_tprop_column::<i64>(edge, id).map(DiskTProp::I64),
+        otherwise => {
+            dbg!(otherwise);
+            todo!()
+        }
     }
 }
 

--- a/raphtory/src/disk_graph/graph_impl/tprops.rs
+++ b/raphtory/src/disk_graph/graph_impl/tprops.rs
@@ -223,10 +223,7 @@ pub fn read_tprop_column(id: usize, field: Field, edge: Edge) -> Option<DiskTPro
             Some(DiskTProp::Str64(TPropColumn::new(props, timestamps)))
         }
         DataType::Date64 => new_tprop_column::<i64>(edge, id).map(DiskTProp::I64),
-        otherwise => {
-            dbg!(otherwise);
-            todo!()
-        }
+        _ => todo!(),
     }
 }
 


### PR DESCRIPTION
- **Use PathBuf for python path input (#1813)**
- **Load const props (#1811)**
- **expose encode graph (#1812)**
- **add support to exclude edge temp properties on import (#1814)**
- **Edge repr layers (#1809)**
- **type annotations in stubs created from docs (#1815)**
- **GraphQL UI (#1816)**
- **fix the `to_df` in AlgorithmResult and Edges (#1820)**
- **Release v0.13.0 (#1823)**
- **fix disk graph bug for dates**
- **avoid loading all graphs on server startup**

### What changes were proposed in this pull request?

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


