### PR TITLE
exclude LayeredGraph from EdgeFilterOps

### DIFF
--- a/raphtory/src/db/api/storage/graph/storage_ops/mod.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/mod.rs
@@ -412,9 +412,10 @@ impl GraphStorage {
             EdgesStorage::Mem(edges) => {
                 let iter = (0..edges.len()).map(EID);
                 let filtered = match view.filter_state() {
-                    FilterState::Neither => FilterVariants::Neither(
-                        iter.map(move |eid| edges.get_mem(eid).as_edge_ref()),
-                    ),
+                    FilterState::Neither => FilterVariants::Neither(iter.filter_map(move |eid| {
+                        let e = EdgeStorageRef::Mem(edges.get_mem(eid));
+                        e.has_layer(view.layer_ids()).then(|| e.out_ref())
+                    })),
                     FilterState::Both => FilterVariants::Both(iter.filter_map(move |e| {
                         let e = EdgeStorageRef::Mem(edges.get_mem(e));
                         (view.filter_edge(e, view.layer_ids())

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -2532,6 +2532,23 @@ mod db_tests {
     }
 
     #[test]
+    fn test_layer_degree() {
+        let g = Graph::new();
+        g.add_edge(0, 1, 2, NO_PROPS, Some("layer1")).unwrap();
+        g.add_edge(1, 1, 2, NO_PROPS, Some("layer2")).unwrap();
+        g.add_edge(2, 1, 3, NO_PROPS, Some("layer1")).unwrap();
+        g.add_edge(3, 1, 2, NO_PROPS, None).unwrap();
+
+        test_storage!(&g, |g| {
+            let n = g.node(1).unwrap();
+            let n_layer = n.layers("layer1").unwrap();
+            assert_eq!(n_layer.out_degree(), 2);
+            assert_eq!(n_layer.in_degree(), 0);
+            assert_eq!(n_layer.degree(), 2);
+        });
+    }
+
+    #[test]
     fn test_layer_name() {
         let graph = Graph::new();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
make out_degree, in_degree quicker for a single layer
### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


