### PR TITLE
add create_subgraph function to graphql

### DIFF
--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -222,6 +222,27 @@ impl Mut {
         data.insert_graph(path, g).await?;
         Ok(path.to_owned())
     }
+
+    /// Create a subgraph out of some existing graph in the server
+    ///
+    /// Returns::
+    ///    name of the new graph
+    async fn create_subgraph<'a>(
+        ctx: &Context<'a>,
+        parent_path: &str,
+        nodes: Vec<String>,
+        new_path: String,
+        overwrite: bool,
+    ) -> Result<String> {
+        let data = ctx.data_unchecked::<Data>();
+        let parent_graph = data.get_graph(parent_path)?.0.graph.materialize()?;
+        let new_subgraph = parent_graph.subgraph(nodes).materialize()?;
+        if overwrite {
+            let _ignored = data.delete_graph(&new_path);
+        }
+        data.insert_graph(&new_path, new_subgraph).await?;
+        Ok(new_path)
+    }
 }
 
 #[derive(App)]

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -235,7 +235,7 @@ impl Mut {
         overwrite: bool,
     ) -> Result<String> {
         let data = ctx.data_unchecked::<Data>();
-        let parent_graph = data.get_graph(parent_path)?.0.graph.materialize()?;
+        let parent_graph = data.get_graph(parent_path)?.0.graph;
         let new_subgraph = parent_graph.subgraph(nodes).materialize()?;
         if overwrite {
             let _ignored = data.delete_graph(&new_path);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a new GraphQL mutation `create_subgraph`.

### Why are the changes needed?
We need this in order to be able to save graphs in the UI

### Does this PR introduce any user-facing change? If yes is this documented?
Yes it adds a new GraphQL function and the new docstring was included

### How was this patch tested?
This is not being tested, although the function is quite small and all its components are heavily tested in similar functions.

### Are there any further changes required?
No


