### PR TITLE
contains and keys were giving inconsistent results

### DIFF
--- a/python/tests/test_graphdb/test_graphdb.py
+++ b/python/tests/test_graphdb/test_graphdb.py
@@ -1041,6 +1041,15 @@ def test_edge_constant_properties_layers():
     assert constant_exploded.keys() == ["test"]
 
 
+def test_temporal_edge_properties_layers():
+    g = Graph()
+    g.add_edge(0, 1, 2, {"test": 1}, layer="a")
+    g.add_edge(0, 1, 2)
+    temporal_exploded = g.default_layer().edges.explode().properties.temporal
+    assert temporal_exploded.keys() == ["test"]
+    assert temporal_exploded.values() == [[[]]]
+
+
 def test_arrow_array_properties():
     g = Graph()
     days = pa.array([1, 12, 17, 23, 28], type=pa.uint8())

--- a/python/tests/test_graphdb/test_graphdb.py
+++ b/python/tests/test_graphdb/test_graphdb.py
@@ -1031,6 +1031,16 @@ def create_graph_edge_properties():
     return g
 
 
+def test_edge_constant_properties_layers():
+    g = Graph()
+    g.add_edge(0, 1, 2, layer="a")
+    g.add_edge(0, 1, 2)
+    g.edge(1, 2).add_constant_properties({"test": 1})
+    constant_exploded = g.layer("a").edges.explode().properties.constant
+    assert constant_exploded.values() == [[None]]
+    assert constant_exploded.keys() == ["test"]
+
+
 def test_arrow_array_properties():
     g = Graph()
     days = pa.array([1, 12, 17, 23, 28], type=pa.uint8())

--- a/raphtory/src/db/api/properties/constant_props.rs
+++ b/raphtory/src/db/api/properties/constant_props.rs
@@ -39,7 +39,7 @@ impl<'a, P: ConstPropertiesOps + Sync> ConstantProperties<'a, P> {
     }
 
     pub fn contains(&self, key: &str) -> bool {
-        self.get(key).is_some()
+        self.props.get_const_prop_id(key).is_some()
     }
 
     pub fn as_map(&self) -> HashMap<ArcStr, Prop> {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes a panic exception in python for constant properties

```python
    g = Graph()
    g.add_edge(0, 1, 2, layer="a")
    g.add_edge(0, 1, 2)
    g.edge(1, 2).add_constant_properties({"test": 1})
    constant_exploded = g.layer("a").edges.explode().properties.constant.values() # used to panic here!
```

### Why are the changes needed?

bug due to `keys` and `contains` having inconsistent results

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

Added a test for the above example in python

### Are there any further changes required?


