### PR TITLE
Fix quirks in rolling and expanding APIs

### DIFF
--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -843,6 +843,19 @@ class Graph(GraphView):
             Graph: the graph with event semantics applied
         """
 
+    @staticmethod
+    def from_parquet(graph_dir: str | PathLike) -> Graph:
+        """
+        Read graph from parquet files
+
+        Arguments:
+           graph_dir (str | PathLike): the folder where the graph is stored as parquet
+
+        Returns:
+          Graph: a view of the graph
+
+        """
+
     def get_all_node_types(self) -> List[str]:
         """
         Returns all the node types in the graph.
@@ -1344,6 +1357,15 @@ class Graph(GraphView):
 
         Returns:
             Graph: a view of the persisted graph
+        """
+
+    def to_parquet(self, graph_dir: str | PathLike):
+        """
+        Persist graph to parquet files
+
+        Arguments:
+            graph_dir (str | PathLike): the folder where the graph will be persisted as parquet
+
         """
 
     def update_constant_properties(self, properties: PropInput) -> None:

--- a/python/tests/test_graphdb/test_disk_graph.py
+++ b/python/tests/test_graphdb/test_disk_graph.py
@@ -40,6 +40,7 @@ edges = pd.DataFrame(
 
 def test_counts():
     from raphtory import DiskGraphStorage
+
     graph_dir = tempfile.TemporaryDirectory()
     graph = DiskGraphStorage.load_from_pandas(
         graph_dir.name, edges, "time", "src", "dst"
@@ -51,6 +52,7 @@ def test_counts():
 
 def test_disk_graph():
     from raphtory import DiskGraphStorage
+
     curr_dir = os.path.dirname(os.path.abspath(__file__))
     rsc_dir = os.path.join(
         curr_dir, "..", "..", "..", "pometry-storage-private", "resources"
@@ -141,6 +143,7 @@ def test_disk_graph():
 
 def test_disk_graph_type_filter():
     from raphtory import DiskGraphStorage
+
     curr_dir = os.path.dirname(os.path.abspath(__file__))
     rsc_dir = os.path.join(
         curr_dir, "..", "..", "..", "pometry-storage-private", "resources"

--- a/raphtory/src/algorithms/metrics/clustering_coefficient/local_clustering_coefficient_batch.rs
+++ b/raphtory/src/algorithms/metrics/clustering_coefficient/local_clustering_coefficient_batch.rs
@@ -55,7 +55,6 @@ pub fn local_clustering_coefficient_batch<G: StaticGraphViewOps, V: AsNodeRef>(
 mod clustering_coefficient_tests {
     use super::local_clustering_coefficient_batch;
     use crate::{
-        algorithms::centrality::pagerank::page_rank_tests::assert_eq_f64,
         db::{
             api::{mutation::AdditionOps, view::*},
             graph::graph::Graph,

--- a/raphtory/src/core/utils/time.rs
+++ b/raphtory/src/core/utils/time.rs
@@ -307,7 +307,92 @@ impl Interval {
         };
         Ok(duration)
     }
+
+    pub fn discrete(num: u64) -> Self {
+        Interval {
+            epoch_alignment: false,
+            size: IntervalSize::Discrete(num)
+        }
+    }
+
+    pub fn milliseconds(ms: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::from(Duration::milliseconds(ms)),
+        }
+    }
+
+    pub fn seconds(seconds: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::from(Duration::seconds(seconds)),
+        }
+    }
+
+    pub fn minutes(minutes: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::from(Duration::minutes(minutes)),
+        }
+    }
+
+    pub fn hours(hours: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::from(Duration::hours(hours)),
+        }
+    }
+
+    pub fn days(days: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::from(Duration::days(days)),
+        }
+    }
+
+    pub fn weeks(weeks: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::from(Duration::weeks(weeks)),
+        }
+    }
+
+    pub fn months(months: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::months(months),
+        }
+    }
+
+    pub fn years(years: i64) -> Self {
+        Interval {
+            epoch_alignment: true,
+            size: IntervalSize::months(12 * years),
+        }
+    }
+
+    pub fn and(&self, other: &Self) -> Result<Self,  IntervalTypeError> {
+        match (self.size, other.size) {
+            (IntervalSize::Discrete(l), IntervalSize::Discrete(r)) => {
+                Ok(Interval {
+                    epoch_alignment: false,
+                    size: IntervalSize::Discrete(l + r),
+                })
+            },
+            (IntervalSize::Temporal {..}, IntervalSize::Temporal {..}) => {
+                Ok(Interval {
+                    epoch_alignment: true,
+                    size: self.size.add_temporal(other.size)
+                })
+            }
+            (_, _) => Err(IntervalTypeError())
+        }
+    }
 }
+
+#[derive(thiserror::Error, Debug)]
+#[error("Discrete and temporal intervals cannot be combined")]
+pub struct IntervalTypeError();
 
 impl Sub<Interval> for i64 {
     type Output = i64;

--- a/raphtory/src/core/utils/time.rs
+++ b/raphtory/src/core/utils/time.rs
@@ -2,7 +2,10 @@ use crate::core::utils::time::error::{ParseTimeError::InvalidDateTimeString, *};
 use chrono::{DateTime, Duration, Months, NaiveDate, NaiveDateTime, TimeZone};
 use itertools::{Either, Itertools};
 use regex::Regex;
-use std::ops::{Add, Sub};
+use std::{
+    convert::Infallible,
+    ops::{Add, Sub},
+};
 
 pub mod error {
     use chrono::ParseError;
@@ -27,6 +30,12 @@ pub mod error {
         NegativeInt,
         #[error("'{0}' is not a valid datetime, valid formats are RFC3339, RFC2822, %Y-%m-%d, %Y-%m-%dT%H:%M:%S%.3f, %Y-%m-%dT%H:%M:%S%, %Y-%m-%d %H:%M:%S%.3f and %Y-%m-%d %H:%M:%S%")]
         InvalidDateTimeString(String),
+    }
+}
+
+impl From<Infallible> for ParseTimeError {
+    fn from(value: Infallible) -> Self {
+        match value {}
     }
 }
 

--- a/raphtory/src/core/utils/time.rs
+++ b/raphtory/src/core/utils/time.rs
@@ -188,6 +188,14 @@ impl Default for Interval {
     }
 }
 
+impl TryFrom<String> for Interval {
+    type Error = ParseTimeError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+
 impl TryFrom<&str> for Interval {
     type Error = ParseTimeError;
     fn try_from(value: &str) -> Result<Self, Self::Error> {

--- a/raphtory/src/db/api/view/time.rs
+++ b/raphtory/src/db/api/view/time.rs
@@ -142,7 +142,8 @@ pub trait TimeOps<'graph>:
     fn expanding<I>(&self, step: I) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
         Self: Sized + Clone + 'static,
-        I: TryInto<Interval, Error = ParseTimeError>;
+        I: TryInto<Interval>,
+        ParseTimeError: From<<I as TryInto<Interval>>::Error>;
 
     /// Creates a `WindowSet` with the given `window` size and optional `step`
     /// using a rolling window. The last window may fall partially outside the range of the data/view.
@@ -155,7 +156,8 @@ pub trait TimeOps<'graph>:
     ) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
         Self: Sized + Clone + 'static,
-        I: TryInto<Interval, Error = ParseTimeError>;
+        I: TryInto<Interval>,
+        ParseTimeError: From<<I as TryInto<Interval>>::Error>;
 }
 
 impl<'graph, V: OneHopFilter<'graph> + 'graph + InternalTimeOps<'graph>> TimeOps<'graph> for V {
@@ -241,7 +243,8 @@ impl<'graph, V: OneHopFilter<'graph> + 'graph + InternalTimeOps<'graph>> TimeOps
     fn expanding<I>(&self, step: I) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
         Self: Sized + Clone + 'static,
-        I: TryInto<Interval, Error = ParseTimeError>,
+        I: TryInto<Interval>,
+        ParseTimeError: From<<I as TryInto<Interval>>::Error>,
     {
         let parent = self.clone();
         match (self.timeline_start(), self.timeline_end()) {
@@ -261,7 +264,8 @@ impl<'graph, V: OneHopFilter<'graph> + 'graph + InternalTimeOps<'graph>> TimeOps
     ) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
         Self: Sized + Clone + 'static,
-        I: TryInto<Interval, Error = ParseTimeError>,
+        I: TryInto<Interval>,
+        ParseTimeError: From<<I as TryInto<Interval>>::Error>,
     {
         let parent = self.clone();
         match (self.timeline_start(), self.timeline_end()) {

--- a/raphtory/src/db/api/view/time.rs
+++ b/raphtory/src/db/api/view/time.rs
@@ -141,7 +141,7 @@ pub trait TimeOps<'graph>:
     /// An expanding window is a window that grows by `step` size at each iteration.
     fn expanding<I>(&self, step: I) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
-        Self: Sized + Clone + 'static,
+        Self: Sized + Clone + 'graph,
         I: TryInto<Interval>,
         ParseTimeError: From<<I as TryInto<Interval>>::Error>;
 
@@ -155,7 +155,7 @@ pub trait TimeOps<'graph>:
         step: Option<I>,
     ) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
-        Self: Sized + Clone + 'static,
+        Self: Sized + Clone + 'graph,
         I: TryInto<Interval>,
         ParseTimeError: From<<I as TryInto<Interval>>::Error>;
 }
@@ -242,7 +242,7 @@ impl<'graph, V: OneHopFilter<'graph> + 'graph + InternalTimeOps<'graph>> TimeOps
 
     fn expanding<I>(&self, step: I) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
-        Self: Sized + Clone + 'static,
+        Self: Sized + Clone + 'graph,
         I: TryInto<Interval>,
         ParseTimeError: From<<I as TryInto<Interval>>::Error>,
     {
@@ -263,7 +263,7 @@ impl<'graph, V: OneHopFilter<'graph> + 'graph + InternalTimeOps<'graph>> TimeOps
         step: Option<I>,
     ) -> Result<WindowSet<'graph, Self>, ParseTimeError>
     where
-        Self: Sized + Clone + 'static,
+        Self: Sized + Clone + 'graph,
         I: TryInto<Interval>,
         ParseTimeError: From<<I as TryInto<Interval>>::Error>,
     {

--- a/raphtory/src/python/types/macros/trait_impl/timeops.rs
+++ b/raphtory/src/python/types/macros/trait_impl/timeops.rs
@@ -64,7 +64,7 @@ macro_rules! impl_timeops {
             ///
             /// Returns:
             ///     WindowSet: A `WindowSet` object.
-            fn expanding(&self, step: $crate::python::utils::PyInterval) -> Result<$crate::db::api::view::WindowSet<'static, $base_type>, $crate::core::utils::time::error::ParseTimeError> {
+            fn expanding(&self, step: $crate::core::utils::time::Interval) -> Result<$crate::db::api::view::WindowSet<'static, $base_type>, $crate::core::utils::time::error::ParseTimeError> {
                 self.$field.expanding(step)
             }
 
@@ -82,8 +82,8 @@ macro_rules! impl_timeops {
             #[pyo3(signature = (window, step=None))]
             fn rolling(
                 &self,
-                window: $crate::python::utils::PyInterval,
-                step: Option<$crate::python::utils::PyInterval>,
+                window:$crate::core::utils::time::Interval,
+                step: Option<$crate::core::utils::time::Interval>,
             ) -> Result<$crate::db::api::view::WindowSet<'static, $base_type>, $crate::core::utils::time::error::ParseTimeError> {
                 self.$field.rolling(window, step)
             }

--- a/raphtory/src/python/utils/mod.rs
+++ b/raphtory/src/python/utils/mod.rs
@@ -9,7 +9,7 @@ use crate::{
             GidRef,
         },
         storage::timeindex::AsTime,
-        utils::time::{error::ParseTimeError, Interval, IntoTime, TryIntoTime},
+        utils::time::{Interval, IntoTime, TryIntoTime},
         Prop, PropUnwrap,
     },
     db::api::view::*,
@@ -161,42 +161,19 @@ impl IntoTime for PyTime {
     }
 }
 
-pub struct PyInterval {
-    interval: Result<Interval, ParseTimeError>,
-}
-
-impl PyInterval {
-    fn new<I>(interval: I) -> Self
-    where
-        I: TryInto<Interval, Error = ParseTimeError>,
-    {
-        Self {
-            interval: interval.try_into(),
-        }
-    }
-}
-
-impl<'source> FromPyObject<'source> for PyInterval {
+impl<'source> FromPyObject<'source> for Interval {
     fn extract_bound(interval: &Bound<'source, PyAny>) -> PyResult<Self> {
-        let string = interval.extract::<String>();
-        let result = string.map(|string| PyInterval::new(string.as_str()));
+        if let Ok(string) = interval.extract::<String>() {
+            return Ok(string.try_into()?);
+        };
 
-        let result = result.or_else(|_| {
-            let number = interval.extract::<u64>();
-            number.map(PyInterval::new)
-        });
+        if let Ok(number) = interval.extract::<u64>() {
+            return Ok(number.try_into()?);
+        };
 
-        result.map_err(|_| {
-            let message = format!("interval '{interval}' must be a str or an unsigned integer");
-            PyTypeError::new_err(message)
-        })
-    }
-}
-
-impl TryFrom<PyInterval> for Interval {
-    type Error = ParseTimeError;
-    fn try_from(value: PyInterval) -> Result<Self, Self::Error> {
-        value.interval
+        Err(PyTypeError::new_err(format!(
+            "interval '{interval}' must be a str or an unsigned integer"
+        )))
     }
 }
 

--- a/raphtory/src/python/utils/mod.rs
+++ b/raphtory/src/python/utils/mod.rs
@@ -161,7 +161,7 @@ impl IntoTime for PyTime {
     }
 }
 
-pub(crate) struct PyInterval {
+pub struct PyInterval {
     interval: Result<Interval, ParseTimeError>,
 }
 

--- a/raphtory/src/serialise/parquet/mod.rs
+++ b/raphtory/src/serialise/parquet/mod.rs
@@ -406,13 +406,7 @@ impl ParquetDecoder for PersistentGraph {
 mod test {
     use super::*;
     use crate::{
-        db::{
-            api::{
-                storage::graph::edges::edge_storage_ops::EdgeStorageOps,
-                view::internal::TimeSemantics,
-            },
-            graph::graph::assert_graph_equal,
-        },
+        db::graph::graph::assert_graph_equal,
         test_utils::{
             build_edge_list_dyn, build_graph, build_graph_strat, build_nodes_dyn, GraphFixture,
             NodeFixture,


### PR DESCRIPTION
### What changes were proposed in this pull request?

`rolling` and `expanding` can now accept `Interval` directly instead of complaining about incompatible `Error` types in the conversion

### Why are the changes needed?

Make it easier to reuse the parsed `Interval` inside an algorithm.

### Does this PR introduce any user-facing change? If yes is this documented?

Not really, all existing code continues to work as before.

### How was this patch tested?

the tests

### Are there any further changes required?

no


