### PR TITLE
fix the benchmark permissions so they can be submitted to github pages

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,11 @@
 name: Rust Benchmarks
 permissions:
+  # submit PR comment
   pull-requests: write
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Permissions on the benchmark workflow were too restrictive



