### PR TITLE
No `get_by_id` on `Properties`

### DIFF
--- a/raphtory/src/db/api/properties/props.rs
+++ b/raphtory/src/db/api/properties/props.rs
@@ -33,12 +33,6 @@ impl<P: PropertiesOps + Clone> Properties<P> {
             })
     }
 
-    pub fn get_by_id(&self, id: usize) -> Option<Prop> {
-        self.props
-            .temporal_value(id)
-            .or_else(|| self.props.get_const_prop(id))
-    }
-
     /// Check if property `key` exists.
     pub fn contains(&self, key: &str) -> bool {
         self.get(key).is_some()


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove the `get_by_id` function on `Properties`

### Why are the changes needed?

`get_by_id` makes no sense for `Properties` as temporal and constant properties do not have consistent ids. Only `TemporalProperties` and `ConstantProperties` can support `get_by_id`.

### Does this PR introduce any user-facing change? If yes is this documented?

this method was technically pub but cannot be used in any sensible way.

### How was this patch tested?

the tests

### Are there any further changes required?


