### PR TITLE
Snapshot at/latest

### DIFF
--- a/python/tests/graphql/misc/test_snapshot.py
+++ b/python/tests/graphql/misc/test_snapshot.py
@@ -1,0 +1,47 @@
+import tempfile
+
+from pandas.core.generic import gc
+from raphtory.graphql import GraphServer, RaphtoryClient
+
+def test_snapshot():
+    work_dir = tempfile.mkdtemp()
+    server = GraphServer(work_dir)
+    with server.start():
+        client = RaphtoryClient("http://localhost:1736")
+
+        def query(graph: str, window: str):
+            return client.query(f"""{{
+                graph(path: "{graph}") {{
+                    window: {window} {{
+                        edges {{
+                            list {{
+                                src {{
+                                    name
+                                }}
+                                dst {{
+                                    name
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}""")
+
+        client.new_graph("event", "EVENT")
+        g = client.remote_graph("event")
+        g.add_edge(1, 1, 2)
+        g.add_edge(2, 1, 3)
+
+        for time in range(0, 4):
+            assert query("event", f"before(time: {time + 1})") == query("event", f"snapshotAt(time: {time})")
+        assert query("event", f"before(time: 1000)") == query("event", f"snapshotLatest")
+
+        client.new_graph("persistent", "PERSISTENT")
+        g = client.remote_graph("persistent")
+        g.add_edge(1, 1, 2)
+        g.add_edge(2, 1, 3)
+        g.delete_edge(3, 1, 2)
+
+        for time in range(0, 5):
+            assert query("persistent", f"at(time: {time})") == query("persistent", f"snapshotAt(time: {time})")
+        assert query("persistent", f"latest") == query("persistent", f"snapshotLatest")

--- a/python/tests/test_graphdb/test_graphdb.py
+++ b/python/tests/test_graphdb/test_graphdb.py
@@ -2382,6 +2382,35 @@ def test_at_edges():
             old_at_way.append(e.at(2))
         assert old_at_way == list(g.edges.at(2))
 
+    check(g)
+
+
+def test_snapshot():
+    g = Graph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 3)
+
+    @with_disk_graph
+    def check_event(g):
+        for time in range(0, 4):
+            assert g.before(time + 1) == g.snapshot_at(time)
+        assert g == g.snapshot_latest()
+
+    check_event(g)
+
+    g = PersistentGraph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 3)
+    g.delete_edge(3, 1, 2)
+
+    @with_disk_graph
+    def check_persistent(g):
+        for time in range(0, 5):
+            assert g.at(time) == g.snapshot_at(time)
+        assert g.latest() == g.snapshot_latest()
+
+    check_persistent(g)
+
 
 def test_one_hop_filter_reset():
     g = Graph()

--- a/python/tests/test_graphdb/test_graphdb.py
+++ b/python/tests/test_graphdb/test_graphdb.py
@@ -2390,26 +2390,18 @@ def test_snapshot():
     g.add_edge(1, 1, 2)
     g.add_edge(2, 1, 3)
 
-    @with_disk_graph
-    def check_event(g):
-        for time in range(0, 4):
-            assert g.before(time + 1) == g.snapshot_at(time)
-        assert g == g.snapshot_latest()
-
-    check_event(g)
+    for time in range(0, 4):
+        assert g.before(time + 1) == g.snapshot_at(time)
+    assert g == g.snapshot_latest()
 
     g = PersistentGraph()
     g.add_edge(1, 1, 2)
     g.add_edge(2, 1, 3)
     g.delete_edge(3, 1, 2)
 
-    @with_disk_graph
-    def check_persistent(g):
-        for time in range(0, 5):
-            assert g.at(time) == g.snapshot_at(time)
-        assert g.latest() == g.snapshot_latest()
-
-    check_persistent(g)
+    for time in range(0, 5):
+        assert g.at(time) == g.snapshot_at(time)
+    assert g.latest() == g.snapshot_latest()
 
 
 def test_one_hop_filter_reset():

--- a/raphtory-graphql/src/model/graph/edge.rs
+++ b/raphtory-graphql/src/model/graph/edge.rs
@@ -74,6 +74,14 @@ impl Edge {
         self.ee.latest().into()
     }
 
+    async fn snapshot_at(&self, time: i64) -> Edge {
+        self.ee.snapshot_at(time).into()
+    }
+
+    async fn snapshot_latest(&self) -> Edge {
+        self.ee.snapshot_latest().into()
+    }
+
     async fn before(&self, time: i64) -> Edge {
         self.ee.before(time).into()
     }

--- a/raphtory-graphql/src/model/graph/edges.rs
+++ b/raphtory-graphql/src/model/graph/edges.rs
@@ -60,6 +60,13 @@ impl GqlEdges {
         self.update(self.ee.latest())
     }
 
+    async fn snapshot_at(&self, time: i64) -> Self {
+        self.update(self.ee.snapshot_at(time))
+    }
+    async fn snapshot_latest(&self) -> Self {
+        self.update(self.ee.snapshot_latest())
+    }
+
     async fn before(&self, time: i64) -> Self {
         self.update(self.ee.before(time))
     }

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -166,6 +166,14 @@ impl GqlGraph {
         self.apply(|g| g.latest(), |g| g.latest())
     }
 
+    async fn snapshot_at(&self, time: i64) -> GqlGraph {
+        self.apply(|g| g.snapshot_at(time), |g| g.snapshot_at(time))
+    }
+
+    async fn snapshot_latest(&self) -> GqlGraph {
+        self.apply(|g| g.snapshot_latest(), |g| g.snapshot_latest())
+    }
+
     async fn before(&self, time: i64) -> GqlGraph {
         self.apply(|g| g.before(time), |g| g.before(time))
     }

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -70,6 +70,14 @@ impl Node {
         self.vv.latest().into()
     }
 
+    async fn snapshot_at(&self, time: i64) -> Node {
+        self.vv.snapshot_at(time).into()
+    }
+
+    async fn snapshot_latest(&self) -> Node {
+        self.vv.snapshot_latest().into()
+    }
+
     async fn before(&self, time: i64) -> Node {
         self.vv.before(time).into()
     }

--- a/raphtory-graphql/src/model/graph/nodes.rs
+++ b/raphtory-graphql/src/model/graph/nodes.rs
@@ -61,6 +61,14 @@ impl GqlNodes {
         self.update(self.nn.latest())
     }
 
+    async fn snapshot_at(&self, time: i64) -> Self {
+        self.update(self.nn.snapshot_at(time))
+    }
+
+    async fn snapshot_latest(&self) -> Self {
+        self.update(self.nn.snapshot_latest())
+    }
+
     async fn before(&self, time: i64) -> Self {
         self.update(self.nn.before(time))
     }

--- a/raphtory-graphql/src/model/graph/path_from_node.rs
+++ b/raphtory-graphql/src/model/graph/path_from_node.rs
@@ -58,6 +58,14 @@ impl GqlPathFromNode {
     async fn at(&self, time: i64) -> Self {
         self.update(self.nn.at(time))
     }
+
+    async fn snapshot_latest(&self) -> Self {
+        self.update(self.nn.snapshot_latest())
+    }
+
+    async fn snapshot_at(&self, time: i64) -> Self {
+        self.update(self.nn.snapshot_at(time))
+    }
     async fn latest(&self) -> Self {
         self.update(self.nn.latest())
     }

--- a/raphtory/src/db/api/view/time.rs
+++ b/raphtory/src/db/api/view/time.rs
@@ -120,10 +120,14 @@ pub trait TimeOps<'graph>:
     /// Create a view that only includes events at the latest time
     fn latest(&self) -> Self::WindowedViewType;
 
-    // TODO: add docs
+    /// Create a view including all events that have not been explicitly deleted at `time`
+    ///
+    /// This is equivalent to `before(time + 1)` for `EventGraph`s and `at(time)` for `PersitentGraph`s
     fn snapshot_at<T: IntoTime>(&self, time: T) -> Self::WindowedViewType;
 
-    // TODO: add docs
+    /// Create a view including all events that have not been explicitly deleted at the latest time
+    ///
+    /// This is equivalent to a no-op for `EventGraph`s and `latest()` for `PersitentGraph`s
     fn snapshot_latest(&self) -> Self::WindowedViewType;
 
     /// Create a view that only includes events after `start` (exclusive)
@@ -221,7 +225,7 @@ impl<'graph, V: OneHopFilter<'graph> + 'graph + InternalTimeOps<'graph>> TimeOps
     fn snapshot_latest(&self) -> Self::WindowedViewType {
         match self.latest_t() {
             Some(latest) => self.snapshot_at(latest),
-            None => self.internal_window(None, None),
+            None => self.snapshot_at(i64::MIN),
         }
     }
 

--- a/raphtory/src/db/api/view/time.rs
+++ b/raphtory/src/db/api/view/time.rs
@@ -399,32 +399,21 @@ mod time_tests {
     #[test]
     fn snapshot() {
         let graph = PersistentGraph::new();
-        graph.add_edge(3, 0, 1, NO_PROPS, None).unwrap();
-        graph.add_edge(5, 0, 2, NO_PROPS, None).unwrap();
-        graph.delete_edge(7, 0, 1, None).unwrap();
+        graph.add_edge(3, 0, 1, [("a", "a")], None).unwrap();
+        graph.add_edge(4, 0, 2, [("b", "b")], None).unwrap();
+        graph.delete_edge(5, 0, 1, None).unwrap();
 
-        let snapshot = graph.snapshot_at(2);
-        assert_eq!(snapshot.count_edges(), 0);
-
-        let snapshot = graph.snapshot_at(3);
-        assert_eq!(snapshot.count_edges(), 1);
-        assert!(snapshot.has_edge(0, 1));
-
-        let snapshot = graph.snapshot_latest();
-        assert_eq!(snapshot.count_edges(), 1);
-        assert!(snapshot.has_edge(0, 2));
+        for time in 2..6 {
+            assert_eq!(graph.at(time), graph.snapshot_at(time));
+        }
+        assert_eq!(graph.latest(), graph.snapshot_latest());
 
         let graph = graph.event_graph();
 
-        let snapshot = graph.snapshot_at(2);
-        assert_eq!(snapshot.count_edges(), 0);
-
-        let snapshot = graph.snapshot_at(3);
-        assert_eq!(snapshot.count_edges(), 1);
-        assert!(snapshot.has_edge(0, 1));
-
-        let snapshot = graph.snapshot_latest();
-        assert_eq!(snapshot.count_edges(), 2);
+        for time in 2..6 {
+            assert_eq!(graph.before(time + 1), graph.snapshot_at(time));
+        }
+        assert_eq!(graph, graph.snapshot_latest());
     }
 
     #[test]

--- a/raphtory/src/db/api/view/time.rs
+++ b/raphtory/src/db/api/view/time.rs
@@ -403,14 +403,14 @@ mod time_tests {
         graph.add_edge(4, 0, 2, [("b", "b")], None).unwrap();
         graph.delete_edge(5, 0, 1, None).unwrap();
 
-        for time in 2..6 {
+        for time in 2..7 {
             assert_eq!(graph.at(time), graph.snapshot_at(time));
         }
         assert_eq!(graph.latest(), graph.snapshot_latest());
 
         let graph = graph.event_graph();
 
-        for time in 2..6 {
+        for time in 2..7 {
             assert_eq!(graph.before(time + 1), graph.snapshot_at(time));
         }
         assert_eq!(graph, graph.snapshot_latest());

--- a/raphtory/src/db/api/view/time.rs
+++ b/raphtory/src/db/api/view/time.rs
@@ -1,11 +1,10 @@
-use crate::db::api::view::internal::InternalMaterialize;
 use crate::{
     core::{
         storage::timeindex::AsTime,
         utils::time::{error::ParseTimeError, Interval, IntoTime},
     },
     db::api::view::{
-        internal::{OneHopFilter, TimeSemantics},
+        internal::{InternalMaterialize, OneHopFilter, TimeSemantics},
         time::internal::InternalTimeOps,
     },
 };

--- a/raphtory/src/db/graph/graph.rs
+++ b/raphtory/src/db/graph/graph.rs
@@ -398,7 +398,10 @@ mod db_tests {
             api::{
                 properties::internal::ConstPropertiesOps,
                 view::{
-                    internal::{CoreGraphOps, EdgeFilterOps, TimeSemantics},
+                    internal::{
+                        CoreGraphOps, EdgeFilterOps, InternalMaterialize, OneHopFilter,
+                        TimeSemantics,
+                    },
                     time::internal::InternalTimeOps,
                     EdgeViewOps, Layer, LayerOps, NodeViewOps, TimeOps,
                 },
@@ -3174,5 +3177,15 @@ mod db_tests {
             .unwrap();
         let graph = pool.install(|| Graph::new());
         assert_eq!(graph.core_graph().internal_num_nodes(), 0);
+    }
+
+    // TODO: remove this
+    fn test_event() {
+        let g = Graph::new();
+        let m = g.materialize().unwrap();
+        let w = g.window(1, 3).layers("asa").unwrap().window(2, 3);
+        let b = w.base();
+        let b = w.base_graph();
+        let t = w.graph_type();
     }
 }

--- a/raphtory/src/python/types/macros/trait_impl/timeops.rs
+++ b/raphtory/src/python/types/macros/trait_impl/timeops.rs
@@ -120,20 +120,22 @@ macro_rules! impl_timeops {
                 self.$field.latest()
             }
 
-            // TODO: docs
-            #[doc = concat!(r" Create a view of the ", $name, r" including all events after `start` (exclusive).")]
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events that have not been explicitly deleted at `time`.")]
+            ///
+            /// This is equivalent to `before(time + 1)` for `EventGraph`s and `at(time)` for `PersitentGraph`s
             ///
             /// Arguments:
-            ///     start (TimeInput): The start time of the window.
+            ///     time (TimeInput): The time of the window.
             ///
             /// Returns:
             #[doc = concat!(r"     A ", $name, r" object.")]
             pub fn snapshot_at(&self, time: PyTime) -> <$base_type as TimeOps<'static>>::WindowedViewType {
-                self.$field.after(time)
+                self.$field.snapshot_at(time)
             }
 
-            // TODO: docs
-            #[doc = concat!(r" Create a view of the ", $name, r" including all events at the latest time.")]
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events that have not been explicitly deleted at the latest time.")]
+            ///
+            /// This is equivalent to a no-op for `EventGraph`s and `latest()` for `PersitentGraph`s
             ///
             /// Returns:
             #[doc = concat!(r"     A ", $name, r" object.")]

--- a/raphtory/src/python/types/macros/trait_impl/timeops.rs
+++ b/raphtory/src/python/types/macros/trait_impl/timeops.rs
@@ -120,6 +120,27 @@ macro_rules! impl_timeops {
                 self.$field.latest()
             }
 
+            // TODO: docs
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events after `start` (exclusive).")]
+            ///
+            /// Arguments:
+            ///     start (TimeInput): The start time of the window.
+            ///
+            /// Returns:
+            #[doc = concat!(r"     A ", $name, r" object.")]
+            pub fn snapshot_at(&self, time: PyTime) -> <$base_type as TimeOps<'static>>::WindowedViewType {
+                self.$field.after(time)
+            }
+
+            // TODO: docs
+            #[doc = concat!(r" Create a view of the ", $name, r" including all events at the latest time.")]
+            ///
+            /// Returns:
+            #[doc = concat!(r"     A ", $name, r" object.")]
+            pub fn snapshot_latest(&self) -> <$base_type as TimeOps<'static>>::WindowedViewType {
+                self.$field.snapshot_latest()
+            }
+
             #[doc = concat!(r" Create a view of the ", $name, r" including all events before `end` (exclusive).")]
             ///
             /// Arguments:


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds two new window functions `snapshot_at` and `snapshot_latest`

### Why are the changes needed?
These two new functions are needed for those cases where users work with graphs that might be event or persistent and they just want to get all of those entities that have not been deleted at some point in time, which corresponds to `before(t+1)` for event graphs and `at` for persistent graphs.

### Does this PR introduce any user-facing change? If yes is this documented?
Yes, docs were added to rust and python

### How was this patch tested?
A snapshot test was added to `raphtory/src/db/api/view/time.rs`

### Are there any further changes required?
No
