### PR TITLE
Apply multiple views in one graphql function

### DIFF
--- a/raphtory-graphql/src/model/graph/edge.rs
+++ b/raphtory-graphql/src/model/graph/edge.rs
@@ -1,4 +1,6 @@
-use crate::model::graph::{edges::GqlEdges, node::Node, property::GqlProperties};
+use crate::model::graph::{
+    edges::GqlEdges, filtering::EdgeViewCollection, node::Node, property::GqlProperties,
+};
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
 use raphtory::{
     core::utils::errors::GraphError,
@@ -8,7 +10,6 @@ use raphtory::{
     },
     prelude::{LayerOps, TimeOps},
 };
-use crate::model::graph::filtering::{EdgeViewCollection};
 
 #[derive(ResolvedObject)]
 pub(crate) struct Edge {
@@ -105,7 +106,6 @@ impl Edge {
     async fn shrink_end(&self, end: i64) -> Self {
         self.ee.shrink_end(end).into()
     }
-
 
     async fn apply_views(&self, views: Vec<EdgeViewCollection>) -> Result<Edge, GraphError> {
         let mut return_view: Edge = self.ee.clone().into();

--- a/raphtory-graphql/src/model/graph/edges.rs
+++ b/raphtory-graphql/src/model/graph/edges.rs
@@ -1,5 +1,5 @@
 use crate::model::{
-    graph::{edge::Edge},
+    graph::{edge::Edge, filtering::EdgesViewCollection},
     sorting::{EdgeSortBy, SortByTime},
 };
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
@@ -14,7 +14,6 @@ use raphtory::{
 };
 use raphtory_api::iter::IntoDynBoxed;
 use std::{cmp::Ordering, sync::Arc};
-use crate::model::graph::filtering::EdgesViewCollection;
 
 #[derive(ResolvedObject)]
 pub(crate) struct GqlEdges {
@@ -103,7 +102,6 @@ impl GqlEdges {
 
     async fn apply_views(&self, views: Vec<EdgesViewCollection>) -> Result<GqlEdges, GraphError> {
         let mut return_view: GqlEdges = self.update(self.ee.clone());
-
 
         for view in views {
             let mut count = 0;

--- a/raphtory-graphql/src/model/graph/edges.rs
+++ b/raphtory-graphql/src/model/graph/edges.rs
@@ -1,10 +1,11 @@
 use crate::model::{
-    graph::edge::Edge,
+    graph::{edge::Edge},
     sorting::{EdgeSortBy, SortByTime},
 };
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
 use itertools::Itertools;
 use raphtory::{
+    core::utils::errors::GraphError,
     db::{
         api::view::{internal::OneHopFilter, DynamicGraph},
         graph::edges::Edges,
@@ -13,6 +14,7 @@ use raphtory::{
 };
 use raphtory_api::iter::IntoDynBoxed;
 use std::{cmp::Ordering, sync::Arc};
+use crate::model::graph::filtering::EdgesViewCollection;
 
 #[derive(ResolvedObject)]
 pub(crate) struct GqlEdges {
@@ -42,6 +44,9 @@ impl GqlEdges {
     // LAYERS AND WINDOWS //
     ////////////////////////
 
+    async fn default_layer(&self) -> Self {
+        self.update(self.ee.default_layer())
+    }
     async fn layers(&self, names: Vec<String>) -> Self {
         self.update(self.ee.valid_layers(names))
     }
@@ -94,6 +99,80 @@ impl GqlEdges {
 
     async fn shrink_end(&self, end: i64) -> Self {
         self.update(self.ee.shrink_end(end))
+    }
+
+    async fn apply_views(&self, views: Vec<EdgesViewCollection>) -> Result<GqlEdges, GraphError> {
+        let mut return_view: GqlEdges = self.update(self.ee.clone());
+
+
+        for view in views {
+            let mut count = 0;
+            if let Some(_) = view.default_layer {
+                count += 1;
+                return_view = return_view.default_layer().await;
+            }
+            if let Some(layers) = view.layers {
+                count += 1;
+                return_view = return_view.layers(layers).await;
+            }
+            if let Some(layers) = view.exclude_layers {
+                count += 1;
+                return_view = return_view.exclude_layers(layers).await;
+            }
+            if let Some(layer) = view.layer {
+                count += 1;
+                return_view = return_view.layer(layer).await;
+            }
+            if let Some(layer) = view.exclude_layer {
+                count += 1;
+                return_view = return_view.exclude_layer(layer).await;
+            }
+            if let Some(window) = view.window {
+                count += 1;
+                return_view = return_view.window(window.start, window.end).await;
+            }
+            if let Some(time) = view.at {
+                count += 1;
+                return_view = return_view.at(time).await;
+            }
+            if let Some(_) = view.latest {
+                count += 1;
+                return_view = return_view.latest().await;
+            }
+            if let Some(time) = view.snapshot_at {
+                count += 1;
+                return_view = return_view.snapshot_at(time).await;
+            }
+            if let Some(_) = view.snapshot_latest {
+                count += 1;
+                return_view = return_view.snapshot_latest().await;
+            }
+            if let Some(time) = view.before {
+                count += 1;
+                return_view = return_view.before(time).await;
+            }
+            if let Some(time) = view.after {
+                count += 1;
+                return_view = return_view.after(time).await;
+            }
+            if let Some(window) = view.shrink_window {
+                count += 1;
+                return_view = return_view.shrink_window(window.start, window.end).await;
+            }
+            if let Some(time) = view.shrink_start {
+                count += 1;
+                return_view = return_view.shrink_start(time).await;
+            }
+            if let Some(time) = view.shrink_end {
+                count += 1;
+                return_view = return_view.shrink_end(time).await;
+            }
+            if count > 1 {
+                return Err(GraphError::TooManyViewsSet);
+            }
+        }
+
+        Ok(return_view)
     }
 
     async fn explode(&self) -> Self {

--- a/raphtory-graphql/src/model/graph/filtering.rs
+++ b/raphtory-graphql/src/model/graph/filtering.rs
@@ -64,9 +64,8 @@ pub struct NodeViewCollection {
     pub after: Option<i64>,
     pub shrink_window: Option<Window>,
     pub shrink_start: Option<i64>,
-    pub shrink_end: Option<i64>
+    pub shrink_end: Option<i64>,
 }
-
 
 #[derive(InputObject, Clone, Debug)]
 pub struct EdgesViewCollection {

--- a/raphtory-graphql/src/model/graph/filtering.rs
+++ b/raphtory-graphql/src/model/graph/filtering.rs
@@ -2,6 +2,31 @@ use crate::model::graph::property::GqlPropValue;
 use dynamic_graphql::{Enum, InputObject};
 
 #[derive(InputObject, Clone, Debug)]
+pub struct FilterCollection {
+    pub default_layer: Option<bool>,
+    pub layers: Option<Vec<String>>,
+    pub exclude_layers: Option<Vec<String>>,
+    pub layer: Option<String>,
+    pub exclude_layer: Option<String>,
+    pub subgraph: Option<Vec<String>>,
+    pub subgraph_id: Option<Vec<u64>>,
+    pub subgraph_node_types: Option<Vec<String>>,
+    pub exclude_nodes: Option<Vec<String>>,
+    pub exclude_nodes_id: Option<Vec<u64>>,
+    pub window: Option<FilterWindow>,
+    pub at: Option<i64>,
+    pub latest: Option<bool>,
+    pub snapshot_latest: Option<bool>,
+    pub before: Option<i64>,
+    pub after: Option<i64>,
+    pub shrink_window: Option<FilterWindow>,
+    pub shrink_start: Option<i64>,
+    pub shrink_end: Option<i64>,
+    pub node_filter: Option<FilterProperty>,
+    pub edge_filter: Option<FilterProperty>,
+}
+
+#[derive(InputObject, Clone, Debug)]
 pub struct FilterWindow {
     pub start: i64,
     pub end: i64,

--- a/raphtory-graphql/src/model/graph/filtering.rs
+++ b/raphtory-graphql/src/model/graph/filtering.rs
@@ -2,7 +2,7 @@ use crate::model::graph::property::GqlPropValue;
 use dynamic_graphql::{Enum, InputObject};
 
 #[derive(InputObject, Clone, Debug)]
-pub struct FilterCollection {
+pub struct GraphViewCollection {
     pub default_layer: Option<bool>,
     pub layers: Option<Vec<String>>,
     pub exclude_layers: Option<Vec<String>>,
@@ -13,13 +13,14 @@ pub struct FilterCollection {
     pub subgraph_node_types: Option<Vec<String>>,
     pub exclude_nodes: Option<Vec<String>>,
     pub exclude_nodes_id: Option<Vec<u64>>,
-    pub window: Option<FilterWindow>,
+    pub window: Option<Window>,
     pub at: Option<i64>,
     pub latest: Option<bool>,
+    pub snapshot_at: Option<i64>,
     pub snapshot_latest: Option<bool>,
     pub before: Option<i64>,
     pub after: Option<i64>,
-    pub shrink_window: Option<FilterWindow>,
+    pub shrink_window: Option<Window>,
     pub shrink_start: Option<i64>,
     pub shrink_end: Option<i64>,
     pub node_filter: Option<FilterProperty>,
@@ -27,7 +28,86 @@ pub struct FilterCollection {
 }
 
 #[derive(InputObject, Clone, Debug)]
-pub struct FilterWindow {
+pub struct NodesViewCollection {
+    pub default_layer: Option<bool>,
+    pub layers: Option<Vec<String>>,
+    pub exclude_layers: Option<Vec<String>>,
+    pub layer: Option<String>,
+    pub exclude_layer: Option<String>,
+    pub window: Option<Window>,
+    pub at: Option<i64>,
+    pub latest: Option<bool>,
+    pub snapshot_at: Option<i64>,
+    pub snapshot_latest: Option<bool>,
+    pub before: Option<i64>,
+    pub after: Option<i64>,
+    pub shrink_window: Option<Window>,
+    pub shrink_start: Option<i64>,
+    pub shrink_end: Option<i64>,
+    pub type_filter: Option<Vec<String>>,
+    pub node_filter: Option<FilterProperty>,
+}
+
+#[derive(InputObject, Clone, Debug)]
+pub struct NodeViewCollection {
+    pub default_layer: Option<bool>,
+    pub layers: Option<Vec<String>>,
+    pub exclude_layers: Option<Vec<String>>,
+    pub layer: Option<String>,
+    pub exclude_layer: Option<String>,
+    pub window: Option<Window>,
+    pub at: Option<i64>,
+    pub latest: Option<bool>,
+    pub snapshot_at: Option<i64>,
+    pub snapshot_latest: Option<bool>,
+    pub before: Option<i64>,
+    pub after: Option<i64>,
+    pub shrink_window: Option<Window>,
+    pub shrink_start: Option<i64>,
+    pub shrink_end: Option<i64>
+}
+
+
+#[derive(InputObject, Clone, Debug)]
+pub struct EdgesViewCollection {
+    pub default_layer: Option<bool>,
+    pub layers: Option<Vec<String>>,
+    pub exclude_layers: Option<Vec<String>>,
+    pub layer: Option<String>,
+    pub exclude_layer: Option<String>,
+    pub window: Option<Window>,
+    pub at: Option<i64>,
+    pub latest: Option<bool>,
+    pub snapshot_at: Option<i64>,
+    pub snapshot_latest: Option<bool>,
+    pub before: Option<i64>,
+    pub after: Option<i64>,
+    pub shrink_window: Option<Window>,
+    pub shrink_start: Option<i64>,
+    pub shrink_end: Option<i64>,
+}
+
+#[derive(InputObject, Clone, Debug)]
+pub struct EdgeViewCollection {
+    pub default_layer: Option<bool>,
+    pub layers: Option<Vec<String>>,
+    pub exclude_layers: Option<Vec<String>>,
+    pub layer: Option<String>,
+    pub exclude_layer: Option<String>,
+    pub window: Option<Window>,
+    pub at: Option<i64>,
+    pub latest: Option<bool>,
+    pub snapshot_at: Option<i64>,
+    pub snapshot_latest: Option<bool>,
+    pub before: Option<i64>,
+    pub after: Option<i64>,
+    pub shrink_window: Option<Window>,
+    pub shrink_start: Option<i64>,
+    pub shrink_end: Option<i64>,
+}
+
+#[derive(InputObject, Clone, Debug)]
+pub struct Window {
     pub start: i64,
     pub end: i64,
 }

--- a/raphtory-graphql/src/model/graph/filtering.rs
+++ b/raphtory-graphql/src/model/graph/filtering.rs
@@ -1,0 +1,33 @@
+use crate::model::graph::property::GqlPropValue;
+use dynamic_graphql::{Enum, InputObject};
+
+#[derive(InputObject, Clone, Debug)]
+pub struct FilterWindow {
+    pub start: i64,
+    pub end: i64,
+}
+
+#[derive(InputObject, Clone, Debug)]
+pub struct FilterProperty {
+    pub property: String,
+    pub condition: FilterCondition,
+}
+#[derive(InputObject, Clone, Debug)]
+pub struct FilterCondition {
+    pub operator: Operator,
+    pub value: Option<GqlPropValue>,
+}
+
+#[derive(Enum, Copy, Clone, Debug)]
+pub enum Operator {
+    Equal,
+    NotEqual,
+    GreaterThanOrEqual,
+    LessThanOrEqual,
+    GreaterThan,
+    LessThan,
+    IsNone,
+    IsSome,
+    Any,
+    NotAny,
+}

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -2,8 +2,12 @@ use crate::{
     data::Data,
     model::{
         graph::{
-            edge::Edge, edges::GqlEdges, node::Node, nodes::GqlNodes, property::GqlProperties,
-            FilterCondition, Operator,
+            edge::Edge,
+            edges::GqlEdges,
+            filtering::{FilterCondition, FilterProperty, FilterWindow, Operator},
+            node::Node,
+            nodes::GqlNodes,
+            property::GqlProperties,
         },
         plugins::graph_algorithm_plugin::GraphAlgorithmPlugin,
         schema::graph_schema::GraphSchema,
@@ -192,300 +196,6 @@ impl GqlGraph {
 
     async fn shrink_end(&self, end: i64) -> Self {
         self.apply(|g| g.shrink_end(end), |g| g.shrink_end(end))
-    }
-
-    ////////////////////////
-    //// TIME QUERIES //////
-    ////////////////////////
-
-    async fn created(&self) -> Result<i64, GraphError> {
-        self.path.created()
-    }
-
-    async fn last_opened(&self) -> Result<i64, GraphError> {
-        self.path.last_opened()
-    }
-
-    async fn last_updated(&self) -> Result<i64, GraphError> {
-        self.path.last_updated()
-    }
-
-    async fn earliest_time(&self) -> Option<i64> {
-        self.graph.earliest_time()
-    }
-
-    async fn latest_time(&self) -> Option<i64> {
-        self.graph.latest_time()
-    }
-
-    async fn start(&self) -> Option<i64> {
-        self.graph.start()
-    }
-
-    async fn end(&self) -> Option<i64> {
-        self.graph.end()
-    }
-
-    async fn earliest_edge_time(&self, include_negative: Option<bool>) -> Option<i64> {
-        let include_negative = include_negative.unwrap_or(true);
-        let all_edges = self
-            .graph
-            .edges()
-            .earliest_time()
-            .into_iter()
-            .filter_map(|edge_time| edge_time.filter(|&time| (include_negative || time >= 0)))
-            .min();
-        return all_edges;
-    }
-
-    async fn latest_edge_time(&self, include_negative: Option<bool>) -> Option<i64> {
-        let include_negative = include_negative.unwrap_or(true);
-        let all_edges = self
-            .graph
-            .edges()
-            .latest_time()
-            .into_iter()
-            .filter_map(|edge_time| edge_time.filter(|&time| (include_negative || time >= 0)))
-            .max();
-
-        return all_edges;
-    }
-
-    ////////////////////////
-    //////// COUNTERS //////
-    ////////////////////////
-
-    async fn count_edges(&self) -> usize {
-        self.graph.count_edges()
-    }
-
-    async fn count_temporal_edges(&self) -> usize {
-        self.graph.count_temporal_edges()
-    }
-
-    async fn search_edge_count(&self, query: String) -> Result<usize, GraphError> {
-        Ok(self.get_index()?.search_edge_count(&query).unwrap_or(0))
-    }
-
-    async fn count_nodes(&self) -> usize {
-        self.graph.count_nodes()
-    }
-
-    async fn search_node_count(&self, query: String) -> Result<usize, GraphError> {
-        Ok(self.get_index()?.search_node_count(&query).unwrap_or(0))
-    }
-
-    ////////////////////////
-    //// EXISTS CHECKERS ///
-    ////////////////////////
-
-    async fn has_node(&self, name: String) -> bool {
-        self.graph.has_node(name)
-    }
-
-    async fn has_node_id(&self, id: u64) -> bool {
-        self.graph.has_node(id)
-    }
-
-    async fn has_edge(&self, src: String, dst: String, layer: Option<String>) -> bool {
-        match layer {
-            Some(name) => self
-                .graph
-                .layers(name)
-                .map(|l| l.has_edge(src, dst))
-                .unwrap_or(false),
-            None => self.graph.has_edge(src, dst),
-        }
-    }
-
-    async fn has_edge_id(&self, src: u64, dst: u64, layer: Option<String>) -> bool {
-        match layer {
-            Some(name) => self
-                .graph
-                .layers(name)
-                .map(|l| l.has_edge(src, dst))
-                .unwrap_or(false),
-            None => self.graph.has_edge(src, dst),
-        }
-    }
-
-    ////////////////////////
-    //////// GETTERS ///////
-    ////////////////////////
-
-    async fn node(&self, name: String) -> Option<Node> {
-        self.graph.node(name).map(|v| v.into())
-    }
-
-    async fn node_id(&self, id: u64) -> Option<Node> {
-        self.graph.node(id).map(|v| v.into())
-    }
-
-    async fn nodes(&self) -> GqlNodes {
-        GqlNodes::new(self.graph.nodes())
-    }
-
-    async fn search_nodes(
-        &self,
-        query: String,
-        limit: usize,
-        offset: usize,
-    ) -> Result<Vec<Node>, GraphError> {
-        Ok(self
-            .get_index()?
-            .search_nodes(&query, limit, offset)
-            .into_iter()
-            .flatten()
-            .map(|vv| vv.into())
-            .collect())
-    }
-
-    async fn fuzzy_search_nodes(
-        &self,
-        query: String,
-        limit: usize,
-        offset: usize,
-        prefix: bool,
-        levenshtein_distance: u8,
-    ) -> Result<Vec<Node>, GraphError> {
-        Ok(self
-            .get_index()?
-            .fuzzy_search_nodes(&query, limit, offset, prefix, levenshtein_distance)
-            .into_iter()
-            .flatten()
-            .map(|vv| vv.into())
-            .collect())
-    }
-
-    pub fn edge(&self, src: String, dst: String) -> Option<Edge> {
-        self.graph.edge(src, dst).map(|e| e.into())
-    }
-
-    pub fn edge_id(&self, src: u64, dst: u64) -> Option<Edge> {
-        self.graph.edge(src, dst).map(|e| e.into())
-    }
-
-    async fn edges<'a>(&self) -> GqlEdges {
-        GqlEdges::new(self.graph.edges())
-    }
-
-    async fn search_edges(
-        &self,
-        query: String,
-        limit: usize,
-        offset: usize,
-    ) -> Result<Vec<Edge>, GraphError> {
-        Ok(self
-            .get_index()?
-            .search_edges(&query, limit, offset)
-            .into_iter()
-            .flatten()
-            .map(|vv| vv.into())
-            .collect())
-    }
-
-    async fn fuzzy_search_edges(
-        &self,
-        query: String,
-        limit: usize,
-        offset: usize,
-        prefix: bool,
-        levenshtein_distance: u8,
-    ) -> Result<Vec<Edge>, GraphError> {
-        Ok(self
-            .get_index()?
-            .fuzzy_search_edges(&query, limit, offset, prefix, levenshtein_distance)
-            .into_iter()
-            .flatten()
-            .map(|vv| vv.into())
-            .collect())
-    }
-
-    ////////////////////////
-    /////// PROPERTIES /////
-    ////////////////////////
-
-    async fn properties(&self) -> GqlProperties {
-        Into::<DynProperties>::into(self.graph.properties()).into()
-    }
-
-    ////////////////////////
-    // GRAPHQL SPECIFIC ////
-    ////////////////////////
-
-    //These name/path functions basically can only fail
-    //if someone write non-utf characters as a filename
-
-    async fn name(&self) -> Result<String, GraphError> {
-        self.path.get_graph_name()
-    }
-
-    async fn path(&self) -> Result<String, GraphError> {
-        Ok(self
-            .path
-            .get_original_path()
-            .to_str()
-            .ok_or(PathNotParsable(self.path.to_error_path()))?
-            .to_owned())
-    }
-
-    async fn namespace(&self) -> Result<String, GraphError> {
-        Ok(self
-            .path
-            .get_original_path()
-            .parent()
-            .and_then(|p| p.to_str().map(|s| s.to_string()))
-            .ok_or(PathNotParsable(self.path.to_error_path()))?
-            .to_owned())
-    }
-
-    async fn schema(&self) -> GraphSchema {
-        GraphSchema::new(&self.graph)
-    }
-
-    async fn algorithms(&self) -> GraphAlgorithmPlugin {
-        self.graph.clone().into()
-    }
-
-    async fn shared_neighbours(&self, selected_nodes: Vec<String>) -> Vec<Node> {
-        if selected_nodes.is_empty() {
-            return vec![];
-        }
-
-        let neighbours: Vec<HashSet<NodeView<DynamicGraph>>> = selected_nodes
-            .iter()
-            .filter_map(|n| self.graph.node(n))
-            .map(|n| {
-                n.neighbours()
-                    .collect()
-                    .iter()
-                    .map(|vv| vv.clone())
-                    .collect::<HashSet<NodeView<DynamicGraph>>>()
-            })
-            .collect();
-
-        let intersection = neighbours.iter().fold(None, |acc, n| match acc {
-            None => Some(n.clone()),
-            Some(acc) => Some(acc.intersection(n).map(|vv| vv.clone()).collect()),
-        });
-        match intersection {
-            Some(intersection) => intersection.into_iter().map(|vv| vv.into()).collect(),
-            None => vec![],
-        }
-    }
-
-    /// Export all nodes and edges from this graph view to another existing graph
-    async fn export_to<'a>(
-        &'a self,
-        ctx: &Context<'a>,
-        path: String,
-    ) -> Result<bool, Arc<GraphError>> {
-        let data = ctx.data_unchecked::<Data>();
-        let other_g = data.get_graph(path.as_ref())?.0;
-        other_g.import_nodes(self.graph.nodes(), true)?;
-        other_g.import_edges(self.graph.edges(), true)?;
-        other_g.write_updates()?;
-        Ok(true)
     }
 
     async fn node_filter(
@@ -812,5 +522,418 @@ impl GqlGraph {
                 }
             }
         }
+    }
+
+    async fn filter(
+        &self,
+        default_layer: Option<bool>,
+        layers: Option<Vec<String>>,
+        exclude_layers: Option<Vec<String>>,
+        layer: Option<String>,
+        exclude_layer: Option<String>,
+        subgraph: Option<Vec<String>>,
+        subgraph_id: Option<Vec<u64>>,
+        subgraph_node_types: Option<Vec<String>>,
+        exclude_nodes: Option<Vec<String>>,
+        exclude_nodes_id: Option<Vec<u64>>,
+        window: Option<FilterWindow>,
+        at: Option<i64>,
+        latest: Option<bool>,
+        snapshot_latest: Option<bool>,
+        before: Option<i64>,
+        after: Option<i64>,
+        shrink_window: Option<FilterWindow>,
+        shrink_start: Option<i64>,
+        shrink_end: Option<i64>,
+        node_filter: Option<FilterProperty>,
+        edge_filter: Option<FilterProperty>,
+    ) -> Result<GqlGraph, GraphError> {
+        let mut return_view =
+            GqlGraph::new(self.path.clone(), self.graph.clone(), self.index.clone());
+
+        // Apply default layer if specified
+        if let Some(true) = default_layer {
+            return_view = return_view.default_layer().await;
+        }
+
+        // Apply layers inclusion filter
+        if let Some(layers) = layers {
+            return_view = return_view.layers(layers).await;
+        }
+
+        // Apply layer exclusion filter
+        if let Some(exclude_layers) = exclude_layers {
+            return_view = return_view.exclude_layers(exclude_layers).await;
+        }
+
+        // Apply single layer filter
+        if let Some(layer) = layer {
+            return_view = return_view.layer(layer).await;
+        }
+
+        // Apply single layer exclusion
+        if let Some(exclude_layer) = exclude_layer {
+            return_view = return_view.exclude_layer(exclude_layer).await;
+        }
+
+        // Apply subgraph filters
+        if let Some(subgraph) = subgraph {
+            return_view = return_view.subgraph(subgraph).await;
+        }
+        if let Some(subgraph_id) = subgraph_id {
+            return_view = return_view.subgraph_id(subgraph_id).await;
+        }
+        if let Some(subgraph_node_types) = subgraph_node_types {
+            return_view = return_view.subgraph_node_types(subgraph_node_types).await;
+        }
+
+        // Apply node exclusions
+        if let Some(exclude_nodes) = exclude_nodes {
+            return_view = return_view.exclude_nodes(exclude_nodes).await;
+        }
+        if let Some(exclude_nodes_id) = exclude_nodes_id {
+            return_view = return_view.exclude_nodes_id(exclude_nodes_id).await;
+        }
+
+        // Apply time filters
+        if let Some(window) = window {
+            return_view = return_view.window(window.start, window.end).await;
+        }
+        if let Some(at) = at {
+            return_view = return_view.at(at).await;
+        }
+        if let Some(true) = latest {
+            return_view = return_view.latest().await;
+        }
+        if let Some(_) = snapshot_latest {
+            return_view = return_view.snapshot_latest().await;
+        }
+        if let Some(before) = before {
+            return_view = return_view.before(before).await;
+        }
+        if let Some(after) = after {
+            return_view = return_view.after(after).await;
+        }
+
+        // Apply shrinking window filters
+        if let Some(shrink_window) = shrink_window {
+            return_view = return_view
+                .shrink_window(shrink_window.start, shrink_window.end)
+                .await;
+        }
+        if let Some(shrink_start) = shrink_start {
+            return_view = return_view.shrink_start(shrink_start).await;
+        }
+        if let Some(shrink_end) = shrink_end {
+            return_view = return_view.shrink_end(shrink_end).await;
+        }
+
+        // Apply node and edge property filters
+        if let Some(node_filter) = node_filter {
+            return_view = return_view
+                .node_filter(node_filter.property, node_filter.condition)
+                .await?;
+        }
+        if let Some(edge_filter) = edge_filter {
+            return_view = return_view
+                .edge_filter(edge_filter.property, edge_filter.condition)
+                .await?;
+        }
+
+        Ok(return_view)
+    }
+
+    ////////////////////////
+    //// TIME QUERIES //////
+    ////////////////////////
+
+    async fn created(&self) -> Result<i64, GraphError> {
+        self.path.created()
+    }
+
+    async fn last_opened(&self) -> Result<i64, GraphError> {
+        self.path.last_opened()
+    }
+
+    async fn last_updated(&self) -> Result<i64, GraphError> {
+        self.path.last_updated()
+    }
+
+    async fn earliest_time(&self) -> Option<i64> {
+        self.graph.earliest_time()
+    }
+
+    async fn latest_time(&self) -> Option<i64> {
+        self.graph.latest_time()
+    }
+
+    async fn start(&self) -> Option<i64> {
+        self.graph.start()
+    }
+
+    async fn end(&self) -> Option<i64> {
+        self.graph.end()
+    }
+
+    async fn earliest_edge_time(&self, include_negative: Option<bool>) -> Option<i64> {
+        let include_negative = include_negative.unwrap_or(true);
+        let all_edges = self
+            .graph
+            .edges()
+            .earliest_time()
+            .into_iter()
+            .filter_map(|edge_time| edge_time.filter(|&time| (include_negative || time >= 0)))
+            .min();
+        return all_edges;
+    }
+
+    async fn latest_edge_time(&self, include_negative: Option<bool>) -> Option<i64> {
+        let include_negative = include_negative.unwrap_or(true);
+        let all_edges = self
+            .graph
+            .edges()
+            .latest_time()
+            .into_iter()
+            .filter_map(|edge_time| edge_time.filter(|&time| (include_negative || time >= 0)))
+            .max();
+
+        return all_edges;
+    }
+
+    ////////////////////////
+    //////// COUNTERS //////
+    ////////////////////////
+
+    async fn count_edges(&self) -> usize {
+        self.graph.count_edges()
+    }
+
+    async fn count_temporal_edges(&self) -> usize {
+        self.graph.count_temporal_edges()
+    }
+
+    async fn search_edge_count(&self, query: String) -> Result<usize, GraphError> {
+        Ok(self.get_index()?.search_edge_count(&query).unwrap_or(0))
+    }
+
+    async fn count_nodes(&self) -> usize {
+        self.graph.count_nodes()
+    }
+
+    async fn search_node_count(&self, query: String) -> Result<usize, GraphError> {
+        Ok(self.get_index()?.search_node_count(&query).unwrap_or(0))
+    }
+
+    ////////////////////////
+    //// EXISTS CHECKERS ///
+    ////////////////////////
+
+    async fn has_node(&self, name: String) -> bool {
+        self.graph.has_node(name)
+    }
+
+    async fn has_node_id(&self, id: u64) -> bool {
+        self.graph.has_node(id)
+    }
+
+    async fn has_edge(&self, src: String, dst: String, layer: Option<String>) -> bool {
+        match layer {
+            Some(name) => self
+                .graph
+                .layers(name)
+                .map(|l| l.has_edge(src, dst))
+                .unwrap_or(false),
+            None => self.graph.has_edge(src, dst),
+        }
+    }
+
+    async fn has_edge_id(&self, src: u64, dst: u64, layer: Option<String>) -> bool {
+        match layer {
+            Some(name) => self
+                .graph
+                .layers(name)
+                .map(|l| l.has_edge(src, dst))
+                .unwrap_or(false),
+            None => self.graph.has_edge(src, dst),
+        }
+    }
+
+    ////////////////////////
+    //////// GETTERS ///////
+    ////////////////////////
+
+    async fn node(&self, name: String) -> Option<Node> {
+        self.graph.node(name).map(|v| v.into())
+    }
+
+    async fn node_id(&self, id: u64) -> Option<Node> {
+        self.graph.node(id).map(|v| v.into())
+    }
+
+    async fn nodes(&self) -> GqlNodes {
+        GqlNodes::new(self.graph.nodes())
+    }
+
+    async fn search_nodes(
+        &self,
+        query: String,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Node>, GraphError> {
+        Ok(self
+            .get_index()?
+            .search_nodes(&query, limit, offset)
+            .into_iter()
+            .flatten()
+            .map(|vv| vv.into())
+            .collect())
+    }
+
+    async fn fuzzy_search_nodes(
+        &self,
+        query: String,
+        limit: usize,
+        offset: usize,
+        prefix: bool,
+        levenshtein_distance: u8,
+    ) -> Result<Vec<Node>, GraphError> {
+        Ok(self
+            .get_index()?
+            .fuzzy_search_nodes(&query, limit, offset, prefix, levenshtein_distance)
+            .into_iter()
+            .flatten()
+            .map(|vv| vv.into())
+            .collect())
+    }
+
+    pub fn edge(&self, src: String, dst: String) -> Option<Edge> {
+        self.graph.edge(src, dst).map(|e| e.into())
+    }
+
+    pub fn edge_id(&self, src: u64, dst: u64) -> Option<Edge> {
+        self.graph.edge(src, dst).map(|e| e.into())
+    }
+
+    async fn edges<'a>(&self) -> GqlEdges {
+        GqlEdges::new(self.graph.edges())
+    }
+
+    async fn search_edges(
+        &self,
+        query: String,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<Edge>, GraphError> {
+        Ok(self
+            .get_index()?
+            .search_edges(&query, limit, offset)
+            .into_iter()
+            .flatten()
+            .map(|vv| vv.into())
+            .collect())
+    }
+
+    async fn fuzzy_search_edges(
+        &self,
+        query: String,
+        limit: usize,
+        offset: usize,
+        prefix: bool,
+        levenshtein_distance: u8,
+    ) -> Result<Vec<Edge>, GraphError> {
+        Ok(self
+            .get_index()?
+            .fuzzy_search_edges(&query, limit, offset, prefix, levenshtein_distance)
+            .into_iter()
+            .flatten()
+            .map(|vv| vv.into())
+            .collect())
+    }
+
+    ////////////////////////
+    /////// PROPERTIES /////
+    ////////////////////////
+
+    async fn properties(&self) -> GqlProperties {
+        Into::<DynProperties>::into(self.graph.properties()).into()
+    }
+
+    ////////////////////////
+    // GRAPHQL SPECIFIC ////
+    ////////////////////////
+
+    //These name/path functions basically can only fail
+    //if someone write non-utf characters as a filename
+
+    async fn name(&self) -> Result<String, GraphError> {
+        self.path.get_graph_name()
+    }
+
+    async fn path(&self) -> Result<String, GraphError> {
+        Ok(self
+            .path
+            .get_original_path()
+            .to_str()
+            .ok_or(PathNotParsable(self.path.to_error_path()))?
+            .to_owned())
+    }
+
+    async fn namespace(&self) -> Result<String, GraphError> {
+        Ok(self
+            .path
+            .get_original_path()
+            .parent()
+            .and_then(|p| p.to_str().map(|s| s.to_string()))
+            .ok_or(PathNotParsable(self.path.to_error_path()))?
+            .to_owned())
+    }
+
+    async fn schema(&self) -> GraphSchema {
+        GraphSchema::new(&self.graph)
+    }
+
+    async fn algorithms(&self) -> GraphAlgorithmPlugin {
+        self.graph.clone().into()
+    }
+
+    async fn shared_neighbours(&self, selected_nodes: Vec<String>) -> Vec<Node> {
+        if selected_nodes.is_empty() {
+            return vec![];
+        }
+
+        let neighbours: Vec<HashSet<NodeView<DynamicGraph>>> = selected_nodes
+            .iter()
+            .filter_map(|n| self.graph.node(n))
+            .map(|n| {
+                n.neighbours()
+                    .collect()
+                    .iter()
+                    .map(|vv| vv.clone())
+                    .collect::<HashSet<NodeView<DynamicGraph>>>()
+            })
+            .collect();
+
+        let intersection = neighbours.iter().fold(None, |acc, n| match acc {
+            None => Some(n.clone()),
+            Some(acc) => Some(acc.intersection(n).map(|vv| vv.clone()).collect()),
+        });
+        match intersection {
+            Some(intersection) => intersection.into_iter().map(|vv| vv.into()).collect(),
+            None => vec![],
+        }
+    }
+
+    /// Export all nodes and edges from this graph view to another existing graph
+    async fn export_to<'a>(
+        &'a self,
+        ctx: &Context<'a>,
+        path: String,
+    ) -> Result<bool, Arc<GraphError>> {
+        let data = ctx.data_unchecked::<Data>();
+        let other_g = data.get_graph(path.as_ref())?.0;
+        other_g.import_nodes(self.graph.nodes(), true)?;
+        other_g.import_edges(self.graph.edges(), true)?;
+        other_g.write_updates()?;
+        Ok(true)
     }
 }

--- a/raphtory-graphql/src/model/graph/graph.rs
+++ b/raphtory-graphql/src/model/graph/graph.rs
@@ -4,9 +4,7 @@ use crate::{
         graph::{
             edge::Edge,
             edges::GqlEdges,
-            filtering::{
-                FilterCondition, GraphViewCollection, Operator,
-            },
+            filtering::{FilterCondition, GraphViewCollection, Operator},
             node::Node,
             nodes::GqlNodes,
             property::GqlProperties,

--- a/raphtory-graphql/src/model/graph/mod.rs
+++ b/raphtory-graphql/src/model/graph/mod.rs
@@ -1,8 +1,6 @@
-use crate::model::graph::property::GqlPropValue;
-use dynamic_graphql::{Enum, InputObject};
-
 pub(crate) mod edge;
 mod edges;
+pub(crate) mod filtering;
 pub(crate) mod graph;
 pub(crate) mod graphs;
 pub(crate) mod mutable_graph;
@@ -11,23 +9,3 @@ mod nodes;
 mod path_from_node;
 pub(crate) mod property;
 pub(crate) mod vectorised_graph;
-
-#[derive(InputObject, Debug)]
-pub struct FilterCondition {
-    pub operator: Operator,
-    pub value: Option<GqlPropValue>,
-}
-
-#[derive(Enum, Copy, Clone, Debug)]
-pub enum Operator {
-    Equal,
-    NotEqual,
-    GreaterThanOrEqual,
-    LessThanOrEqual,
-    GreaterThan,
-    LessThan,
-    IsNone,
-    IsSome,
-    Any,
-    NotAny,
-}

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -1,17 +1,17 @@
 use crate::model::graph::{
-    edges::GqlEdges, nodes::GqlNodes, path_from_node::GqlPathFromNode, property::GqlProperties,
+    edges::GqlEdges, filtering::NodeViewCollection, nodes::GqlNodes,
+    path_from_node::GqlPathFromNode, property::GqlProperties,
 };
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
 use raphtory::{
     algorithms::components::{in_component, out_component},
+    core::utils::errors::GraphError,
     db::{
         api::{properties::dyn_props::DynProperties, view::*},
         graph::node::NodeView,
     },
     prelude::NodeStateOps,
 };
-use raphtory::core::utils::errors::GraphError;
-use crate::model::graph::filtering::{NodeViewCollection};
 
 #[derive(ResolvedObject)]
 pub(crate) struct Node {

--- a/raphtory-graphql/src/model/graph/node.rs
+++ b/raphtory-graphql/src/model/graph/node.rs
@@ -10,6 +10,8 @@ use raphtory::{
     },
     prelude::NodeStateOps,
 };
+use raphtory::core::utils::errors::GraphError;
+use crate::model::graph::filtering::{NodeViewCollection};
 
 #[derive(ResolvedObject)]
 pub(crate) struct Node {
@@ -43,7 +45,9 @@ impl Node {
     ////////////////////////
     // LAYERS AND WINDOWS //
     ////////////////////////
-
+    async fn default_layer(&self) -> Node {
+        self.vv.default_layer().into()
+    }
     async fn layers(&self, names: Vec<String>) -> Node {
         self.vv.valid_layers(names).into()
     }
@@ -98,6 +102,80 @@ impl Node {
 
     async fn shrink_end(&self, end: i64) -> Self {
         self.vv.shrink_end(end).into()
+    }
+
+    async fn apply_views(&self, views: Vec<NodeViewCollection>) -> Result<Node, GraphError> {
+        let mut return_view: Node = self.vv.clone().into();
+
+        for view in views {
+            let mut count = 0;
+            if let Some(_) = view.default_layer {
+                count += 1;
+                return_view = return_view.default_layer().await;
+            }
+            if let Some(layers) = view.layers {
+                count += 1;
+                return_view = return_view.layers(layers).await;
+            }
+            if let Some(layers) = view.exclude_layers {
+                count += 1;
+                return_view = return_view.exclude_layers(layers).await;
+            }
+            if let Some(layer) = view.layer {
+                count += 1;
+                return_view = return_view.layer(layer).await;
+            }
+            if let Some(layer) = view.exclude_layer {
+                count += 1;
+                return_view = return_view.exclude_layer(layer).await;
+            }
+            if let Some(window) = view.window {
+                count += 1;
+                return_view = return_view.window(window.start, window.end).await;
+            }
+            if let Some(time) = view.at {
+                count += 1;
+                return_view = return_view.at(time).await;
+            }
+            if let Some(_) = view.latest {
+                count += 1;
+                return_view = return_view.latest().await;
+            }
+            if let Some(time) = view.snapshot_at {
+                count += 1;
+                return_view = return_view.snapshot_at(time).await;
+            }
+            if let Some(_) = view.snapshot_latest {
+                count += 1;
+                return_view = return_view.snapshot_latest().await;
+            }
+            if let Some(time) = view.before {
+                count += 1;
+                return_view = return_view.before(time).await;
+            }
+            if let Some(time) = view.after {
+                count += 1;
+                return_view = return_view.after(time).await;
+            }
+            if let Some(window) = view.shrink_window {
+                count += 1;
+                return_view = return_view.shrink_window(window.start, window.end).await;
+            }
+            if let Some(time) = view.shrink_start {
+                count += 1;
+                return_view = return_view.shrink_start(time).await;
+            }
+            if let Some(time) = view.shrink_end {
+                count += 1;
+                return_view = return_view.shrink_end(time).await;
+            }
+
+            if count > 1 {
+                return Err(GraphError::TooManyViewsSet);
+            }
+        }
+
+        Ok(return_view)
     }
 
     ////////////////////////

--- a/raphtory-graphql/src/model/graph/nodes.rs
+++ b/raphtory-graphql/src/model/graph/nodes.rs
@@ -1,5 +1,8 @@
 use crate::model::{
-    graph::{node::Node, FilterCondition, Operator},
+    graph::{
+        filtering::{FilterCondition, Operator},
+        node::Node,
+    },
     sorting::{NodeSortBy, SortByTime},
 };
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};

--- a/raphtory-graphql/src/model/graph/nodes.rs
+++ b/raphtory-graphql/src/model/graph/nodes.rs
@@ -1,6 +1,6 @@
 use crate::model::{
     graph::{
-        filtering::{FilterCondition, Operator},
+        filtering::{FilterCondition, NodesViewCollection, Operator},
         node::Node,
     },
     sorting::{NodeSortBy, SortByTime},
@@ -45,6 +45,9 @@ impl GqlNodes {
     ////////////////////////
     // LAYERS AND WINDOWS //
     ////////////////////////
+    async fn default_layer(&self) -> Self {
+        self.update(self.nn.default_layer())
+    }
 
     async fn layers(&self, names: Vec<String>) -> Self {
         self.update(self.nn.valid_layers(names))
@@ -227,6 +230,90 @@ impl GqlNodes {
                 }
             }
         }
+    }
+
+    async fn apply_views(&self, views: Vec<NodesViewCollection>) -> Result<GqlNodes, GraphError> {
+        let mut return_view: GqlNodes = GqlNodes::new(self.nn.clone());
+
+        for view in views {
+            let mut count = 0;
+            if let Some(_) = view.default_layer {
+                count += 1;
+                return_view = return_view.default_layer().await;
+            }
+            if let Some(layers) = view.layers {
+                count += 1;
+                return_view = return_view.layers(layers).await;
+            }
+            if let Some(layers) = view.exclude_layers {
+                count += 1;
+                return_view = return_view.exclude_layers(layers).await;
+            }
+            if let Some(layer) = view.layer {
+                count += 1;
+                return_view = return_view.layer(layer).await;
+            }
+            if let Some(layer) = view.exclude_layer {
+                count += 1;
+                return_view = return_view.exclude_layer(layer).await;
+            }
+            if let Some(window) = view.window {
+                count += 1;
+                return_view = return_view.window(window.start, window.end).await;
+            }
+            if let Some(time) = view.at {
+                count += 1;
+                return_view = return_view.at(time).await;
+            }
+            if let Some(_) = view.latest {
+                count += 1;
+                return_view = return_view.latest().await;
+            }
+            if let Some(time) = view.snapshot_at {
+                count += 1;
+                return_view = return_view.snapshot_at(time).await;
+            }
+            if let Some(_) = view.snapshot_latest {
+                count += 1;
+                return_view = return_view.snapshot_latest().await;
+            }
+            if let Some(time) = view.before {
+                count += 1;
+                return_view = return_view.before(time).await;
+            }
+            if let Some(time) = view.after {
+                count += 1;
+                return_view = return_view.after(time).await;
+            }
+            if let Some(window) = view.shrink_window {
+                count += 1;
+                return_view = return_view.shrink_window(window.start, window.end).await;
+            }
+            if let Some(time) = view.shrink_start {
+                count += 1;
+                return_view = return_view.shrink_start(time).await;
+            }
+            if let Some(time) = view.shrink_end {
+                count += 1;
+                return_view = return_view.shrink_end(time).await;
+            }
+            if let Some(types) = view.type_filter {
+                count += 1;
+                return_view = return_view.type_filter(types).await;
+            }
+            if let Some(node_filter) = view.node_filter {
+                count += 1;
+                return_view = return_view
+                    .node_filter(node_filter.property, node_filter.condition)
+                    .await?;
+            }
+
+            if count > 1 {
+                return Err(GraphError::TooManyViewsSet);
+            }
+        }
+
+        Ok(return_view)
     }
 
     /////////////////

--- a/raphtory/src/core/utils/errors.rs
+++ b/raphtory/src/core/utils/errors.rs
@@ -307,8 +307,8 @@ pub enum GraphError {
     #[error("Unsupported: Cannot convert {0} to ArrowDataType ")]
     UnsupportedArrowDataType(PropType),
 
-    #[error("More than one filter set within a FilterCollection object - due to limitations in graphql we cannot tell which order to execute these in. Please add these filters as individual objects in the order you want them to execute.")]
-    TooManyFiltersSet,
+    #[error("More than one view set within a ViewCollection object - due to limitations in graphql we cannot tell which order to execute these in. Please add these views as individual objects in the order you want them to execute.")]
+    TooManyViewsSet,
 }
 
 impl GraphError {

--- a/raphtory/src/core/utils/errors.rs
+++ b/raphtory/src/core/utils/errors.rs
@@ -306,6 +306,9 @@ pub enum GraphError {
 
     #[error("Unsupported: Cannot convert {0} to ArrowDataType ")]
     UnsupportedArrowDataType(PropType),
+
+    #[error("More than one filter set within a FilterCollection object - due to limitations in graphql we cannot tell which order to execute these in. Please add these filters as individual objects in the order you want them to execute.")]
+    TooManyFiltersSet,
 }
 
 impl GraphError {


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Added default layer to GQLNodes, Node and Edge as they were missing.
- Added a new function `apply_views` to all Graphql entities which allows you to apply all views in one function by passing a vec of view objects.

### Why are the changes needed?
Arbitrarily deep json responses when you want to apply different filters are annoying to parse. 

### Does this PR introduce any user-facing change? If yes is this documented?
Yes, not currently
### Are there any further changes required?
- [ ] Tests to be added
- [ ] Need to make some good examples
- [ ] need to refactor internal node which is called `vv` not `nn`
- [ ] Should GQLNodes/Edges be renamed or Node/Edge
