### PR TITLE
add option to output graphql schema

### DIFF
--- a/raphtory-graphql/src/main.rs
+++ b/raphtory-graphql/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{command, Parser};
+use clap::{command, Parser, Subcommand};
 use raphtory_graphql::{
     config::{
         app_config::AppConfigBuilder,
@@ -54,16 +54,26 @@ struct Args {
     #[arg(long, default_value_t = DEFAULT_AUTH_ENABLED_FOR_READS)]
     auth_enabled_for_reads: bool,
 
-    #[arg(long, default_value = None)]
-    output_schema: Option<String>,
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    #[command(about = "Writes the GraphQL schema into the given path")]
+    Schema {
+        #[arg(value_parser)]
+        path: String,
+    },
 }
 
 #[tokio::main]
 async fn main() -> IoResult<()> {
     let args = Args::parse();
-    if let Some(output_schema) = args.output_schema {
+
+    if let Some(Commands::Schema { path }) = args.command {
         let schema = App::create_schema().finish().unwrap();
-        std::fs::write(output_schema, schema.sdl()).unwrap();
+        std::fs::write(path, schema.sdl()).unwrap();
     } else {
         let app_config = Some(
             AppConfigBuilder::new()

--- a/raphtory-graphql/src/main.rs
+++ b/raphtory-graphql/src/main.rs
@@ -60,20 +60,17 @@ struct Args {
 
 #[derive(Subcommand)]
 enum Commands {
-    #[command(about = "Writes the GraphQL schema into the given path")]
-    Schema {
-        #[arg(value_parser)]
-        path: String,
-    },
+    #[command(about = "Print the GraphQL schema to the standard output")]
+    Schema,
 }
 
 #[tokio::main]
 async fn main() -> IoResult<()> {
     let args = Args::parse();
 
-    if let Some(Commands::Schema { path }) = args.command {
+    if let Some(Commands::Schema) = args.command {
         let schema = App::create_schema().finish().unwrap();
-        std::fs::write(path, schema.sdl()).unwrap();
+        println!("{}", schema.sdl());
     } else {
         let app_config = Some(
             AppConfigBuilder::new()

--- a/raphtory-graphql/src/main.rs
+++ b/raphtory-graphql/src/main.rs
@@ -10,6 +10,7 @@ use raphtory_graphql::{
             DEFAULT_TRACING_ENABLED,
         },
     },
+    model::App,
     server::DEFAULT_PORT,
     GraphServer,
 };
@@ -52,29 +53,36 @@ struct Args {
 
     #[arg(long, default_value_t = DEFAULT_AUTH_ENABLED_FOR_READS)]
     auth_enabled_for_reads: bool,
+
+    #[arg(long, default_value = None)]
+    output_schema: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> IoResult<()> {
     let args = Args::parse();
+    if let Some(output_schema) = args.output_schema {
+        let schema = App::create_schema().finish().unwrap();
+        std::fs::write(output_schema, schema.sdl()).unwrap();
+    } else {
+        let app_config = Some(
+            AppConfigBuilder::new()
+                .with_cache_capacity(args.cache_capacity)
+                .with_cache_tti_seconds(args.cache_tti_seconds)
+                .with_log_level(args.log_level)
+                .with_tracing(args.tracing)
+                .with_otlp_agent_host(args.otlp_agent_host)
+                .with_otlp_agent_port(args.otlp_agent_port)
+                .with_otlp_tracing_service_name(args.otlp_tracing_service_name)
+                .with_auth_public_key(args.auth_public_key)
+                .expect(PUBLIC_KEY_DECODING_ERR_MSG)
+                .with_auth_enabled_for_reads(args.auth_enabled_for_reads)
+                .build(),
+        );
 
-    let app_config = Some(
-        AppConfigBuilder::new()
-            .with_cache_capacity(args.cache_capacity)
-            .with_cache_tti_seconds(args.cache_tti_seconds)
-            .with_log_level(args.log_level)
-            .with_tracing(args.tracing)
-            .with_otlp_agent_host(args.otlp_agent_host)
-            .with_otlp_agent_port(args.otlp_agent_port)
-            .with_otlp_tracing_service_name(args.otlp_tracing_service_name)
-            .with_auth_public_key(args.auth_public_key)
-            .expect(PUBLIC_KEY_DECODING_ERR_MSG)
-            .with_auth_enabled_for_reads(args.auth_enabled_for_reads)
-            .build(),
-    );
-
-    GraphServer::new(args.working_dir, app_config, None)?
-        .run_with_port(args.port)
-        .await?;
+        GraphServer::new(args.working_dir, app_config, None)?
+            .run_with_port(args.port)
+            .await?;
+    }
     Ok(())
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds a new option so that running the graphql binary with:
```bash
raphtory-graphql schema > schema.graphql
```

Will create the file in the given path containing the graphql schema. It won't run the server in this case and will ignore any other option.

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?
No docstrings currently for the graphql binary

### How was this patch tested?
Tested manually

### Are there any further changes required?
No


