### PR TITLE
GraphQL optional indexing

### DIFF
--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -58,7 +58,7 @@ impl Data {
         Self {
             work_dir: work_dir.to_path_buf(),
             cache,
-            index: false,
+            index: true,
             embedding_conf: Default::default(),
         }
     }

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -36,6 +36,7 @@ pub struct EmbeddingConf {
 pub struct Data {
     work_dir: PathBuf,
     cache: Cache<PathBuf, GraphWithVectors>,
+    index: bool,
     pub(crate) embedding_conf: Option<EmbeddingConf>,
 }
 
@@ -57,6 +58,7 @@ impl Data {
         Self {
             work_dir: work_dir.to_path_buf(),
             cache,
+            index: false,
             embedding_conf: Default::default(),
         }
     }
@@ -78,7 +80,8 @@ impl Data {
     ) -> Result<(), GraphError> {
         let folder = ValidGraphFolder::try_from(self.work_dir.clone(), path)?;
         let vectors = self.vectorise(graph.clone(), &folder).await;
-        let graph = GraphWithVectors::new(graph.into(), vectors);
+        let index = self.index.then(|| graph.clone().into());
+        let graph = GraphWithVectors::new(graph, index, vectors);
         self.insert_graph_with_vectors(path, graph)
     }
 
@@ -172,7 +175,7 @@ impl Data {
         // it's important that we check if there is a valid template set for this graph path
         // before actually loading the graph, otherwise we are loading the graph for no reason
         let template = self.resolve_template(folder.get_original_path())?;
-        let graph = self.read_graph_from_folder(folder).ok()?.graph.graph;
+        let graph = self.read_graph_from_folder(folder).ok()?.graph;
         self.vectorise_with_template(graph, folder, template).await
     }
 
@@ -240,7 +243,7 @@ impl Data {
             .map(|conf| conf.cache.clone())
             .unwrap_or(Arc::new(None));
 
-        GraphWithVectors::read_from_folder(folder, embedding, cache)
+        GraphWithVectors::read_from_folder(folder, self.index, embedding, cache)
     }
 }
 

--- a/raphtory-graphql/src/graph.rs
+++ b/raphtory-graphql/src/graph.rs
@@ -27,18 +27,21 @@ use crate::paths::ExistingGraphFolder;
 
 #[derive(Clone)]
 pub struct GraphWithVectors {
-    pub graph: IndexedGraph<MaterializedGraph>,
+    pub graph: MaterializedGraph,
+    pub index: Option<IndexedGraph<MaterializedGraph>>,
     pub vectors: Option<VectorisedGraph<MaterializedGraph>>,
     folder: OnceCell<GraphFolder>,
 }
 
 impl GraphWithVectors {
     pub(crate) fn new(
-        graph: IndexedGraph<MaterializedGraph>,
+        graph: MaterializedGraph,
+        index: Option<IndexedGraph<MaterializedGraph>>,
         vectors: Option<VectorisedGraph<MaterializedGraph>>,
     ) -> Self {
         Self {
             graph,
+            index,
             vectors,
             folder: Default::default(),
         }
@@ -100,6 +103,7 @@ impl GraphWithVectors {
 
     pub(crate) fn read_from_folder(
         folder: &ExistingGraphFolder,
+        index: bool,
         embedding: Arc<dyn EmbeddingFunction>,
         cache: Arc<Option<EmbeddingCache>>,
     ) -> Result<Self, GraphError> {
@@ -119,7 +123,8 @@ impl GraphWithVectors {
 
         println!("Graph loaded = {}", folder.get_original_path_str());
         Ok(Self {
-            graph: IndexedGraph::from_graph(&graph)?,
+            graph: graph.clone(),
+            index: index.then(|| graph.into()),
             vectors,
             folder: OnceCell::with_value(folder.clone().into()),
         })
@@ -144,7 +149,7 @@ impl Base for GraphWithVectors {
     type Base = MaterializedGraph;
     #[inline]
     fn base(&self) -> &Self::Base {
-        &self.graph.graph
+        &self.graph
     }
 }
 

--- a/raphtory-graphql/src/model/graph/mutable_graph.rs
+++ b/raphtory-graphql/src/model/graph/mutable_graph.rs
@@ -64,7 +64,11 @@ impl GqlMutableGraph {
     /// Get the non-mutable graph
 
     async fn graph(&self) -> GqlGraph {
-        GqlGraph::new(self.path.clone(), self.graph.graph.clone())
+        GqlGraph::new(
+            self.path.clone(),
+            self.graph.graph.clone(),
+            self.graph.index.clone(),
+        )
     }
 
     /// Get mutable existing node

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -80,7 +80,7 @@ impl QueryRoot {
         let data = ctx.data_unchecked::<Data>();
         Ok(data
             .get_graph(path)
-            .map(|(g, folder)| GqlGraph::new(folder, g.graph))?)
+            .map(|(g, folder)| GqlGraph::new(folder, g.graph, g.index))?)
     }
 
     async fn update_graph<'a>(ctx: &Context<'a>, path: String) -> Result<GqlMutableGraph> {
@@ -111,7 +111,7 @@ impl QueryRoot {
     async fn receive_graph<'a>(ctx: &Context<'a>, path: String) -> Result<String, Arc<GraphError>> {
         let path = path.as_ref();
         let data = ctx.data_unchecked::<Data>();
-        let g = data.get_graph(path)?.0.graph.graph.clone();
+        let g = data.get_graph(path)?.0.graph.clone();
         let res = url_encode_graph(g)?;
         Ok(res)
     }


### PR DESCRIPTION
- **Use PathBuf for python path input (#1813)**
- **Load const props (#1811)**
- **expose encode graph (#1812)**
- **add support to exclude edge temp properties on import (#1814)**
- **Edge repr layers (#1809)**
- **type annotations in stubs created from docs (#1815)**
- **GraphQL UI (#1816)**
- **fix the `to_df` in AlgorithmResult and Edges (#1820)**
- **Release v0.13.0 (#1823)**
- **GrapQL improvements for disk graph (#1824)**
- **wip**
- **some minor details left**

### What changes were proposed in this pull request?

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


