### PR TITLE
Fix Raphtory python client

### DIFF
--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -5698,7 +5698,7 @@ class Properties(object):
     """A view of the properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -5767,7 +5767,7 @@ class ConstantProperties(object):
     """A view of constant properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -5848,7 +5848,7 @@ class TemporalProperties(object):
     """A view of the temporal properties of an entity"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -5928,7 +5928,7 @@ class TemporalProperties(object):
 
 class PropertiesView(object):
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __eq__(self, value):
         """Return self==value."""

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -780,7 +780,7 @@ class Matching(object):
         """True if self else False"""
 
     def __contains__(self, key):
-        """Return key in self."""
+        """Return bool(key in self)."""
 
     def __iter__(self):
         """Implement iter(self)."""


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changes the python client to only have one internal client client instead of creating one for each query.

### Why are the changes needed?
100x queries per second 

### Does this PR introduce any user-facing change? If yes is this documented?
No
### How was this patch tested?
Existing tests
### Are there any further changes required?
This is a quick fix, probably some other ways this could be faster

