### PR TITLE
try to optimise edges for subgraph

### DIFF
--- a/python/tests/test_graphql/misc/test_map_props.py
+++ b/python/tests/test_graphql/misc/test_map_props.py
@@ -2,7 +2,14 @@ import tempfile
 from raphtory.graphql import GraphServer, RaphtoryClient
 from raphtory import Graph
 
-TEST_PROPS = {"number": 1, "string": "text", "numbers": [1, 14], "strings": ["a", "text"], "map": {"a": 1}}
+TEST_PROPS = {
+    "number": 1,
+    "string": "text",
+    "numbers": [1, 14],
+    "strings": ["a", "text"],
+    "map": {"a": 1},
+}
+
 
 def test_map_props():
     work_dir = tempfile.mkdtemp()
@@ -28,6 +35,7 @@ def test_map_props():
         node = rg.add_node(0, "test")
         node.add_constant_properties({"test": TEST_PROPS})
         check_test_prop(client)
+
 
 def check_test_prop(client: RaphtoryClient):
     query = """{


### PR DESCRIPTION
### What changes were proposed in this pull request?

Calling `edges` on a subgraph should no longer iterate over all edges in the entire graph to apply the subgraph filter.

### Why are the changes needed?

Subgraph `edges` was slow on large graphs.

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

The tests

### Are there any further changes required?


