### PR TITLE
no manual variant management for proto enums

### DIFF
--- a/raphtory/src/serialise/graph.proto
+++ b/raphtory/src/serialise/graph.proto
@@ -40,35 +40,35 @@ message NewMeta {
   message NewGraphTProp {
     string name = 1;
     uint64 id = 2;
-    PropType.PropType p_type = 3 [deprecated=true];
+    PropType.PropType p_type = 3 [deprecated = true];
     PropType.PType p_type2 = 4;
   }
 
   message NewNodeCProp {
     string name = 1;
     uint64 id = 2;
-    PropType.PropType p_type = 3 [deprecated=true];
+    PropType.PropType p_type = 3 [deprecated = true];
     PropType.PType p_type2 = 4;
   }
 
   message NewNodeTProp {
     string name = 1;
     uint64 id = 2;
-    PropType.PropType p_type = 3[deprecated=true];
+    PropType.PropType p_type = 3[deprecated = true];
     PropType.PType p_type2 = 4;
   }
 
   message NewEdgeCProp {
     string name = 1;
     uint64 id = 2;
-    PropType.PropType p_type = 3[deprecated=true];
+    PropType.PropType p_type = 3[deprecated = true];
     PropType.PType p_type2 = 4;
   }
 
   message NewEdgeTProp {
     string name = 1;
     uint64 id = 2;
-    PropType.PropType p_type = 3 [deprecated=true];
+    PropType.PropType p_type = 3 [deprecated = true];
     PropType.PType p_type2 = 4;
   }
 
@@ -177,8 +177,8 @@ message PropType {
     List = 10;
     Map = 11;
     NDTime = 12;
-    Graph = 13 [deprecated=true];
-    PersistentGraph = 14 [deprecated=true];
+    Graph = 13 [deprecated = true];
+    PersistentGraph = 14 [deprecated = true];
     Document = 15;
     DTime = 16;
   }
@@ -187,9 +187,13 @@ message PropType {
     PropType p_type = 1;
   }
 
+  message Scalar {
+    PropType p_type = 1;
+  }
+
   message PType{
     oneof kind {
-      PropType scalar = 1;
+      Scalar scalar = 1;
       Array array = 2;
     }
   }
@@ -209,8 +213,8 @@ message Prop {
     bool bool_value = 10;
     Props prop = 11;
     Dict map = 12;
-    Graph graph = 13 [deprecated=true]; // Assuming Data can be represented as bytes.
-    Graph persistentGraph = 14 [deprecated=true]; // Assuming Data can be represented as bytes.
+    Graph graph = 13 [deprecated = true]; // Assuming Data can be represented as bytes.
+    Graph persistentGraph = 14 [deprecated = true]; // Assuming Data can be represented as bytes.
     NDTime ndTime = 15;
     string dTime = 16;
     DocumentInput documentInput = 17;

--- a/raphtory/src/serialise/proto_ext.rs
+++ b/raphtory/src/serialise/proto_ext.rs
@@ -1,4 +1,7 @@
-use super::proto::{prop::Array, prop_type::Array as ArrayType};
+use super::proto::{
+    prop::Array,
+    prop_type::{Array as ArrayType, Scalar as ScalarType},
+};
 use crate::{
     core::{
         prop_array::PropArray, utils::errors::GraphError, DocumentInput, Lifespan, Prop, PropType,
@@ -63,39 +66,18 @@ fn as_proto_prop_type2(p_type: &PropType) -> Option<PType> {
             })
         }
         _ => Some(PType {
-            kind: Some(proto::prop_type::p_type::Kind::Scalar(
-                as_proto_prop_type(p_type)?.into(),
-            )),
+            kind: Some(proto::prop_type::p_type::Kind::Scalar(ScalarType {
+                p_type: as_proto_prop_type(p_type)?.into(),
+            })),
         }),
-    }
-}
-
-fn prop_type_from_i32(i: i32) -> Option<SPropType> {
-    match i {
-        0 => Some(SPropType::Str),
-        1 => Some(SPropType::U8),
-        2 => Some(SPropType::U16),
-        3 => Some(SPropType::I32),
-        4 => Some(SPropType::I64),
-        5 => Some(SPropType::U32),
-        6 => Some(SPropType::U64),
-        7 => Some(SPropType::F32),
-        8 => Some(SPropType::F64),
-        9 => Some(SPropType::Bool),
-        10 => Some(SPropType::List),
-        11 => Some(SPropType::Map),
-        12 => Some(SPropType::NdTime),
-        16 => Some(SPropType::DTime),
-        15 => Some(SPropType::Document),
-        _ => None,
     }
 }
 
 fn as_prop_type2(p_type: PType) -> Option<PropType> {
     match p_type.kind? {
-        proto::prop_type::p_type::Kind::Scalar(p_type) => as_prop_type(prop_type_from_i32(p_type)?),
+        proto::prop_type::p_type::Kind::Scalar(scalar) => as_prop_type(scalar.p_type()),
         proto::prop_type::p_type::Kind::Array(array) => {
-            let p_type = as_prop_type(prop_type_from_i32(array.p_type)?)?;
+            let p_type = as_prop_type(array.p_type())?;
             Some(PropType::Array(Box::new(p_type)))
         }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

minor change to the new property type structure in proto so we don't manually have to maintain int -> variant mappings



