### PR TITLE
Basic creation/updating of metadata in .raph for MetaGraph

### DIFF
--- a/.github/workflows/test_rust_disk_storage_workflow.yml
+++ b/.github/workflows/test_rust_disk_storage_workflow.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - { os: macos-latest, flags: "" }
-          - { os: ubuntu-20.04, flags: "-C link-arg=-fuse-ld=lld" }
+          - { os: ubuntu-latest, flags: "-C link-arg=-fuse-ld=lld" }
           - { os: windows-latest, flags: "" }
     steps:
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test_rust_workflow.yml
+++ b/.github/workflows/test_rust_workflow.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
           - os: windows-latest
     steps:
       - uses: maxim-lobanov/setup-xcode@v1

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -920,7 +920,7 @@ mod graphql_test {
         let mut req = Request::new(query).variables(Variables::from_json(variables));
         req.set_upload("variables.file", upload_val);
         let res = schema.execute(req).await;
-        assert_eq!(res.errors.len(), 0);
+        assert_eq!(res.errors, vec![]);
         let res_json = res.data.into_json().unwrap();
         assert_eq!(res_json, json!({"uploadGraph": "test"}));
 

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -1330,11 +1330,11 @@ mod graphql_test {
                     "path": "",
                     "graphs": [
                         {
-                            "path": "graph2",
-                            "name": "graph2",
+                            "path": "graph",
+                            "name": "graph",
                             "metadata": {
-                                "nodeCount": 2,
-                                "edgeCount": 1,
+                                "nodeCount": 6,
+                                "edgeCount": 6,
                                 "properties": [
                                     {
                                         "key": "name",
@@ -1344,11 +1344,11 @@ mod graphql_test {
                             }
                         },
                         {
-                            "path": "graph",
-                            "name": "graph",
+                            "path": "graph2",
+                            "name": "graph2",
                             "metadata": {
-                                "nodeCount": 6,
-                                "edgeCount": 6,
+                                "nodeCount": 2,
+                                "edgeCount": 1,
                                 "properties": [
                                     {
                                         "key": "name",

--- a/raphtory-graphql/src/model/graph/meta_graph.rs
+++ b/raphtory-graphql/src/model/graph/meta_graph.rs
@@ -1,7 +1,8 @@
-use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
-use raphtory::core::utils::errors::GraphError;
-
+use crate::model::graph::property::GqlProp;
 use crate::paths::ExistingGraphFolder;
+use dynamic_graphql::{ResolvedObject, ResolvedObjectFields, SimpleObject};
+use raphtory::core::utils::errors::GraphError;
+use raphtory::serialise::metadata::GraphMetadata;
 
 #[derive(ResolvedObject)]
 pub(crate) struct MetaGraph {
@@ -30,5 +31,30 @@ impl MetaGraph {
     }
     async fn last_updated(&self) -> Result<i64, GraphError> {
         self.folder.last_updated()
+    }
+    async fn metadata(&self) -> Result<GqlGraphMetadata, GraphError> {
+        let metadata = self.folder.read_metadata()?;
+        Ok(GqlGraphMetadata::from(metadata))
+    }
+}
+
+#[derive(Clone, SimpleObject)]
+pub(crate) struct GqlGraphMetadata {
+    pub(crate) node_count: usize,
+    pub(crate) edge_count: usize,
+    pub(crate) properties: Vec<GqlProp>,
+}
+
+impl From<GraphMetadata> for GqlGraphMetadata {
+    fn from(metadata: GraphMetadata) -> Self {
+        GqlGraphMetadata {
+            node_count: metadata.node_count,
+            edge_count: metadata.edge_count,
+            properties: metadata
+                .properties
+                .into_iter()
+                .map(|(key, prop)| GqlProp::new(key.to_string(), prop))
+                .collect(),
+        }
     }
 }

--- a/raphtory-graphql/src/model/graph/meta_graph.rs
+++ b/raphtory-graphql/src/model/graph/meta_graph.rs
@@ -1,8 +1,6 @@
-use crate::model::graph::property::GqlProp;
-use crate::paths::ExistingGraphFolder;
+use crate::{model::graph::property::GqlProp, paths::ExistingGraphFolder};
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields, SimpleObject};
-use raphtory::core::utils::errors::GraphError;
-use raphtory::serialise::metadata::GraphMetadata;
+use raphtory::{core::utils::errors::GraphError, serialise::metadata::GraphMetadata};
 
 #[derive(ResolvedObject)]
 pub(crate) struct MetaGraph {

--- a/raphtory-graphql/src/model/graph/namespace.rs
+++ b/raphtory-graphql/src/model/graph/namespace.rs
@@ -1,8 +1,7 @@
-use crate::paths::ValidGraphFolder;
 use crate::{
     data::get_relative_path,
     model::graph::meta_graph::MetaGraph,
-    paths::{valid_path, ExistingGraphFolder},
+    paths::{valid_path, ExistingGraphFolder, ValidGraphFolder},
 };
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
 use itertools::Itertools;

--- a/raphtory-graphql/src/model/graph/namespace.rs
+++ b/raphtory-graphql/src/model/graph/namespace.rs
@@ -1,9 +1,11 @@
+use crate::paths::ValidGraphFolder;
 use crate::{
     data::get_relative_path,
     model::graph::meta_graph::MetaGraph,
     paths::{valid_path, ExistingGraphFolder},
 };
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields};
+use itertools::Itertools;
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
@@ -60,7 +62,14 @@ impl Namespace {
 impl Namespace {
     async fn graphs(&self) -> Vec<MetaGraph> {
         self.get_all_graph_folders()
-            .iter()
+            .into_iter()
+            .sorted_by(|a, b| {
+                let a_as_valid_folder: ValidGraphFolder = a.clone().into();
+                let b_as_valid_folder: ValidGraphFolder = b.clone().into();
+                a_as_valid_folder
+                    .get_original_path_str()
+                    .cmp(b_as_valid_folder.get_original_path_str())
+            })
             .map(|g| MetaGraph::new(g.clone()))
             .collect()
     }

--- a/raphtory-graphql/src/model/graph/property.rs
+++ b/raphtory-graphql/src/model/graph/property.rs
@@ -1,7 +1,5 @@
 use async_graphql::{Error, Name, Value as GqlValue};
-use dynamic_graphql::{
-    InputObject, ResolvedObject, ResolvedObjectFields, Scalar, ScalarValue,
-};
+use dynamic_graphql::{InputObject, ResolvedObject, ResolvedObjectFields, Scalar, ScalarValue};
 use itertools::Itertools;
 use raphtory::{
     core::{utils::errors::GraphError, IntoPropMap, Prop},

--- a/raphtory-graphql/src/model/graph/property.rs
+++ b/raphtory-graphql/src/model/graph/property.rs
@@ -1,7 +1,6 @@
 use async_graphql::{Error, Name, Value as GqlValue};
 use dynamic_graphql::{
-    internal::{InputObject, Resolve},
-    Enum, InputObject, ResolvedObject, ResolvedObjectFields, Scalar, ScalarValue,
+    InputObject, ResolvedObject, ResolvedObjectFields, Scalar, ScalarValue,
 };
 use itertools::Itertools;
 use raphtory::{

--- a/raphtory-graphql/src/model/graph/property.rs
+++ b/raphtory-graphql/src/model/graph/property.rs
@@ -144,7 +144,7 @@ fn prop_to_gql(prop: &Prop) -> GqlValue {
     }
 }
 
-#[derive(ResolvedObject)]
+#[derive(Clone, ResolvedObject)]
 pub(crate) struct GqlProp {
     key: String,
     prop: Prop,
@@ -354,7 +354,7 @@ impl GqlProperties {
         self.props.temporal().into()
     }
 
-    async fn constant(&self) -> GqlConstantProperties {
+    pub(crate) async fn constant(&self) -> GqlConstantProperties {
         self.props.constant().into()
     }
 }
@@ -373,7 +373,7 @@ impl GqlConstantProperties {
         self.props.keys().map(|k| k.clone().into()).collect()
     }
 
-    async fn values(&self, keys: Option<Vec<String>>) -> Vec<GqlProp> {
+    pub(crate) async fn values(&self, keys: Option<Vec<String>>) -> Vec<GqlProp> {
         match keys {
             Some(keys) => self
                 .props

--- a/raphtory-graphql/src/paths.rs
+++ b/raphtory-graphql/src/paths.rs
@@ -1,13 +1,12 @@
+use raphtory::{
+    core::utils::errors::{GraphError, InvalidPathReason, InvalidPathReason::*},
+    serialise::GraphFolder,
+};
 use std::{
     fs,
     ops::Deref,
     path::{Component, Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
-};
-
-use raphtory::{
-    core::utils::errors::{GraphError, InvalidPathReason, InvalidPathReason::*},
-    serialise::GraphFolder,
 };
 
 #[derive(Clone, Debug)]
@@ -34,7 +33,6 @@ impl From<ExistingGraphFolder> for GraphFolder {
         value.folder.folder
     }
 }
-
 impl ExistingGraphFolder {
     pub(crate) fn try_from(base_path: PathBuf, relative_path: &str) -> Result<Self, GraphError> {
         let graph_folder = ValidGraphFolder::try_from(base_path, relative_path)?;
@@ -70,6 +68,12 @@ impl ExistingGraphFolder {
 pub struct ValidGraphFolder {
     original_path: String,
     folder: GraphFolder,
+}
+
+impl From<ExistingGraphFolder> for ValidGraphFolder {
+    fn from(value: ExistingGraphFolder) -> Self {
+        value.folder
+    }
 }
 
 impl Deref for ValidGraphFolder {

--- a/raphtory/src/core/utils/errors.rs
+++ b/raphtory/src/core/utils/errors.rs
@@ -316,8 +316,8 @@ pub enum GraphError {
     TqdmError,
     #[error("An error when parsing Jinja query templates: {0}")]
     JinjaError(String),
-    #[error("An error when parsing the data to json")]
-    SerdeError,
+    #[error("An error when parsing the data to json: {0}")]
+    SerdeError(#[from] serde_json::Error),
     #[error("System time error: {0}")]
     SystemTimeError(#[from] SystemTimeError),
     #[error("Property filtering not implemented on PersistentGraph yet")]

--- a/raphtory/src/db/api/storage/storage.rs
+++ b/raphtory/src/db/api/storage/storage.rs
@@ -122,10 +122,8 @@ impl Storage {
     /// Initialise the cache by pointing it at a proto file.
     /// Future updates will be appended to the cache.
     pub(crate) fn init_cache(&self, path: &GraphFolder) -> Result<(), GraphError> {
-        self.cache.get_or_try_init(|| {
-            let file = path.get_appendable_graph_file()?;
-            Ok::<_, GraphError>(GraphWriter::new(file))
-        })?;
+        self.cache
+            .get_or_try_init(|| Ok::<_, GraphError>(GraphWriter::new(path.clone())?))?;
         Ok(())
     }
 

--- a/raphtory/src/serialise/incremental.rs
+++ b/raphtory/src/serialise/incremental.rs
@@ -292,7 +292,7 @@ impl InternalCache for MaterializedGraph {
     }
 }
 
-impl<'graph, G: InternalCache + StableDecode + StableEncode<'graph>> CacheOps for G {
+impl<G: InternalCache + StableDecode + StableEncode> CacheOps for G {
     fn cache(&self, path: impl Into<GraphFolder>) -> Result<(), GraphError> {
         let folder = path.into();
         self.encode(&folder)?;

--- a/raphtory/src/serialise/metadata.rs
+++ b/raphtory/src/serialise/metadata.rs
@@ -1,6 +1,4 @@
-use crate::core::Prop;
-use crate::prelude::GraphViewOps;
-use crate::serialise::GraphFolder;
+use crate::{core::Prop, prelude::GraphViewOps, serialise::GraphFolder};
 use raphtory_api::core::storage::arc_str::ArcStr;
 use serde::{Deserialize, Serialize};
 

--- a/raphtory/src/serialise/metadata.rs
+++ b/raphtory/src/serialise/metadata.rs
@@ -4,7 +4,7 @@ use crate::serialise::GraphFolder;
 use raphtory_api::core::storage::arc_str::ArcStr;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(PartialEq, Serialize, Deserialize, Debug)]
 pub struct GraphMetadata {
     pub node_count: usize,
     pub edge_count: usize,

--- a/raphtory/src/serialise/metadata.rs
+++ b/raphtory/src/serialise/metadata.rs
@@ -1,0 +1,19 @@
+use crate::core::Prop;
+use crate::prelude::GraphViewOps;
+use crate::serialise::GraphFolder;
+use raphtory_api::core::storage::arc_str::ArcStr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct GraphMetadata {
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub properties: Vec<(ArcStr, Prop)>,
+}
+
+pub fn assert_metadata_correct<'graph>(folder: &GraphFolder, graph: &impl GraphViewOps<'graph>) {
+    let metadata = folder.read_metadata().unwrap();
+    assert_eq!(metadata.node_count, graph.count_nodes());
+    assert_eq!(metadata.edge_count, graph.count_edges());
+    assert_eq!(metadata.properties, graph.properties().as_vec());
+}

--- a/raphtory/src/serialise/mod.rs
+++ b/raphtory/src/serialise/mod.rs
@@ -11,16 +11,15 @@ mod proto {
     include!(concat!(env!("OUT_DIR"), "/serialise.rs"));
 }
 
-use crate::core::utils::errors::GraphError;
-use crate::db::api::view::MaterializedGraph;
-use crate::prelude::GraphViewOps;
-use crate::serialise::metadata::GraphMetadata;
+use crate::{
+    core::utils::errors::GraphError, db::api::view::MaterializedGraph, prelude::GraphViewOps,
+    serialise::metadata::GraphMetadata,
+};
 pub use proto::Graph as ProtoGraph;
 pub use serialise::{CacheOps, StableDecode, StableEncode};
-use std::io::{BufReader, ErrorKind};
 use std::{
     fs::{self, File, OpenOptions},
-    io::{self, Read, Write},
+    io::{self, BufReader, ErrorKind, Read, Write},
     path::{Path, PathBuf},
 };
 use tracing::info;
@@ -210,10 +209,9 @@ impl From<&GraphFolder> for GraphFolder {
 #[cfg(test)]
 mod zip_tests {
     use super::{StableDecode, StableEncode};
-    use crate::serialise::metadata::GraphMetadata;
     use crate::{
         prelude::{AdditionOps, CacheOps, Graph, GraphViewOps, NO_PROPS},
-        serialise::GraphFolder,
+        serialise::{metadata::GraphMetadata, GraphFolder},
     };
     use raphtory_api::core::utils::logging::global_info_logger;
 

--- a/raphtory/src/serialise/mod.rs
+++ b/raphtory/src/serialise/mod.rs
@@ -91,12 +91,12 @@ impl GraphFolder {
         }
     }
 
-    pub fn write_graph<'graph>(&self, graph: &impl StableEncode<'graph>) -> Result<(), GraphError> {
+    pub fn write_graph(&self, graph: &impl StableEncode) -> Result<(), GraphError> {
         self.write_graph_data(graph)?;
         self.write_metadata(graph)
     }
 
-    fn write_graph_data<'graph>(&self, graph: &impl StableEncode<'graph>) -> Result<(), io::Error> {
+    fn write_graph_data(&self, graph: &impl StableEncode) -> Result<(), io::Error> {
         let bytes = graph.encode_to_vec();
         if self.prefer_zip_format {
             let file = File::create(&self.root_folder)?;

--- a/raphtory/src/serialise/serialise.rs
+++ b/raphtory/src/serialise/serialise.rs
@@ -1,5 +1,5 @@
 use super::{proto_ext::PropTypeExt, GraphFolder};
-use crate::prelude::GraphViewOps;
+use crate::db::api::view::StaticGraphViewOps;
 use crate::{
     core::{
         entities::{graph::tgraph::TemporalGraph, LayerIds},
@@ -42,7 +42,7 @@ macro_rules! zip_tprop_updates {
     };
 }
 
-pub trait StableEncode<'graph>: GraphViewOps<'graph> {
+pub trait StableEncode: StaticGraphViewOps {
     fn encode_to_proto(&self) -> proto::Graph;
     fn encode_to_vec(&self) -> Vec<u8> {
         self.encode_to_proto().encode_to_vec()
@@ -79,7 +79,7 @@ pub trait CacheOps: Sized {
     fn load_cached(path: impl Into<GraphFolder>) -> Result<Self, GraphError>;
 }
 
-impl<'graph> StableEncode<'graph> for GraphStorage {
+impl StableEncode for GraphStorage {
     fn encode_to_proto(&self) -> proto::Graph {
         let storage = self.lock();
         let mut graph = proto::Graph::default();
@@ -229,7 +229,7 @@ impl<'graph> StableEncode<'graph> for GraphStorage {
     }
 }
 
-impl<'graph> StableEncode<'graph> for Graph {
+impl StableEncode for Graph {
     fn encode_to_proto(&self) -> proto::Graph {
         let mut graph = self.core_graph().encode_to_proto();
         graph.set_graph_type(proto::GraphType::Event);
@@ -237,7 +237,7 @@ impl<'graph> StableEncode<'graph> for Graph {
     }
 }
 
-impl<'graph> StableEncode<'graph> for PersistentGraph {
+impl StableEncode for PersistentGraph {
     fn encode_to_proto(&self) -> proto::Graph {
         let mut graph = self.core_graph().encode_to_proto();
         graph.set_graph_type(proto::GraphType::Persistent);
@@ -245,7 +245,7 @@ impl<'graph> StableEncode<'graph> for PersistentGraph {
     }
 }
 
-impl<'graph> StableEncode<'graph> for MaterializedGraph {
+impl StableEncode for MaterializedGraph {
     fn encode_to_proto(&self) -> proto::Graph {
         match self {
             MaterializedGraph::EventGraph(graph) => graph.encode_to_proto(),

--- a/raphtory/src/serialise/serialise.rs
+++ b/raphtory/src/serialise/serialise.rs
@@ -49,11 +49,8 @@ pub trait StableEncode<'graph>: GraphViewOps<'graph> {
     }
 
     fn encode(&self, path: impl Into<GraphFolder>) -> Result<(), GraphError> {
-        let bytes = self.encode_to_vec();
         let folder = path.into();
-        folder.write_graph(&bytes)?;
-        folder.write_metadata(self)?;
-        Ok(())
+        folder.write_graph(self)
     }
 }
 

--- a/raphtory/src/serialise/serialise.rs
+++ b/raphtory/src/serialise/serialise.rs
@@ -1,5 +1,4 @@
 use super::{proto_ext::PropTypeExt, GraphFolder};
-use crate::db::api::view::StaticGraphViewOps;
 use crate::{
     core::{
         entities::{graph::tgraph::TemporalGraph, LayerIds},
@@ -13,7 +12,7 @@ use crate::{
                 edges::edge_storage_ops::EdgeStorageOps, nodes::node_storage_ops::NodeStorageOps,
                 storage_ops::GraphStorage, tprop_storage_ops::TPropOps,
             },
-            view::{internal::CoreGraphOps, MaterializedGraph},
+            view::{internal::CoreGraphOps, MaterializedGraph, StaticGraphViewOps},
         },
         graph::views::deletion_graph::PersistentGraph,
     },
@@ -661,14 +660,13 @@ mod proto_test {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::serialise::metadata::assert_metadata_correct;
     use crate::{
         db::{
             api::{mutation::DeletionOps, properties::internal::ConstPropertiesOps},
             graph::graph::assert_graph_equal,
         },
         prelude::*,
-        serialise::{proto::GraphType, ProtoGraph},
+        serialise::{metadata::assert_metadata_correct, proto::GraphType, ProtoGraph},
         test_utils::{build_edge_list, build_graph_from_edge_list},
     };
     use chrono::{DateTime, NaiveDateTime};


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add functions hooking into graph creation and graph writes to create/update metadata within the .raph file, which can then be fetched from the MetaGraph resource from GraphQL.

This metadata currently consists of:
- node count
- edge count
- graph properties

### Why are the changes needed?

To provide an endpoint to fetch this information without having to decode and fetch the full graph.

### Does this PR introduce any user-facing change? If yes is this documented?

A new endpoint is provided from GQL, and the new behavior will modify the .raph file, but should not be a breaking change for users.

### How was this patch tested?

Tests added to raphtory-graphql to test that the metadata is created/updated and can be fetched via MetaGraph (as well as namespaces in general), and also tests were added to check that the right behavior happens if an invalid .raph file exists.

### Are there any further changes required?

None unless more complex metadata is required in the future, or a more complex storage method is needed.