### PR TITLE
no reason to make a Hashset when building a subgraph anymore

### DIFF
--- a/raphtory/src/db/api/view/graph.rs
+++ b/raphtory/src/db/api/view/graph.rs
@@ -337,11 +337,6 @@ impl<'graph, G: BoxableGraphView + Sized + Clone + 'graph> GraphViewOps<'graph> 
     }
 
     fn subgraph<I: IntoIterator<Item = V>, V: AsNodeRef>(&self, nodes: I) -> NodeSubgraph<G> {
-        let _layer_ids = self.layer_ids();
-        let nodes: FxHashSet<VID> = nodes
-            .into_iter()
-            .flat_map(|v| (&self).node(v).map(|v| v.node))
-            .collect();
         NodeSubgraph::new(self.clone(), nodes)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove the Hashset building step from `subgraph` as it is no longer needed.

### Why are the changes needed?

Missed removing this in #1869

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

The tests

### Are there any further changes required?


