### PR TITLE
make sure not to scramble the output values for subgraphs that have a non-standard node order

### DIFF
--- a/raphtory/src/db/api/state/node_state.rs
+++ b/raphtory/src/db/api/state/node_state.rs
@@ -201,14 +201,13 @@ impl<'graph, V, G: GraphViewOps<'graph>> NodeState<'graph, V, G> {
     /// - `graph`: the graph view
     /// - `values`: the unfiltered values (i.e., `values.len() == graph.unfiltered_num_nodes()`). This method handles the filtering.
     /// - `map`: Closure mapping input to output values
-    pub fn new_from_eval_mapped<R>(graph: G, values: Vec<R>, map: impl Fn(R) -> V) -> Self {
+    pub fn new_from_eval_mapped<R: Clone>(graph: G, values: Vec<R>, map: impl Fn(R) -> V) -> Self {
         let index = Index::for_graph(graph.clone());
         let values = match &index {
             None => values.into_iter().map(map).collect(),
-            Some(index) => values
-                .into_iter()
-                .enumerate()
-                .filter_map(|(i, v)| index.contains(&VID(i)).then(|| map(v)))
+            Some(index) => index
+                .iter()
+                .map(|vid| map(values[vid.index()].clone()))
                 .collect(),
         };
         Self::new(graph.clone(), graph, values, index)

--- a/raphtory/src/db/graph/views/node_subgraph.rs
+++ b/raphtory/src/db/graph/views/node_subgraph.rs
@@ -116,10 +116,16 @@ impl<'graph, G: GraphViewOps<'graph>> ListOps for NodeSubgraph<G> {
 #[cfg(test)]
 mod subgraph_tests {
     use crate::{
-        algorithms::motifs::triangle_count::triangle_count, db::graph::graph::assert_graph_equal,
-        prelude::*, test_storage,
+        algorithms::{
+            components::weakly_connected_components, motifs::triangle_count::triangle_count,
+        },
+        db::graph::graph::assert_graph_equal,
+        prelude::*,
+        test_storage,
     };
+    use ahash::{HashSet, HashSetExt};
     use itertools::Itertools;
+    use std::collections::BTreeSet;
 
     #[test]
     fn test_materialize_no_edges() {
@@ -189,5 +195,30 @@ mod subgraph_tests {
                 sgm.unique_layers().collect_vec()
             );
         });
+    }
+
+    #[test]
+    fn test_cc() {
+        let graph = Graph::new();
+        graph.add_node(0, 0, NO_PROPS, None).unwrap();
+        graph.add_node(0, 3, NO_PROPS, None).unwrap();
+        graph.add_node(1, 2, NO_PROPS, None).unwrap();
+        graph.add_node(1, 4, NO_PROPS, None).unwrap();
+        graph.add_edge(0, 0, 1, NO_PROPS, Some("1")).unwrap();
+        graph.add_edge(1, 3, 4, NO_PROPS, Some("1")).unwrap();
+        let sg = graph.subgraph([0, 1, 3, 4]);
+        let cc = weakly_connected_components(&sg, 100, None);
+        let groups = cc.groups();
+        let group_sets = groups
+            .iter()
+            .map(|(_, g)| g.id().into_iter_values().collect::<BTreeSet<_>>())
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            group_sets,
+            HashSet::from_iter([
+                BTreeSet::from([GID::U64(0), GID::U64(1)]),
+                BTreeSet::from([GID::U64(3), GID::U64(4)])
+            ])
+        );
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The new NodeState had a bug where it would scramble the order of values for subgraphs if they have a node order that is different from the underlying graph

### Why are the changes needed?

Some algorithms were returning nonsensical results on subgraphs 

### Does this PR introduce any user-facing change? If yes is this documented?

bug fix

### How was this patch tested?

added a test for connected components on subgraph that reproduces the issue

### Are there any further changes required?


