### PR TITLE
Make load edges pub in parquet_loaders.rs

### DIFF
--- a/raphtory/src/io/parquet_loaders.rs
+++ b/raphtory/src/io/parquet_loaders.rs
@@ -69,7 +69,7 @@ pub fn load_nodes_from_parquet<
     Ok(())
 }
 
-pub(crate) fn load_edges_from_parquet<
+pub fn load_edges_from_parquet<
     G: StaticGraphViewOps + InternalPropertyAdditionOps + InternalAdditionOps + InternalCache,
 >(
     graph: &G,


### PR DESCRIPTION
Make `load_edges_from_parquet` public instead of `pub(crate)`

### What changes were proposed in this pull request?

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Issues

_If this resolves any issues, please link to them here, the format is a KEYWORD followed by @<ISSUE NUMBER>__
KEYWORDS available are `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
Please delete this text before creating your PR 

### Are there any further changes required?


