### PR TITLE
GqlEdges sorting

### DIFF
--- a/python/tests/graphql/test_edge_sorting.py
+++ b/python/tests/graphql/test_edge_sorting.py
@@ -142,6 +142,80 @@ def test_graph_edge_sort_by_nothing(graph):
     run_graphql_test(query, expected_output, graph())
 
 @pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_src(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ src: true }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_dst(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ dst: true }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
 def test_graph_edge_sort_by_earliest_time(graph):
     query = """
     query {
@@ -477,6 +551,43 @@ def test_graph_edge_sort_by_eprop5(graph):
     run_graphql_test(query, expected_output, graph())
 
 @pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_nonexistent_prop(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "i_dont_exist" }, { property: "eprop2", reverse: true }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
 def test_graph_edge_sort_by_combined(graph):
     query = """
     query {
@@ -514,12 +625,12 @@ def test_graph_edge_sort_by_combined(graph):
     run_graphql_test(query, expected_output, graph())
 
 @pytest.mark.parametrize("graph", [Graph, PersistentGraph])
-def test_graph_edge_sort_by_nonexistent_prop(graph):
+def test_graph_edge_sort_by_combined_2(graph):
     query = """
     query {
       graph(path: "g") {
         edges {
-          sorted(sortBys: [{ property: "i_dont_exist" }, { property: "eprop2", reverse: true }]) {
+          sorted(sortBys: [{ dst: true }, { time: EARLIEST }, { property: "eprop3" }, { time: LATEST, reverse: true }]) {
             list {
               src {
                 id
@@ -538,11 +649,11 @@ def test_graph_edge_sort_by_nonexistent_prop(graph):
             "edges": {
                 "sorted": {
                     "list": [
-                        {"src": { "id": "c" }, "dst": { "id": "d" } },
                         {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
                         {"src": { "id": "b" }, "dst": { "id": "d" } },
                         {"src": { "id": "a" }, "dst": { "id": "d" } },
-                        {"src": { "id": "b" }, "dst": { "id": "c" } },
                     ]
                 }
             }

--- a/python/tests/graphql/test_edge_sorting.py
+++ b/python/tests/graphql/test_edge_sorting.py
@@ -1,0 +1,551 @@
+import tempfile
+
+import pytest
+
+from raphtory.graphql import GraphServer
+from raphtory import Graph, PersistentGraph
+import json
+import re
+
+PORT = 1737
+
+
+def create_test_graph(g):
+    g.add_edge(
+        3,
+        "a",
+        "d",
+        properties={
+            "eprop1": 60,
+            "eprop2": 0.4,
+            "eprop3": "xyz123",
+            "eprop4": True,
+            "eprop5": [1, 2, 3],
+        },
+    )
+    g.add_edge(
+        2,
+        "b",
+        "d",
+        properties={
+            "eprop1": 10,
+            "eprop2": 1.7,
+            "eprop3": "xyz123",
+            "eprop4": True,
+            "eprop5": [3, 4, 5],
+        },
+    )
+    g.add_edge(
+        1,
+        "c",
+        "d",
+        properties={
+            "eprop1": 30,
+            "eprop2": 6.4,
+            "eprop3": "xyz123",
+            "eprop4": False,
+            "eprop5": [10],
+        },
+    )
+    g.add_edge(
+        1,
+        "a",
+        "b",
+        properties={
+            "eprop1": 80,
+            "eprop2": 3.3,
+            "eprop3": "xyz1234",
+            "eprop4": False,
+        },
+    )
+    g.add_edge(
+        4,
+        "b",
+        "c",
+        properties={
+            "eprop1": 100,
+            "eprop2": -2.3,
+            "eprop3": "ayz123",
+            "eprop5": [10, 20, 30],
+        },
+    )
+    return g
+
+
+def run_graphql_test(query, expected_output, graph):
+    create_test_graph(graph)
+    tmp_work_dir = tempfile.mkdtemp()
+    with GraphServer(tmp_work_dir).start(PORT) as server:
+        client = server.get_client()
+        client.send_graph(path="g", graph=graph)
+
+        response = client.query(query)
+
+        # Convert response to a dictionary if needed and compare
+        response_dict = json.loads(response) if isinstance(response, str) else response
+        assert response_dict == expected_output
+
+
+def run_graphql_error_test(query, expected_error_message, graph):
+    create_test_graph(graph)
+    tmp_work_dir = tempfile.mkdtemp()
+    with GraphServer(tmp_work_dir).start(PORT) as server:
+        client = server.get_client()
+        client.send_graph(path="g", graph=graph)
+
+        with pytest.raises(Exception) as excinfo:
+            client.query(query)
+
+        full_error_message = str(excinfo.value)
+        match = re.search(r'"message":"(.*?)"', full_error_message)
+        error_message = match.group(1) if match else ""
+
+        assert (
+            error_message == expected_error_message
+        ), f"Expected '{expected_error_message}', but got '{error_message}'"
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_nothing(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: []) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_earliest_time(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ time: EARLIEST }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_earliest_time_reversed(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ time: EARLIEST, reverse: true }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        # C->D and A->B have the same time so will maintain their relative order
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph])
+def test_graph_edge_sort_by_latest_time(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ time: LATEST }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [PersistentGraph])
+def test_graph_edge_sort_by_latest_time_persistent_graph(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ time: LATEST }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    # In the persistent graph all edges will have the same latest_time
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_eprop1(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "eprop1" }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_eprop2(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "eprop2" }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_eprop3(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "eprop3" }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_eprop4(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "eprop4" }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_eprop5(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "eprop5" }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_combined(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "eprop3", reverse: true }, { property: "eprop4" }, { time: EARLIEST }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())
+
+@pytest.mark.parametrize("graph", [Graph, PersistentGraph])
+def test_graph_edge_sort_by_nonexistent_prop(graph):
+    query = """
+    query {
+      graph(path: "g") {
+        edges {
+          sorted(sortBys: [{ property: "i_dont_exist" }, { property: "eprop2", reverse: true }]) {
+            list {
+              src {
+                id
+              }
+              dst {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    expected_output = {
+        "graph": {
+            "edges": {
+                "sorted": {
+                    "list": [
+                        {"src": { "id": "c" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "b" } },
+                        {"src": { "id": "b" }, "dst": { "id": "d" } },
+                        {"src": { "id": "a" }, "dst": { "id": "d" } },
+                        {"src": { "id": "b" }, "dst": { "id": "c" } },
+                    ]
+                }
+            }
+        }
+    }
+    run_graphql_test(query, expected_output, graph())

--- a/raphtory-graphql/src/model/graph/edges.rs
+++ b/raphtory-graphql/src/model/graph/edges.rs
@@ -1,15 +1,15 @@
 use crate::model::graph::edge::Edge;
-use dynamic_graphql::{Enum, InputObject};
-use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
+use dynamic_graphql::{Enum, InputObject, ResolvedObject, ResolvedObjectFields};
 use itertools::Itertools;
-use raphtory::db::api::view::internal::OneHopFilter;
 use raphtory::{
-    db::{api::view::DynamicGraph, graph::edges::Edges},
+    db::{
+        api::view::{internal::OneHopFilter, DynamicGraph},
+        graph::edges::Edges,
+    },
     prelude::{EdgeViewOps, LayerOps, TimeOps},
 };
 use raphtory_api::iter::IntoDynBoxed;
-use std::cmp::Ordering;
-use std::sync::Arc;
+use std::{cmp::Ordering, sync::Arc};
 
 #[derive(ResolvedObject)]
 pub(crate) struct GqlEdges {

--- a/raphtory/src/db/graph/edges.rs
+++ b/raphtory/src/db/graph/edges.rs
@@ -64,6 +64,18 @@ impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> OneHopFilter<'gr
 }
 
 impl<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>> Edges<'graph, G, GH> {
+    pub fn new(
+        graph: GH,
+        base_graph: G,
+        edges: Arc<dyn Fn() -> BoxedLIter<'graph, EdgeRef> + Send + Sync + 'graph>,
+    ) -> Self {
+        Edges {
+            graph,
+            base_graph,
+            edges,
+        }
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = EdgeView<&G, &GH>> + '_ {
         let base_graph = &self.base_graph;
         let graph = &self.graph;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Provide a `sorted` field to GqlEdges so that the client may query for a list of edges sorted by some criteria. Currently supports sorting by src ID, dst ID, latest time, earliest time, property value (via `properties`, i.e. the unified properties), passing in multiple fields to sort by in order of priority, and reversing the sort. 

### Why are the changes needed?

Timestamp sorting was requested by client

### Does this PR introduce any user-facing change? If yes is this documented?

Yes, GraphQL API is currently not documented

### How was this patch tested?

Some basic tests run in the GraphQL Playground to test the query, and unit tests were added to `python/tests/graphql/test_edge_sorting.py`.

### Are there any further changes required?

Some improvements to the API to allow for sorting by constant properties and temporal properties specifically could be possible in the future, if need be.


