### PR TITLE
Fix and update time semantics for PersistentGraph

### DIFF
--- a/raphtory/src/db/api/storage/graph/edges/edge_entry.rs
+++ b/raphtory/src/db/api/storage/graph/edges/edge_entry.rs
@@ -45,8 +45,8 @@ impl<'a, 'b: 'a> EdgeStorageOps<'a> for &'a EdgeStorageEntry<'b> {
         self.as_ref().out_ref()
     }
 
-    fn active(self, layer_ids: &LayerIds, w: Range<i64>) -> bool {
-        self.as_ref().active(layer_ids, w)
+    fn added(self, layer_ids: &LayerIds, w: Range<i64>) -> bool {
+        self.as_ref().added(layer_ids, w)
     }
 
     fn has_layer(self, layer_ids: &LayerIds) -> bool {

--- a/raphtory/src/db/api/storage/graph/edges/edge_ref.rs
+++ b/raphtory/src/db/api/storage/graph/edges/edge_ref.rs
@@ -59,8 +59,8 @@ impl<'a> EdgeStorageOps<'a> for EdgeStorageRef<'a> {
         for_all!(self, edge => EdgeStorageOps::out_ref(edge))
     }
 
-    fn active(self, layer_ids: &LayerIds, w: Range<i64>) -> bool {
-        for_all!(self, edge => EdgeStorageOps::active(edge, layer_ids, w))
+    fn added(self, layer_ids: &LayerIds, w: Range<i64>) -> bool {
+        for_all!(self, edge => EdgeStorageOps::added(edge, layer_ids, w))
     }
 
     fn has_layer(self, layer_ids: &LayerIds) -> bool {

--- a/raphtory/src/db/api/storage/graph/storage_ops/time_semantics.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/time_semantics.rs
@@ -98,7 +98,7 @@ impl TimeSemantics for GraphStorage {
         w: Range<i64>,
         layer_ids: &LayerIds,
     ) -> bool {
-        edge.active(layer_ids, w)
+        edge.added(layer_ids, w)
     }
 
     fn node_history<'a>(&'a self, v: VID) -> BoxedLIter<'a, TimeIndexEntry> {

--- a/raphtory/src/db/api/storage/graph/tprop_storage_ops.rs
+++ b/raphtory/src/db/api/storage/graph/tprop_storage_ops.rs
@@ -42,7 +42,7 @@ macro_rules! for_all_variants {
     };
 }
 
-pub trait TPropOps<'a>: Sized + 'a + Send {
+pub trait TPropOps<'a>: Sized + 'a + Send + Clone {
     fn active(self, w: Range<i64>) -> bool {
         self.iter_window_t(w).next().is_some()
     }

--- a/raphtory/src/db/graph/views/deletion_graph.rs
+++ b/raphtory/src/db/graph/views/deletion_graph.rs
@@ -218,9 +218,9 @@ impl TimeSemantics for PersistentGraph {
         let v = self.core_node_entry(v);
         let additions = v.additions();
         if additions.first_t()? <= start {
-            Some(additions.range_t(start..end).first_t().unwrap_or(start))
+            Some(start)
         } else {
-            None
+            additions.range_t(start..end).first_t()
         }
     }
 
@@ -1289,5 +1289,15 @@ mod test_deletions {
 
         assert_eq!(g.window(-1, 0).earliest_time(), None);
         assert_eq!(g.window(-1, 0).latest_time(), None);
+    }
+
+    #[test]
+    fn test_node_earliest_time_window() {
+        let g = PersistentGraph::new();
+        g.add_edge(0, 1, 2, NO_PROPS, None).unwrap();
+        g.add_edge(4, 1, 3, NO_PROPS, None).unwrap();
+
+        assert_eq!(g.window(2, 7).node(3).unwrap().earliest_time(), Some(4));
+        assert_eq!(g.window(2, 7).node(1).unwrap().earliest_time(), Some(2));
     }
 }

--- a/raphtory/src/disk_graph/graph_impl/edge_storage_ops.rs
+++ b/raphtory/src/disk_graph/graph_impl/edge_storage_ops.rs
@@ -19,7 +19,7 @@ use rayon::prelude::*;
 use std::{iter, ops::Range};
 
 impl<'a> EdgeStorageOps<'a> for Edge<'a> {
-    fn active(self, layer_ids: &LayerIds, w: Range<i64>) -> bool {
+    fn added(self, layer_ids: &LayerIds, w: Range<i64>) -> bool {
         self.has_layer(layer_ids) && {
             match layer_ids {
                 LayerIds::None => false,
@@ -29,7 +29,7 @@ impl<'a> EdgeStorageOps<'a> for Edge<'a> {
                 LayerIds::One(l_id) => self.get_additions::<i64>(*l_id).active_t(w),
                 LayerIds::Multiple(layers) => layers
                     .iter()
-                    .any(|l_id| self.active(&LayerIds::One(l_id), w.clone())),
+                    .any(|l_id| self.added(&LayerIds::One(l_id), w.clone())),
             }
         }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Changed the semantics for edge deletions without a corresponding addition so that they are only considered as an instantaneous event (the edge does not exist before or after)
- Fixed bug where property values for exploded edges were incorrect for the PersistentGraph
- Cleaned up semantics for earliest and latest time on edges accordingly

### Why are the changes needed?

- Bugs and strange/hard to implement behaviour for the PersistentGraph

### Does this PR introduce any user-facing change? If yes is this documented?

Yes

### How was this patch tested?

Added more tests for the semantics and edge cases

### Are there any further changes required?

[ ] Exploded edges and properties have different semantics at the start of the window (needs to be fixed and unified)

[ ] Document the semantics properly


