### PR TITLE
add support for loading node ids from node property parquet

### DIFF
--- a/raphtory-cypher/examples/raphtory_cypher.rs
+++ b/raphtory-cypher/examples/raphtory_cypher.rs
@@ -65,10 +65,13 @@ mod cypher {
         #[arg(short, long)]
         node_props: Option<String>,
 
-        /// Node properties to load
+        /// Node properties column to load as node type
         #[arg(short, long)]
         node_type_col: Option<String>,
 
+        /// Node properties column to load as node
+        #[arg(short, long)]
+        node_id_col: Option<String>,
         /// Edge list parquet files to load as layers
         #[arg(short='l', last = true, value_parser = parse_key_val::<String, ArgLayer>)]
         layers: Vec<(String, ArgLayer)>,
@@ -196,6 +199,7 @@ mod cypher {
                     args.t_prop_chunk_size,
                     args.num_threads,
                     args.node_type_col.as_deref(),
+                    args.node_id_col.as_deref(),
                 )
                 .expect("Failed to load graph");
             }

--- a/raphtory-cypher/src/lib.rs
+++ b/raphtory-cypher/src/lib.rs
@@ -356,6 +356,7 @@ mod cypher {
                     100,
                     1,
                     None,
+                    None,
                 )
                 .unwrap();
 

--- a/raphtory/src/disk_graph/graph_impl/mod.rs
+++ b/raphtory/src/disk_graph/graph_impl/mod.rs
@@ -489,6 +489,7 @@ mod test {
             t_props_chunk_size,
             num_threads,
             node_type_col,
+            None,
         )
         .unwrap()
         .into_graph();

--- a/raphtory/src/disk_graph/mod.rs
+++ b/raphtory/src/disk_graph/mod.rs
@@ -303,6 +303,7 @@ impl DiskGraphStorage {
         t_props_chunk_size: usize,
         num_threads: usize,
         node_type_col: Option<&str>,
+        node_id_col: Option<&str>,
     ) -> Result<DiskGraphStorage, RAError> {
         let edge_lists: Vec<ExternalEdgeList<&Path>> = layer_parquet_cols
             .into_iter()
@@ -337,6 +338,7 @@ impl DiskGraphStorage {
             &[],
             node_properties.as_ref().map(|p| p.as_ref()),
             node_type_col,
+            node_id_col,
         )?;
         Ok(Self::new(t_graph))
     }

--- a/raphtory/src/io/arrow/df_loaders.rs
+++ b/raphtory/src/io/arrow/df_loaders.rs
@@ -733,6 +733,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                None,
             )
             .unwrap();
             let actual =

--- a/raphtory/src/python/graph/disk_graph.rs
+++ b/raphtory/src/python/graph/disk_graph.rs
@@ -218,7 +218,7 @@ impl PyDiskGraph {
 
     #[staticmethod]
     #[pyo3(
-        signature = (graph_dir, layer_parquet_cols, node_properties, chunk_size, t_props_chunk_size, num_threads, node_type_col)
+        signature = (graph_dir, layer_parquet_cols, node_properties=None, chunk_size=10_000_000, t_props_chunk_size=10_000_000, num_threads=4, node_type_col=None, node_id_col=None)
     )]
     fn load_from_parquets(
         graph_dir: PathBuf,
@@ -228,6 +228,7 @@ impl PyDiskGraph {
         t_props_chunk_size: usize,
         num_threads: usize,
         node_type_col: Option<&str>,
+        node_id_col: Option<&str>,
     ) -> Result<DiskGraphStorage, GraphError> {
         let layer_cols = layer_parquet_cols
             .iter()
@@ -241,6 +242,7 @@ impl PyDiskGraph {
             t_props_chunk_size,
             num_threads,
             node_type_col,
+            node_id_col,
         )
         .map_err(|err| {
             GraphError::LoadFailure(format!("Failed to load graph from parquet files: {err:?}"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disk graph can now load node ids from the node properties instead of sorting the edge list (this is faster and allows for nodes that do not have edges)

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


