### PR TITLE
add utf8view support for proptype conversion from arrow datatype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4400,6 +4400,37 @@ name = "pometry-storage"
 version = "0.15.1"
 
 [[package]]
+name = "pometry-storage-private"
+version = "0.12.1"
+dependencies = [
+ "ahash",
+ "bincode",
+ "bytemuck",
+ "criterion",
+ "itertools 0.12.1",
+ "kdam",
+ "memmap2 0.9.5",
+ "once_cell",
+ "parking_lot",
+ "polars-arrow",
+ "polars-parquet",
+ "polars-utils",
+ "pretty_assertions",
+ "proptest",
+ "rand 0.8.5",
+ "raphtory-api",
+ "rayon",
+ "serde",
+ "serde_json",
+ "strum",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
+ "twox-hash 1.6.3",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4877,7 +4908,7 @@ dependencies = [
  "polars-core",
  "polars-io",
  "polars-parquet",
- "pometry-storage",
+ "pometry-storage-private",
  "pretty_assertions",
  "proptest",
  "prost",
@@ -4971,7 +5002,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "polars-arrow",
- "pometry-storage",
+ "pometry-storage-private",
  "pretty_assertions",
  "proptest",
  "raphtory",
@@ -6542,6 +6573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ debug = 0
 
 [workspace.dependencies]
 #[public-storage]
-pometry-storage = { version = ">=0.8.1", path = "pometry-storage" }
+# pometry-storage = { version = ">=0.8.1", path = "pometry-storage" }
 #[private-storage]
-# pometry-storage = { path = "pometry-storage-private", package = "pometry-storage-private" }
+pometry-storage = { path = "pometry-storage-private", package = "pometry-storage-private" }
 async-graphql = { version = "7.0.13", features = ["dynamic-schema"] }
 bincode = "1.3.3"
 async-graphql-poem = "7.0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ debug = 0
 
 [workspace.dependencies]
 #[public-storage]
-# pometry-storage = { version = ">=0.8.1", path = "pometry-storage" }
+pometry-storage = { version = ">=0.8.1", path = "pometry-storage" }
 #[private-storage]
-pometry-storage = { path = "pometry-storage-private", package = "pometry-storage-private" }
+# pometry-storage = { path = "pometry-storage-private", package = "pometry-storage-private" }
 async-graphql = { version = "7.0.13", features = ["dynamic-schema"] }
 bincode = "1.3.3"
 async-graphql-poem = "7.0.13"

--- a/raphtory-api/src/core/mod.rs
+++ b/raphtory-api/src/core/mod.rs
@@ -135,6 +135,7 @@ impl From<&DataType> for PropType {
         match value {
             DataType::Utf8 => PropType::Str,
             DataType::LargeUtf8 => PropType::Str,
+            DataType::Utf8View => PropType::Str,
             DataType::UInt8 => PropType::U8,
             DataType::UInt16 => PropType::U16,
             DataType::Int32 => PropType::I32,
@@ -143,6 +144,7 @@ impl From<&DataType> for PropType {
             DataType::UInt64 => PropType::U64,
             DataType::Float32 => PropType::F32,
             DataType::Float64 => PropType::F64,
+            DataType::Decimal(_, scale) => PropType::Decimal { scale: *scale as i64 },
             DataType::Boolean => PropType::Bool,
 
             _ => PropType::Empty,

--- a/raphtory-api/src/core/mod.rs
+++ b/raphtory-api/src/core/mod.rs
@@ -144,7 +144,9 @@ impl From<&DataType> for PropType {
             DataType::UInt64 => PropType::U64,
             DataType::Float32 => PropType::F32,
             DataType::Float64 => PropType::F64,
-            DataType::Decimal(_, scale) => PropType::Decimal { scale: *scale as i64 },
+            DataType::Decimal(_, scale) => PropType::Decimal {
+                scale: *scale as i64,
+            },
             DataType::Boolean => PropType::Bool,
 
             _ => PropType::Empty,

--- a/raphtory/src/core/mod.rs
+++ b/raphtory/src/core/mod.rs
@@ -339,7 +339,7 @@ pub fn arrow_dtype_from_prop_type(prop_type: &PropType) -> Result<DataType, Grap
 
 pub fn prop_type_from_arrow_dtype(arrow_dtype: &DataType) -> PropType {
     match arrow_dtype {
-        DataType::LargeUtf8 | DataType::Utf8 => PropType::Str,
+        DataType::LargeUtf8 | DataType::Utf8 | DataType::Utf8View => PropType::Str,
         DataType::UInt8 => PropType::U8,
         DataType::UInt16 => PropType::U16,
         DataType::Int32 => PropType::I32,


### PR DESCRIPTION
### What changes were proposed in this pull request?
adding case for utf8view to proptype conversion from arrow datatype

### Why are the changes needed?
this is fixing a bug with utf8view-encoded proptypes

### Does this PR introduce any user-facing change? If yes is this documented?
N/A

### How was this patch tested?
this was applied in the artemis environment and resolved the issue where utf8view-encoded props were causing problems.

### Are there any further changes required?
I think NodeTypes might need the same fix applied.

