### PR TITLE
remove early-culling code from SCC

### DIFF
--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -136,7 +136,7 @@ class ConstProperties(object):
     """A view of constant properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -220,11 +220,12 @@ class DiskGraphStorage(object):
     def load_from_parquets(
         graph_dir,
         layer_parquet_cols,
-        node_properties,
-        chunk_size,
-        t_props_chunk_size,
-        num_threads,
-        node_type_col,
+        node_properties=None,
+        chunk_size=10000000,
+        t_props_chunk_size=10000000,
+        num_threads=4,
+        node_type_col=None,
+        node_id_col=None,
     ): ...
     def load_node_const_properties(self, location, col_names=None, chunk_size=None): ...
     def merge_by_sorted_gids(self, other, graph_dir):
@@ -4498,7 +4499,7 @@ class Properties(object):
     """A view of the properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -4685,7 +4686,7 @@ class TemporalProperties(object):
     """A view of the temporal properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -24,7 +24,7 @@ class Matching(object):
         """True if self else False"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __iter__(self):
         """Implement iter(self)."""

--- a/raphtory/src/algorithms/components/scc.rs
+++ b/raphtory/src/algorithms/components/scc.rs
@@ -1,14 +1,9 @@
-use std::{
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     algorithms::algorithm_result::AlgorithmResult,
     core::entities::VID,
-    db::{
-        api::view::StaticGraphViewOps,
-        graph::node::NodeView,
-    },
+    db::{api::view::StaticGraphViewOps, graph::node::NodeView},
     prelude::*,
 };
 
@@ -79,9 +74,7 @@ where
     result
 }
 
-pub fn strongly_connected_components<G>(
-    graph: &G,
-) -> AlgorithmResult<G, usize>
+pub fn strongly_connected_components<G>(graph: &G) -> AlgorithmResult<G, usize>
 where
     G: StaticGraphViewOps,
 {

--- a/raphtory/src/algorithms/components/scc.rs
+++ b/raphtory/src/algorithms/components/scc.rs
@@ -1,22 +1,13 @@
 use std::{
     collections::{HashMap, HashSet},
-    fmt::Debug,
 };
-
-use itertools::Itertools;
 
 use crate::{
     algorithms::algorithm_result::AlgorithmResult,
-    core::{entities::VID, state::compute_state::ComputeStateVec},
+    core::entities::VID,
     db::{
         api::view::StaticGraphViewOps,
         graph::node::NodeView,
-        task::{
-            context::Context,
-            node::eval_node::EvalNodeView,
-            task::{ATask, Job, Step},
-            task_runner::TaskRunner,
-        },
     },
     prelude::*,
 };
@@ -90,11 +81,12 @@ where
 
 pub fn strongly_connected_components<G>(
     graph: &G,
-    threads: Option<usize>,
 ) -> AlgorithmResult<G, usize>
 where
     G: StaticGraphViewOps,
 {
+    // TODO: evaluate/improve this early-culling code
+    /*
     #[derive(Clone, Debug, Default)]
     struct SCCNode {
         is_scc_node: bool,
@@ -147,20 +139,15 @@ where
             .filter(|(_, state)| state.is_scc_node)
             .map(|(vid, _)| VID(vid)),
     );
-    let results_type = std::any::type_name::<usize>();
-    let groups = tarjan_scc(&sub_graph);
+     */
 
-    let mut id = groups.len();
+    let results_type = std::any::type_name::<usize>();
+    let groups = tarjan_scc(graph);
+
     let mut res = HashMap::new();
     for (id, group) in groups.into_iter().enumerate() {
         for VID(node) in group {
             res.insert(node, id);
-        }
-    }
-    for (node, state) in local.into_iter().enumerate() {
-        if !state.is_scc_node {
-            res.insert(node, id);
-            id += 1;
         }
     }
 
@@ -202,7 +189,7 @@ mod strongly_connected_components_tests {
         }
 
         test_storage!(&graph, |graph| {
-            let scc_nodes: HashSet<_> = strongly_connected_components(graph, None)
+            let scc_nodes: HashSet<_> = strongly_connected_components(graph)
                 .group_by()
                 .into_values()
                 .map(|mut v| {
@@ -246,7 +233,7 @@ mod strongly_connected_components_tests {
         }
 
         test_storage!(&graph, |graph| {
-            let scc_nodes: HashSet<_> = strongly_connected_components(graph, None)
+            let scc_nodes: HashSet<_> = strongly_connected_components(graph)
                 .group_by()
                 .into_values()
                 .map(|mut v| {
@@ -273,7 +260,7 @@ mod strongly_connected_components_tests {
         }
 
         test_storage!(&graph, |graph| {
-            let scc_nodes: HashSet<_> = strongly_connected_components(graph, None)
+            let scc_nodes: HashSet<_> = strongly_connected_components(graph)
                 .group_by()
                 .into_values()
                 .map(|mut v| {
@@ -308,7 +295,7 @@ mod strongly_connected_components_tests {
         }
 
         test_storage!(&graph, |graph| {
-            let scc_nodes: HashSet<_> = strongly_connected_components(graph, None)
+            let scc_nodes: HashSet<_> = strongly_connected_components(graph)
                 .group_by()
                 .into_values()
                 .map(|mut v| {

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -125,7 +125,7 @@ pub fn weakly_connected_components(
 pub fn strongly_connected_components(
     g: &PyGraphView,
 ) -> AlgorithmResult<DynamicGraph, usize, usize> {
-    components::strongly_connected_components(&g.graph, None)
+    components::strongly_connected_components(&g.graph)
 }
 
 #[cfg(feature = "storage")]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove inefficient early-culling code from SCC implementation.

### Why are the changes needed?
The SCC implementation features a block of code in the beginning which exhaustively checks which nodes belong to a strongly connected component by performing a BFS search and checking if the source node is reachable from itself. In the way this is implemented, this is entirely redundant to the process of just executing Tarjan's SCC algorithm, which it already subsequently executes.

### Does this PR introduce any user-facing change? If yes is this documented?
The Python function signature remains unaffected. The Rust method no longer contains a `threads` parameter.

### How was this patch tested?
All Rust unit-tests and Python tests still pass.

### Are there any further changes required?
The Tarjan implementation can be parallelized. Additionally, I am working on a generalized validation and benchmarking framework for the algorithms library.

