### PR TITLE
implement IntoPyObject for node state of integer tuples

### DIFF
--- a/raphtory/src/python/graph/node_state/node_state.rs
+++ b/raphtory/src/python/graph/node_state/node_state.rs
@@ -611,6 +611,12 @@ impl_node_state!(
     "list[Tuple[int, str]]"
 );
 
+impl_node_state_ord!(
+    NodeStateI64Tuple<(i64, i64)>,
+    "NodeStateI64Tuple",
+    "Tuple[int, int]"
+);
+
 impl_node_state_ord!(NodeStateMotifs<Vec<usize>>, "NodeStateMotifs", "list[int]");
 
 impl_node_state_ord!(


### PR DESCRIPTION
### What changes were proposed in this pull request?
It implements IntoPyObject for NodeState<(i64, i64)>

### Why are the changes needed?
It's a pretty common case that happen to not be useful for any of our implemented algorithms, but might be for some user-defined ones

### Does this PR introduce any user-facing change? If yes is this documented?
Not really

### How was this patch tested?
Not much to test

### Are there any further changes required?
No

