### PR TITLE
fix motif images missing from wheel

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,3 +39,4 @@ dev = ["docstring_parser >= 0.16", "pandas-stubs"]
 [tool.maturin]
 features = ["pyo3/extension-module"]
 python-source = "python"
+include = ["motif-images/*"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

the legend images for the motif plot were missing from the wheel distributions



