### PR TITLE
make the inner rust value accessible on python NodeState and LazyNodeState wrappers

### DIFF
--- a/raphtory/src/python/graph/node_state.rs
+++ b/raphtory/src/python/graph/node_state.rs
@@ -255,6 +255,12 @@ macro_rules! impl_lazy_node_state {
             inner: LazyNodeState<'static, $op, DynamicGraph, DynamicGraph>,
         }
 
+        impl $name {
+            pub fn inner(&self) -> &LazyNodeState<'static, $op, DynamicGraph, DynamicGraph> {
+                &self.inner
+            }
+        }
+
         #[pymethods]
         impl $name {
             /// Compute all values and return the result as a node view
@@ -304,6 +310,12 @@ macro_rules! impl_node_state {
         #[pyclass(module = "raphtory.node_state", frozen)]
         pub struct $name {
             inner: Arc<NodeState<'static, $value, DynamicGraph, DynamicGraph>>,
+        }
+
+        impl $name {
+            pub fn inner(&self) -> &NodeState<'static, $value, DynamicGraph, DynamicGraph> {
+                self.inner.as_ref()
+            }
         }
 
         impl_node_state_ops!(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Makes the inner wrapped value accessible on python `NodeState` and `LazyNodeState` wrappers.

### Why are the changes needed?

So they can be used as input arguments for other functions.

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

No real changes, nothing to test

### Are there any further changes required?


