### PR TITLE
Change compression to fastest

### DIFF
--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -253,7 +253,7 @@ impl GraphServer {
             .at("/playground", get(ui))
             .at("/health", get(health))
             .with(Cors::new())
-            .with(Compression::new().with_quality(CompressionLevel::Best));
+            .with(Compression::new().with_quality(CompressionLevel::Fastest));
         Ok(app)
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Swap server compression for best to fastest to balance between package size and compression time


