### PR TITLE
impl gql path filter, add tests

### DIFF
--- a/python/tests/test_base_install/test_filters/test_node_composite_filter.py
+++ b/python/tests/test_base_install/test_filters/test_node_composite_filter.py
@@ -1,6 +1,6 @@
 from raphtory import Prop, filter
 import pytest
-from filters_setup import init_graph
+from filters_setup import init_graph, create_test_graph
 from utils import with_disk_variants
 
 
@@ -63,5 +63,65 @@ def test_not_node_composite_filter():
             ["1", "3", "4", "David Gilmour", "Jimmy Page", "John Mayer"]
         )
         assert result_ids == expected_ids
+
+    return check
+
+
+@with_disk_variants(create_test_graph)
+def test_out_neighbours_composite_filter():
+    def check(graph):
+        filter_expr1 = filter.Node.name() == "d"
+        filter_expr2 = filter.Property("prop1") > 10
+        result_names = sorted(graph.node("a").filter_nodes(filter_expr1 & filter_expr2).out_neighbours.name)
+        expected_names = ['d']
+        assert result_names == expected_names
+
+        filter_expr = filter.Property("prop1") < 10
+        result_names = sorted(graph.node("a").filter_nodes(filter_expr).out_neighbours.name)
+        expected_names = []
+        assert result_names == expected_names
+
+    return check
+
+
+@with_disk_variants(create_test_graph)
+def test_in_neighbours_composite_filter():
+    def check(graph):
+        filter_expr1 = filter.Node.name() == "a"
+        filter_expr2 = filter.Property("prop1") > 10
+        result_names = sorted(graph.node("d").filter_nodes(filter_expr1 & filter_expr2).in_neighbours.name)
+        expected_names = ['a']
+        assert result_names == expected_names
+
+        filter_expr = filter.Property("prop1") > 10
+        result_names = sorted(graph.node("d").filter_nodes(filter_expr).in_neighbours.name)
+        expected_names = ['a', 'c']
+        assert result_names == expected_names
+
+        filter_expr = filter.Property("prop1") < 10
+        result_names = sorted(graph.node("d").filter_nodes(filter_expr).in_neighbours.name)
+        expected_names = []
+        assert result_names == expected_names
+
+    return check
+
+
+@with_disk_variants(create_test_graph)
+def test_neighbours_composite_filter():
+    def check(graph):
+        filter_expr = filter.Property("prop4") == False
+        result_names = sorted(graph.node("a").filter_nodes(filter_expr).neighbours.name)
+        expected_names = ['d']
+        assert result_names == expected_names
+
+        filter_expr = filter.Property("prop1") <= 100
+        result_names = sorted(graph.node("d").filter_nodes(filter_expr).neighbours.name)
+        expected_names = ['a', 'b', 'c']
+        assert result_names == expected_names
+
+        filter_expr = filter.Property("prop1") > 500
+        result_names = sorted(graph.node("d").filter_nodes(filter_expr).neighbours.name)
+        expected_names = []
+        assert result_names == expected_names
 
     return check

--- a/python/tests/test_base_install/test_filters/test_node_composite_filter.py
+++ b/python/tests/test_base_install/test_filters/test_node_composite_filter.py
@@ -67,7 +67,7 @@ def test_not_node_composite_filter():
     return check
 
 
-@with_disk_variants(create_test_graph)
+@with_disk_variants(create_test_graph, variants=["graph", "persistent_graph"])
 def test_out_neighbours_composite_filter():
     def check(graph):
         filter_expr1 = filter.Node.name() == "d"
@@ -84,7 +84,7 @@ def test_out_neighbours_composite_filter():
     return check
 
 
-@with_disk_variants(create_test_graph)
+@with_disk_variants(create_test_graph, variants=["graph", "persistent_graph"])
 def test_in_neighbours_composite_filter():
     def check(graph):
         filter_expr1 = filter.Node.name() == "a"
@@ -106,7 +106,7 @@ def test_in_neighbours_composite_filter():
     return check
 
 
-@with_disk_variants(create_test_graph)
+@with_disk_variants(create_test_graph, variants=["graph", "persistent_graph"])
 def test_neighbours_composite_filter():
     def check(graph):
         filter_expr = filter.Property("prop4") == False

--- a/python/tests/test_base_install/test_graphql/test_filters/test_neighbours_filter.py
+++ b/python/tests/test_base_install/test_graphql/test_filters/test_neighbours_filter.py
@@ -1,0 +1,180 @@
+import pytest
+from raphtory import Graph, PersistentGraph
+from filters_setup import create_test_graph
+from utils import run_graphql_test, run_graphql_error_test
+
+EVENT_GRAPH = create_test_graph(Graph())
+PERSISTENT_GRAPH = create_test_graph(PersistentGraph())
+
+
+@pytest.mark.parametrize("graph", [EVENT_GRAPH, PERSISTENT_GRAPH])
+def test_out_neighbours_found(graph):
+    query = """
+        query {
+          graph(path: "g") {
+            node(name: "a") {
+              nodeFilter(filter: {
+                and: [
+                  {
+                    node: {
+                      field: NODE_NAME,
+                      operator: EQUAL,
+                      value:{ str: "d" }
+                    }
+                  },
+                  {
+                    property: {
+                      name: "prop1"
+                      operator: GREATER_THAN
+                      value: { i64: 10 }
+                    }
+                  }
+                ]
+              }) {
+                outNeighbours {
+                  list {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    expected_output = {"graph": {"node": {"nodeFilter": {"outNeighbours": {"list": [{"name": "d"}]}}}}}
+    run_graphql_test(query, expected_output, graph)
+
+
+@pytest.mark.parametrize("graph", [EVENT_GRAPH, PERSISTENT_GRAPH])
+def test_out_neighbours_not_found(graph):
+    query = """
+        query {
+          graph(path: "g") {
+            node(name: "a") {
+              nodeFilter(filter: {
+                node: {
+                  field: NODE_NAME,
+                  operator: EQUAL,
+                  value:{ str: "e" }
+                }
+              }) {
+                outNeighbours {
+                  list {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    expected_output = {"graph": {"node": {"nodeFilter": {"outNeighbours": {"list": []}}}}}
+    run_graphql_test(query, expected_output, graph)
+
+
+@pytest.mark.parametrize("graph", [EVENT_GRAPH, PERSISTENT_GRAPH])
+def test_in_neighbours_found(graph):
+    query = """
+        query {
+          graph(path: "g") {
+            node(name: "d") {
+              nodeFilter(filter: {
+                    property: {
+                      name: "prop1"
+                      operator: GREATER_THAN
+                      value: { i64: 10 }
+                    }
+              }) {
+                inNeighbours {
+                  list {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    expected_output = {"graph": {"node": {"nodeFilter": {"inNeighbours": {"list": [{'name': 'a'}, {'name': 'c'}]}}}}}
+    run_graphql_test(query, expected_output, graph)
+
+
+@pytest.mark.parametrize("graph", [EVENT_GRAPH, PERSISTENT_GRAPH])
+def test_in_neighbours_not_found(graph):
+    query = """
+        query {
+          graph(path: "g") {
+            node(name: "d") {
+              nodeFilter(filter: {
+                node: {
+                  field: NODE_NAME,
+                  operator: EQUAL,
+                  value:{ str: "e" }
+                }
+              }) {
+                inNeighbours {
+                  list {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    expected_output = {"graph": {"node": {"nodeFilter": {"inNeighbours": {"list": []}}}}}
+    run_graphql_test(query, expected_output, graph)
+
+
+@pytest.mark.parametrize("graph", [EVENT_GRAPH, PERSISTENT_GRAPH])
+def test_neighbours_found(graph):
+    query = """
+        query {
+          graph(path: "g") {
+            node(name: "d") {
+              nodeFilter(filter: {
+                node: {
+                  field: NODE_NAME,
+                  operator: NOT_EQUAL,
+                  value:{ str: "a" }
+                }
+              }) {
+                neighbours {
+                  list {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    expected_output = {"graph": {"node": {"nodeFilter": {"neighbours": {"list": [{'name': 'b'}, {'name': 'c'}]}}}}}
+    run_graphql_test(query, expected_output, graph)
+
+
+@pytest.mark.parametrize("graph", [EVENT_GRAPH, PERSISTENT_GRAPH])
+def test_neighbours_not_found(graph):
+    query = """
+        query {
+          graph(path: "g") {
+            node(name: "d") {
+              nodeFilter(filter: {
+                node: {
+                  field: NODE_NAME,
+                  operator: EQUAL,
+                  value:{ str: "e" }
+                }
+              }) {
+                neighbours {
+                  list {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    expected_output = {"graph": {"node": {"nodeFilter": {"neighbours": {"list": []}}}}}
+    run_graphql_test(query, expected_output, graph)

--- a/python/tests/test_base_install/test_graphql/test_namespace.py
+++ b/python/tests/test_base_install/test_graphql/test_namespace.py
@@ -3,6 +3,7 @@ import pytest
 from raphtory import Graph
 from raphtory.graphql import GraphServer, RaphtoryClient
 import json
+import time
 
 
 def make_folder_structure(client):
@@ -13,6 +14,7 @@ def make_folder_structure(client):
     client.send_graph("test/first/internal/graph", g, overwrite=True)
     client.send_graph("test/second/internal/graph1", g, overwrite=True)
     client.send_graph("test/second/internal/graph2", g, overwrite=True)
+    time.sleep(1)
 
 
 def sort_dict(d):
@@ -31,6 +33,7 @@ def test_namespaces_and_metagraph():
     with GraphServer(work_dir).start():
         client = RaphtoryClient("http://localhost:1736")
         make_folder_structure(client)
+       
         # tests list and page on namespaces and metagraphs
         query = """{
           root {

--- a/python/tests/test_base_install/test_graphql/test_namespace.py
+++ b/python/tests/test_base_install/test_graphql/test_namespace.py
@@ -3,7 +3,6 @@ import pytest
 from raphtory import Graph
 from raphtory.graphql import GraphServer, RaphtoryClient
 import json
-import time
 
 
 def make_folder_structure(client):
@@ -14,7 +13,6 @@ def make_folder_structure(client):
     client.send_graph("test/first/internal/graph", g, overwrite=True)
     client.send_graph("test/second/internal/graph1", g, overwrite=True)
     client.send_graph("test/second/internal/graph2", g, overwrite=True)
-    time.sleep(1)
 
 
 def sort_dict(d):

--- a/raphtory-graphql/src/model/graph/namespace.rs
+++ b/raphtory-graphql/src/model/graph/namespace.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use tokio::task::spawn_blocking;
 use walkdir::WalkDir;
 
-#[derive(ResolvedObject, Clone)]
+#[derive(ResolvedObject, Clone, Ord, Eq, PartialEq, PartialOrd)]
 pub(crate) struct Namespace {
     base_dir: PathBuf,
     current_dir: PathBuf,
@@ -52,6 +52,7 @@ impl Namespace {
                     None
                 }
             })
+            .sorted()
             .collect()
     }
 }
@@ -129,6 +130,7 @@ impl Namespace {
                             None
                         }
                     })
+                    .sorted()
                     .collect(),
             )
         })


### PR DESCRIPTION
Filter neighbours:

```python
filter_expr1 = filter.Node.name() == "d"
filter_expr2 = filter.Property("prop1") > 10
result_names = sorted(graph.node("a").filter_nodes(filter_expr1 & filter_expr2).out_neighbours.name)
expected_names = ['d']
assert result_names == expected_names
```

```gql
query {
  graph(path: "g") {
    node(name: "a") {
      nodeFilter(filter: {
        and: [
          {
            node: {
              field: NODE_NAME,
              operator: EQUAL,
              value:{ str: "d" }
            }
          },
          {
            property: {
              name: "prop1"
              operator: GREATER_THAN
              value: { i64: 10 }
            }
          }
        ]
      }) {
        outNeighbours {
          list {
            name
          }
        }
      }
    }
  }
}
```
