### PR TITLE
Add distance from starting node for in- and out-components

### DIFF
--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -432,9 +432,11 @@ class Edge(object):
         """
 
     def explode(self):
-        """Explodes an edge and returns all instances it had been updated as seperate edges"""
+        """Explodes returns an edge object for each update within the original edge."""
 
-    def explode_layers(self): ...
+    def explode_layers(self):
+        """Explode layers returns an edge object for each layer within the original edge. These new edge object contains only updates from respective layers."""
+
     def has_layer(self, name: str):
         """
          Check if Edge has the layer `"name"`
@@ -908,9 +910,11 @@ class Edges(object):
         """
 
     def explode(self):
-        """Explodes an edge and returns all instances it had been updated as seperate edges"""
+        """Explodes returns an edge object for each update within the original edge."""
 
-    def explode_layers(self): ...
+    def explode_layers(self):
+        """Explode layers returns an edge object for each layer within the original edge. These new edge object contains only updates from respective layers."""
+
     def has_layer(self, name: str):
         """
          Check if Edges has the layer `"name"`
@@ -1963,6 +1967,16 @@ class GraphView(object):
 
         Returns:
              GraphView
+        """
+
+    def cache_view(self):
+        """
+        Applies the filters to the graph and retains the node ids and the edge ids
+        in the graph that satisfy the filters
+        creates bitsets per layer for nodes and edges
+
+        Returns:
+          MaskedGraph: Returns the masked graph
         """
 
     def count_edges(self) -> int:

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -575,7 +575,7 @@ def min_out_degree(g: GraphView):
         int : value of the smallest outdegree
     """
 
-def out_component(node: Node):
+def out_component(node: Node) -> NodeStateUsize:
     """
     Out component -- Finding the "out-component" of a node in a directed graph involves identifying all nodes that can be reached following only outgoing edges.
 
@@ -583,7 +583,7 @@ def out_component(node: Node):
         node (Node) : The node whose out-component we wish to calculate
 
     Returns:
-       An array containing the Nodes within the given nodes out-component
+       NodeStateUsize: A NodeState mapping the nodes in the out-component to their distance from the starting node.
     """
 
 def out_components(g: GraphView):

--- a/python/tests/graphql/edit_graph/test_graphql.py
+++ b/python/tests/graphql/edit_graph/test_graphql.py
@@ -633,24 +633,9 @@ def test_edge_id():
             "graph": {
                 "edges": {
                     "list": [
-                        {
-                            "id": [
-                                "ben",
-                                "shivam"
-                            ]
-                        },
-                        {
-                            "id": [
-                                "oogway",
-                                "po"
-                            ]
-                        },
-                        {
-                            "id": [
-                                "po",
-                                "ben"
-                            ]
-                        }
+                        {"id": ["ben", "shivam"]},
+                        {"id": ["oogway", "po"]},
+                        {"id": ["po", "ben"]},
                     ]
                 }
             }

--- a/python/tests/test_algorithms.py
+++ b/python/tests/test_algorithms.py
@@ -69,10 +69,10 @@ def test_in_component():
 
     actual = algorithms.in_component(g.node(3))
     correct = [g.node(7), g.node(1)]
-    assert set(actual) == set(correct)
+    assert set(actual.nodes()) == set(correct)
     actual = algorithms.in_component(g.node(3).window(1, 6))
     correct = [g.node(1)]
-    assert set(actual) == set(correct)
+    assert set(actual.nodes()) == set(correct)
 
 
 def test_out_components():

--- a/python/tests/test_algorithms.py
+++ b/python/tests/test_algorithms.py
@@ -104,10 +104,10 @@ def test_out_component():
 
     actual = algorithms.out_component(g.node(3))
     correct = [g.node(4), g.node(5), g.node(6)]
-    assert set(actual) == set(correct)
+    assert set(actual.nodes()) == set(correct)
     actual = algorithms.out_component(g.node(4).at(4))
     correct = [g.node(5)]
-    assert set(actual) == set(correct)
+    assert set(actual.nodes()) == set(correct)
 
 
 def test_empty_algo():

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -174,8 +174,8 @@ impl Node {
 
     async fn in_component(&self) -> Vec<Node> {
         in_component(self.vv.clone())
-            .iter()
-            .map(|n| n.clone().into())
+            .nodes()
+            .map(|n| n.cloned().into())
             .collect()
     }
 

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -8,7 +8,9 @@ use raphtory::{
         api::{properties::dyn_props::DynProperties, view::*},
         graph::node::NodeView,
     },
+    prelude::NodeStateOps,
 };
+
 #[derive(ResolvedObject)]
 pub(crate) struct Node {
     pub(crate) vv: NodeView<DynamicGraph>,
@@ -179,8 +181,8 @@ impl Node {
 
     async fn out_component(&self) -> Vec<Node> {
         out_component(self.vv.clone())
-            .iter()
-            .map(|n| n.clone().into())
+            .nodes()
+            .map(|n| n.cloned().into())
             .collect()
     }
 

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -64,9 +64,9 @@ use rand::{prelude::StdRng, SeedableRng};
 use raphtory_api::core::{entities::GID, Direction};
 use std::collections::{HashMap, HashSet};
 
-use crate::algorithms::bipartite::max_weight_matching::Matching;
 #[cfg(feature = "storage")]
 use crate::python::graph::disk_graph::PyDiskGraph;
+use crate::{algorithms::bipartite::max_weight_matching::Matching, db::api::state::NodeState};
 #[cfg(feature = "storage")]
 use pometry_storage::algorithms::connected_components::connected_components as connected_components_rs;
 
@@ -180,10 +180,10 @@ pub fn out_components(g: &PyGraphView) -> AlgorithmResult<DynamicGraph, Vec<GID>
 ///     node (Node) : The node whose out-component we wish to calculate
 ///
 /// Returns:
-///    An array containing the Nodes within the given nodes out-component
+///    NodeStateUsize: A NodeState mapping the nodes in the out-component to their distance from the starting node.
 #[pyfunction]
 #[pyo3(signature = (node))]
-pub fn out_component(node: &PyNode) -> Vec<NodeView<DynamicGraph>> {
+pub fn out_component(node: &PyNode) -> NodeState<'static, usize, DynamicGraph> {
     components::out_component(node.node.clone())
 }
 

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -157,7 +157,7 @@ pub fn in_components(g: &PyGraphView) -> AlgorithmResult<DynamicGraph, Vec<GID>,
 ///    An array containing the Nodes within the given nodes in-component
 #[pyfunction]
 #[pyo3(signature = (node))]
-pub fn in_component(node: &PyNode) -> Vec<NodeView<DynamicGraph>> {
+pub fn in_component(node: &PyNode) -> NodeState<'static, usize, DynamicGraph> {
     components::in_component(node.node.clone())
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the return of in-component and out-component to include the distance from the starting node.

### Why are the changes needed?

The distances are often useful context and can be obtained almost for free during the algorithm but are hard to compute later.

### Does this PR introduce any user-facing change? If yes is this documented?

Documentation is adjusted to reflect the new return type

### How was this patch tested?

adjusted the tests to test the distances as well

### Are there any further changes required?


