### PR TITLE
Exclude HTML files from GitHub stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # exclude .ipynb from stats
 *.ipynb linguist-documentation
 
+# exclude .html from stats
+*.html linguist-documentation
+
 # exclude docs from stats
 docs/* linguist-documentation
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exclude the HTML files from GitHub stats.

### Why are the changes needed?

Some very large HTML files were skewing the GitHub language statistics towards HTML. Raphtory is not an HTML project. 

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

### Are there any further changes required?


