### PR TITLE
Fix node and edge filters

### DIFF
--- a/raphtory/src/db/api/storage/graph/storage_ops/edge_filter.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/edge_filter.rs
@@ -13,10 +13,6 @@ impl EdgeFilterOps for GraphStorage {
         true
     }
 
-    fn edge_filter_includes_node_filter(&self) -> bool {
-        true
-    }
-
     fn filter_edge(&self, _edge: EdgeStorageRef, _layer_ids: &LayerIds) -> bool {
         true
     }

--- a/raphtory/src/db/api/storage/graph/storage_ops/node_filter.rs
+++ b/raphtory/src/db/api/storage/graph/storage_ops/node_filter.rs
@@ -15,6 +15,11 @@ impl NodeFilterOps for GraphStorage {
     }
 
     #[inline]
+    fn edge_filter_includes_node_filter(&self) -> bool {
+        true
+    }
+
+    #[inline]
     fn filter_node(&self, _node: NodeStorageRef, _layer_ids: &LayerIds) -> bool {
         true
     }

--- a/raphtory/src/db/api/view/internal/edge_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/edge_filter_ops.rs
@@ -12,10 +12,6 @@ pub trait EdgeFilterOps {
     /// If true, all edges returned by `self.edge_list()` exist, otherwise it needs further filtering
     fn edge_list_trusted(&self) -> bool;
 
-    /// If true, do not need to check src and dst of the edge separately, even if nodes are filtered
-    /// (i.e., edge filter already makes sure there are no edges between non-existent nodes)
-    fn edge_filter_includes_node_filter(&self) -> bool;
-
     fn filter_edge(&self, edge: EdgeStorageRef, layer_ids: &LayerIds) -> bool;
 }
 
@@ -48,11 +44,6 @@ impl<G: DelegateEdgeFilterOps> EdgeFilterOps for G {
     #[inline]
     fn edge_list_trusted(&self) -> bool {
         self.graph().edge_list_trusted()
-    }
-
-    #[inline]
-    fn edge_filter_includes_node_filter(&self) -> bool {
-        self.graph().edge_filter_includes_node_filter()
     }
 
     #[inline]

--- a/raphtory/src/db/api/view/internal/node_filter_ops.rs
+++ b/raphtory/src/db/api/view/internal/node_filter_ops.rs
@@ -17,6 +17,11 @@ pub trait NodeFilterOps {
     /// of nodes in the graph)
     fn node_list_trusted(&self) -> bool;
 
+    /// If true, do not need to check src and dst of the edge separately, even if nodes are filtered
+    /// (i.e., edge filter already makes sure there are no edges between non-existent nodes)
+    /// This should be `false` when implementing `NodeFilterOps` without overriding the edge filter.
+    fn edge_filter_includes_node_filter(&self) -> bool;
+
     /// If `true`, node is included in the graph
     fn filter_node(&self, node: NodeStorageRef, layer_ids: &LayerIds) -> bool;
 }
@@ -35,6 +40,11 @@ where
     #[inline]
     fn node_list_trusted(&self) -> bool {
         self.base().node_list_trusted()
+    }
+
+    #[inline]
+    fn edge_filter_includes_node_filter(&self) -> bool {
+        self.base().edge_filter_includes_node_filter()
     }
 
     #[inline]

--- a/raphtory/src/db/graph/views/cached_view.rs
+++ b/raphtory/src/db/graph/views/cached_view.rs
@@ -110,11 +110,6 @@ impl<'graph, G: GraphViewOps<'graph>> EdgeFilterOps for CachedView<G> {
     }
 
     #[inline]
-    fn edge_filter_includes_node_filter(&self) -> bool {
-        true
-    }
-
-    #[inline]
     fn filter_edge(&self, edge: EdgeStorageRef, layer_ids: &LayerIds) -> bool {
         let filter_fn =
             |(_, edges): &(RoaringTreemap, RoaringTreemap)| edges.contains(edge.eid().as_u64());
@@ -135,6 +130,10 @@ impl<'graph, G: GraphViewOps<'graph>> NodeFilterOps for CachedView<G> {
     }
     fn node_list_trusted(&self) -> bool {
         self.graph.node_list_trusted()
+    }
+
+    fn edge_filter_includes_node_filter(&self) -> bool {
+        true
     }
 
     #[inline]

--- a/raphtory/src/db/graph/views/node_subgraph.rs
+++ b/raphtory/src/db/graph/views/node_subgraph.rs
@@ -75,11 +75,6 @@ impl<'graph, G: GraphViewOps<'graph>> EdgeFilterOps for NodeSubgraph<G> {
     }
 
     #[inline]
-    fn edge_filter_includes_node_filter(&self) -> bool {
-        self.graph.edge_filter_includes_node_filter()
-    }
-
-    #[inline]
     fn filter_edge(&self, edge: EdgeStorageRef, layer_ids: &LayerIds) -> bool {
         self.graph.filter_edge(edge, layer_ids)
             && self.nodes.contains(&edge.src())
@@ -96,6 +91,10 @@ impl<'graph, G: GraphViewOps<'graph>> NodeFilterOps for NodeSubgraph<G> {
         true
     }
 
+    #[inline]
+    fn edge_filter_includes_node_filter(&self) -> bool {
+        self.graph.edge_filter_includes_node_filter()
+    }
     #[inline]
     fn filter_node(&self, node: NodeStorageRef, layer_ids: &LayerIds) -> bool {
         self.graph.filter_node(node, layer_ids) && self.nodes.contains(&node.vid())

--- a/raphtory/src/db/graph/views/node_type_filtered_subgraph.rs
+++ b/raphtory/src/db/graph/views/node_type_filtered_subgraph.rs
@@ -52,16 +52,70 @@ impl<'graph, G: GraphViewOps<'graph>> InheritEdgeFilterOps for TypeFilteredSubgr
 impl<'graph, G: GraphViewOps<'graph>> InheritListOps for TypeFilteredSubgraph<G> {}
 
 impl<'graph, G: GraphViewOps<'graph>> NodeFilterOps for TypeFilteredSubgraph<G> {
+    #[inline]
     fn nodes_filtered(&self) -> bool {
         true
     }
 
+    #[inline]
     fn node_list_trusted(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn edge_filter_includes_node_filter(&self) -> bool {
         false
     }
 
     #[inline]
     fn filter_node(&self, node: NodeStorageRef, layer_ids: &LayerIds) -> bool {
         self.node_types.contains(&node.node_type_id()) && self.graph.filter_node(node, layer_ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn test_type_filtered_subgraph() {
+        let graph = Graph::new();
+        graph.add_edge(1, "A", "B", [("p1", 1u64)], None).unwrap();
+        graph.add_edge(2, "B", "C", [("p1", 2u64)], None).unwrap();
+        graph.add_edge(3, "C", "D", [("p1", 3u64)], None).unwrap();
+        graph.add_edge(4, "D", "E", [("p1", 4u64)], None).unwrap();
+
+        graph
+            .add_node(1, "A", [("p1", 1u64)], Some("water_tribe"))
+            .unwrap();
+        graph
+            .add_node(2, "B", [("p1", 2u64)], Some("water_tribe"))
+            .unwrap();
+        graph
+            .add_node(3, "C", [("p1", 1u64)], Some("fire_nation"))
+            .unwrap();
+        graph
+            .add_node(4, "D", [("p1", 1u64)], Some("air_nomads"))
+            .unwrap();
+
+        let type_filtered_subgraph = graph
+            .subgraph_node_types(vec!["fire_nation", "air_nomads"])
+            .window(1, 5);
+
+        assert_eq!(type_filtered_subgraph.nodes(), vec!["C", "D"]);
+
+        assert_eq!(
+            type_filtered_subgraph
+                .filter_nodes(PropertyFilter::eq("p1", 1u64))
+                .unwrap()
+                .nodes(),
+            vec!["C", "D"]
+        );
+
+        assert!(type_filtered_subgraph
+            .filter_edges(PropertyFilter::eq("p1", 1u64))
+            .unwrap()
+            .edges()
+            .is_empty())
     }
 }

--- a/raphtory/src/db/graph/views/property_filter/edge_property_filter.rs
+++ b/raphtory/src/db/graph/views/property_filter/edge_property_filter.rs
@@ -99,10 +99,6 @@ impl<'graph, G: GraphViewOps<'graph>> EdgeFilterOps for EdgePropertyFilteredGrap
         false
     }
 
-    fn edge_filter_includes_node_filter(&self) -> bool {
-        self.graph.edge_filter_includes_node_filter()
-    }
-
     fn filter_edge(&self, edge: EdgeStorageRef, layer_ids: &LayerIds) -> bool {
         if self.graph.filter_edge(edge, layer_ids) {
             let props = EdgeView::new(&self.graph, edge.out_ref()).properties();

--- a/raphtory/src/db/graph/views/property_filter/exploded_edge_property_filter.rs
+++ b/raphtory/src/db/graph/views/property_filter/exploded_edge_property_filter.rs
@@ -131,10 +131,6 @@ impl<'graph, G: GraphViewOps<'graph>> EdgeFilterOps for ExplodedEdgePropertyFilt
         false
     }
 
-    fn edge_filter_includes_node_filter(&self) -> bool {
-        self.graph.edge_filter_includes_node_filter()
-    }
-
     fn filter_edge(&self, edge: EdgeStorageRef, layer_ids: &LayerIds) -> bool {
         self.graph.filter_edge(edge, layer_ids)
             && self

--- a/raphtory/src/db/graph/views/property_filter/node_property_filter.rs
+++ b/raphtory/src/db/graph/views/property_filter/node_property_filter.rs
@@ -91,14 +91,22 @@ impl<'graph, G: GraphViewOps<'graph>> InheritPropertiesOps for NodePropertyFilte
 impl<'graph, G: GraphViewOps<'graph>> InheritTimeSemantics for NodePropertyFilteredGraph<G> {}
 
 impl<'graph, G: GraphViewOps<'graph>> NodeFilterOps for NodePropertyFilteredGraph<G> {
+    #[inline]
     fn nodes_filtered(&self) -> bool {
         true
     }
 
+    #[inline]
     fn node_list_trusted(&self) -> bool {
         false
     }
 
+    #[inline]
+    fn edge_filter_includes_node_filter(&self) -> bool {
+        false
+    }
+
+    #[inline]
     fn filter_node(&self, node: NodeStorageRef, layer_ids: &LayerIds) -> bool {
         if self.graph.filter_node(node, layer_ids) {
             let props = NodeView::new_internal(&self.graph, node.vid()).properties();

--- a/raphtory/src/db/graph/views/window_graph.rs
+++ b/raphtory/src/db/graph/views/window_graph.rs
@@ -161,16 +161,21 @@ impl<'graph, G: GraphViewOps<'graph>> ListOps for WindowedGraph<G> {
 
 impl<'graph, G: GraphViewOps<'graph>> NodeFilterOps for WindowedGraph<G> {
     #[inline]
-    fn node_list_trusted(&self) -> bool {
-        self.window_is_empty() || self.graph.node_list_trusted() && !self.nodes_filtered()
-    }
-
-    #[inline]
     fn nodes_filtered(&self) -> bool {
         self.window_is_empty()
             || self.graph.nodes_filtered()
             || self.start_bound() > self.core_graph().earliest_time().unwrap_or(i64::MAX)
             || self.end_bound() <= self.core_graph().latest_time().unwrap_or(i64::MIN)
+    }
+
+    #[inline]
+    fn node_list_trusted(&self) -> bool {
+        self.window_is_empty() || self.graph.node_list_trusted() && !self.nodes_filtered()
+    }
+
+    #[inline]
+    fn edge_filter_includes_node_filter(&self) -> bool {
+        self.window_is_empty() || self.graph.edge_filter_includes_node_filter()
     }
 
     #[inline]
@@ -642,11 +647,6 @@ impl<'graph, G: GraphViewOps<'graph>> EdgeFilterOps for WindowedGraph<G> {
     #[inline]
     fn edge_list_trusted(&self) -> bool {
         self.window_is_empty()
-    }
-
-    #[inline]
-    fn edge_filter_includes_node_filter(&self) -> bool {
-        self.window_is_empty() || self.graph.edge_filter_includes_node_filter()
     }
 
     #[inline]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `NodeFilterOps` and `EdgeFilterOps` such that implementing `NodeFilterOps` without also implementing `EdgeFilterOps` works correctly.

### Why are the changes needed?

Fixes #1948 

### Does this PR introduce any user-facing change? If yes is this documented?

No, just a bug fix

### How was this patch tested?

Added a test for the nested filters

### Are there any further changes required?




