### PR TITLE
fix in- and out-components hop filter resetting

### DIFF
--- a/python/tests/test_graphql/misc/test_components.py
+++ b/python/tests/test_graphql/misc/test_components.py
@@ -4,26 +4,27 @@ from raphtory import Graph
 import tempfile
 
 
+def sort_components(data):
+    if "inComponent" in data:
+        data["inComponent"]["list"] = sorted(
+            data["inComponent"]["list"], key=lambda x: x["name"]
+        )
+    if "outComponent" in data:
+        data["outComponent"]["list"] = sorted(
+            data["outComponent"]["list"], key=lambda x: x["name"]
+        )
+
+
+def prepare_for_comparison(structure):
+    if "node" in structure:
+        sort_components(structure["node"])
+    if "window" in structure:
+        sort_components(structure["window"]["node"])
+    if "at" in structure:
+        sort_components(structure["at"]["node"])
+
+
 def test_in_out_components():
-
-    def sort_components(data):
-        if "inComponent" in data:
-            data["inComponent"]["list"] = sorted(
-                data["inComponent"]["list"], key=lambda x: x["name"]
-            )
-        if "outComponent" in data:
-            data["outComponent"]["list"] = sorted(
-                data["outComponent"]["list"], key=lambda x: x["name"]
-            )
-
-    def prepare_for_comparison(structure):
-        if "node" in structure:
-            sort_components(structure["node"])
-        if "window" in structure:
-            sort_components(structure["window"]["node"])
-        if "at" in structure:
-            sort_components(structure["at"]["node"])
-
     query = """
         {
           graph(path: "graph") {
@@ -94,3 +95,98 @@ def test_in_out_components():
         prepare_for_comparison(query_res["graph"])
         prepare_for_comparison(result["graph"])
         assert query_res == result
+
+
+def test_in_out_component_hop_reset():
+    work_dir = tempfile.mkdtemp()
+    g = Graph()
+    g.add_edge(1, 1, 2)
+    g.add_edge(2, 1, 3)
+    g.add_edge(3, 3, 4)
+    g.add_edge(4, 4, 5)
+    g.add_edge(5, 3, 6)
+    g.add_edge(6, 7, 3)
+    g.save_to_file(work_dir + "/graph")
+
+    query_out = """
+        {
+          graph(path: "graph") {
+            node(name: "1") {
+              window(start: 2, end: 4) {
+                outComponent {
+                  list {
+                    name
+                    degree
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+
+    result_out = {
+        "graph": {
+            "node": {
+                "window": {
+                    "outComponent": {
+                        "list": [
+                            {
+                                "name": "3",
+                                "degree": 4,
+                            },
+                            {
+                                "name": "4",
+                                "degree": 2,
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    query_in = """
+        {
+          graph(path: "graph") {
+            node(name: "3") {
+              window(start: 2, end: 4) {
+                inComponent {
+                  list {
+                    name
+                    degree
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+
+    result_in = {
+        "graph": {
+            "node": {
+                "window": {
+                    "inComponent": {
+                        "list": [
+                            {
+                                "name": "1",
+                                "degree": 2,
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    with GraphServer(work_dir).start():
+        client = RaphtoryClient("http://localhost:1736")
+        query_res = client.query(query_out)
+        prepare_for_comparison(query_res["graph"])
+        prepare_for_comparison(result_out["graph"])
+        assert query_res == result_out
+
+        query_res = client.query(query_in)
+        prepare_for_comparison(query_res["graph"])
+        prepare_for_comparison(result_in["graph"])
+        assert query_res == result_in

--- a/raphtory/src/algorithms/components/in_components.rs
+++ b/raphtory/src/algorithms/components/in_components.rs
@@ -98,8 +98,8 @@ where
 ///
 /// The nodes within the given nodes in-component and their distances from the starting node.
 ///
-pub fn in_component<'graph, G: GraphViewOps<'graph>>(
-    node: NodeView<G>,
+pub fn in_component<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>>(
+    node: NodeView<G, GH>,
 ) -> NodeState<'graph, usize, G> {
     let mut in_components = HashMap::new();
     let mut to_check_stack = VecDeque::new();
@@ -110,7 +110,7 @@ pub fn in_component<'graph, G: GraphViewOps<'graph>>(
     });
     while let Some((neighbour_id, d)) = to_check_stack.pop_front() {
         let d = d + 1;
-        if let Some(neighbour) = &node.graph.node(neighbour_id) {
+        if let Some(neighbour) = (&&node.graph).node(neighbour_id) {
             neighbour.in_neighbours().iter().for_each(|node| {
                 let id = node.node;
                 if let Entry::Vacant(entry) = in_components.entry(id) {
@@ -124,8 +124,8 @@ pub fn in_component<'graph, G: GraphViewOps<'graph>>(
     let (nodes, distances): (IndexSet<_, ahash::RandomState>, Vec<_>) =
         in_components.into_iter().sorted().unzip();
     NodeState::new(
-        node.graph.clone(),
-        node.graph.clone(),
+        node.base_graph.clone(),
+        node.base_graph.clone(),
         distances.into(),
         Some(Index::new(nodes)),
     )

--- a/raphtory/src/algorithms/components/out_components.rs
+++ b/raphtory/src/algorithms/components/out_components.rs
@@ -98,8 +98,8 @@ where
 ///
 /// Nodes in the out-component with their distances from the starting node.
 ///
-pub fn out_component<'graph, G: GraphViewOps<'graph>>(
-    node: NodeView<G>,
+pub fn out_component<'graph, G: GraphViewOps<'graph>, GH: GraphViewOps<'graph>>(
+    node: NodeView<G, GH>,
 ) -> NodeState<'graph, usize, G> {
     let mut out_components = HashMap::new();
     let mut to_check_stack = VecDeque::new();
@@ -110,7 +110,7 @@ pub fn out_component<'graph, G: GraphViewOps<'graph>>(
     });
     while let Some((neighbour_id, d)) = to_check_stack.pop_front() {
         let d = d + 1;
-        if let Some(neighbour) = &node.graph.node(neighbour_id) {
+        if let Some(neighbour) = (&&node.graph).node(neighbour_id) {
             neighbour.out_neighbours().iter().for_each(|node| {
                 let id = node.node;
                 if let Entry::Vacant(entry) = out_components.entry(id) {
@@ -124,8 +124,8 @@ pub fn out_component<'graph, G: GraphViewOps<'graph>>(
     let (nodes, distances): (IndexSet<_, ahash::RandomState>, Vec<_>) =
         out_components.into_iter().sorted().unzip();
     NodeState::new(
-        node.graph.clone(),
-        node.graph.clone(),
+        node.base_graph.clone(),
+        node.base_graph.clone(),
         distances.into(),
         Some(Index::new(nodes)),
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

The in- and out-components were not applying the one-hop filter resetting correctly

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

added tests for the graphql queries

### Are there any further changes required?


