### PR TITLE
add integer support to balance algorithm; apply formatting

### DIFF
--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -136,7 +136,7 @@ class ConstProperties(object):
     """A view of constant properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -220,11 +220,12 @@ class DiskGraphStorage(object):
     def load_from_parquets(
         graph_dir,
         layer_parquet_cols,
-        node_properties,
-        chunk_size,
-        t_props_chunk_size,
-        num_threads,
-        node_type_col,
+        node_properties=None,
+        chunk_size=10000000,
+        t_props_chunk_size=10000000,
+        num_threads=4,
+        node_type_col=None,
+        node_id_col=None,
     ): ...
     def load_node_const_properties(self, location, col_names=None, chunk_size=None): ...
     def merge_by_sorted_gids(self, other, graph_dir):
@@ -4498,7 +4499,7 @@ class Properties(object):
     """A view of the properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -4685,7 +4686,7 @@ class TemporalProperties(object):
     """A view of the temporal properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -24,7 +24,7 @@ class Matching(object):
         """True if self else False"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __iter__(self):
         """Implement iter(self)."""

--- a/raphtory/src/algorithms/metrics/balance.rs
+++ b/raphtory/src/algorithms/metrics/balance.rs
@@ -20,7 +20,7 @@ use crate::{
             task_runner::TaskRunner,
         },
     },
-    prelude::{EdgeViewOps, GraphViewOps, NodeViewOps, PropUnwrap},
+    prelude::{EdgeViewOps, GraphViewOps, NodeViewOps},
 };
 use ordered_float::OrderedFloat;
 
@@ -58,7 +58,7 @@ fn balance_per_node<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>, C
                 prop.temporal().get(name).map(|val| {
                     val.values()
                         .into_iter()
-                        .map(|valval| valval.into_f64().unwrap_or(0.0f64))
+                        .map(|valval| valval.as_f64().unwrap_or(0.0f64))
                         .sum::<f64>()
                 })
             })
@@ -70,7 +70,7 @@ fn balance_per_node<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>, C
                 prop.temporal().get(name).map(|val| {
                     val.values()
                         .into_iter()
-                        .map(|valval| valval.into_f64().unwrap_or(0.0f64))
+                        .map(|valval| valval.as_f64().unwrap_or(0.0f64))
                         .sum::<f64>()
                 })
             })
@@ -144,14 +144,14 @@ mod sum_weight_test {
         let graph = Graph::new();
 
         let vs = vec![
-            ("1", "2", 10.0, 1),
-            ("1", "4", 20.0, 2),
-            ("2", "3", 5.0, 3),
-            ("3", "2", 2.0, 4),
-            ("3", "1", 1.0, 5),
-            ("4", "3", 10.0, 6),
-            ("4", "1", 5.0, 7),
-            ("1", "5", 2.0, 8),
+            ("1", "2", 10, 1),
+            ("1", "4", 20, 2),
+            ("2", "3", 5, 3),
+            ("3", "2", 2, 4),
+            ("3", "1", 1, 5),
+            ("4", "3", 10, 6),
+            ("4", "1", 5, 7),
+            ("1", "5", 2, 8),
         ];
 
         for (src, dst, val, time) in &vs {
@@ -160,7 +160,7 @@ mod sum_weight_test {
                     *time,
                     *src,
                     *dst,
-                    [("value_dec".to_string(), Prop::F64(*val))],
+                    [("value_dec".to_string(), Prop::I32(*val))],
                     None,
                 )
                 .expect("Couldnt add edge");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add integer support to balance algorithm.

### Why are the changes needed?
Previously, edge properties had to be converted to floats. Now ints and floats both work as expected.

### Does this PR introduce any user-facing change? If yes is this documented?
No method signatures have been affected. 

### How was this patch tested?
I updated the Rust unit-test to test ints and it passes.

### Are there any further changes required?
N/A

