### PR TITLE
rename examples to rust-examples to fix dependabot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,18 +2096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "examples"
-version = "0.14.0"
-dependencies = [
- "chrono",
- "itertools 0.13.0",
- "raphtory",
- "regex",
- "serde",
- "tracing",
-]
-
-[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5280,6 +5268,18 @@ dependencies = [
  "bitflags 2.6.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust-examples"
+version = "0.14.0"
+dependencies = [
+ "chrono",
+ "itertools 0.13.0",
+ "raphtory",
+ "regex",
+ "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples"
+name = "rust-examples"
 version.workspace = true
 edition = "2021"
 keywords = ["graph", "temporal-graph", "temporal", "examples"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

try renaming the examples crate to fix the dependabot errors

### Why are the changes needed?

dependabot cannot handle a crate named examples (see https://github.com/dependabot/dependabot-core/issues/1156)

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


