### PR TITLE
Make plugin registry static

### DIFF
--- a/examples/custom-gql-apis/src/python.rs
+++ b/examples/custom-gql-apis/src/python.rs
@@ -1,11 +1,10 @@
 use crate::{mutation::HelloMutation, query::HelloQuery};
 use pyo3::prelude::*;
-use raphtory_graphql::python::server::{server::PyGraphServer, take_server_ownership};
+use raphtory_graphql::server::{register_mutation_plugin, register_query_plugin};
 
 #[pyfunction(name = "add_custom_gql_apis")]
-pub fn py_add_custom_gql_apis(server: PyRefMut<PyGraphServer>) -> Result<PyGraphServer, PyErr> {
-    let server = take_server_ownership(server)?;
-    let server = server.register_query_plugin::<_, HelloQuery>("hello_query");
-    let server = server.register_mutation_plugin::<_, HelloMutation>("hello_mutation");
-    Ok(PyGraphServer::new(server))
+pub fn py_add_custom_gql_apis() -> Result<(), PyErr> {
+    register_query_plugin::<_, HelloQuery>("hello_query");
+    register_mutation_plugin::<_, HelloMutation>("hello_mutation");
+    Ok(())
 }

--- a/examples/custom-gql-apis/test/test_hello_world.py
+++ b/examples/custom-gql-apis/test/test_hello_world.py
@@ -7,7 +7,7 @@ from raphtory.graphql import add_custom_gql_apis
 def test_hello_world():
     work_dir = tempfile.mkdtemp()
     server = GraphServer(work_dir)
-    server = add_custom_gql_apis(server)
+    add_custom_gql_apis()
     with server.start() as server:
         client = server.get_client()
         query = """query {

--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -5757,7 +5757,7 @@ class Properties(object):
     """A view of the properties of an entity"""
 
     def __contains__(self, key):
-        """Return bool(key in self)."""
+        """Return key in self."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -5817,7 +5817,7 @@ class Metadata(object):
     """A view of metadata of an entity"""
 
     def __contains__(self, key):
-        """Return bool(key in self)."""
+        """Return key in self."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -5898,7 +5898,7 @@ class TemporalProperties(object):
     """A view of the temporal properties of an entity"""
 
     def __contains__(self, key):
-        """Return bool(key in self)."""
+        """Return key in self."""
 
     def __eq__(self, value):
         """Return self==value."""
@@ -5978,7 +5978,7 @@ class TemporalProperties(object):
 
 class PropertiesView(object):
     def __contains__(self, key):
-        """Return bool(key in self)."""
+        """Return key in self."""
 
     def __eq__(self, value):
         """Return self==value."""

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -798,7 +798,7 @@ class Matching(object):
         """True if self else False"""
 
     def __contains__(self, key):
-        """Return bool(key in self)."""
+        """Return key in self."""
 
     def __iter__(self):
         """Implement iter(self)."""

--- a/python/tests/test_base_install/test_graphql/test_gen_schema.py
+++ b/python/tests/test_base_install/test_graphql/test_gen_schema.py
@@ -7,6 +7,5 @@ graphql_file_path = (schema_dir / "schema.graphql").as_posix()
 
 print(f"Creating graphql.schema file at {graphql_file_path}")
 
-with open(graphql_file_path, 'w', encoding='utf8') as f:
+with open(graphql_file_path, "w", encoding="utf8") as f:
     f.write(schema())
-

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -83,6 +83,26 @@ pub struct GraphServer {
     config: AppConfig,
 }
 
+pub fn register_query_plugin<
+    'a,
+    E: EntryPoint<'a> + 'static + Send,
+    A: Operation<'a, E> + 'static + Send,
+>(
+    name: &str,
+) {
+    E::lock_plugins().insert(name.to_string(), Box::new(A::register_operation));
+}
+
+pub fn register_mutation_plugin<
+    'a,
+    E: EntryPoint<'a> + 'static + Send,
+    A: Operation<'a, E> + 'static + Send,
+>(
+    name: &str,
+) {
+    E::lock_plugins().insert(name.to_string(), Box::new(A::register_operation));
+}
+
 impl GraphServer {
     pub fn new(
         work_dir: PathBuf,
@@ -141,30 +161,6 @@ impl GraphServer {
                     .insert(graph_name.into(), template.clone());
             }
         }
-        self
-    }
-
-    pub fn register_query_plugin<
-        'a,
-        E: EntryPoint<'a> + 'static + Send,
-        A: Operation<'a, E> + 'static + Send,
-    >(
-        self,
-        name: &str,
-    ) -> Self {
-        E::lock_plugins().insert(name.to_string(), Box::new(A::register_operation));
-        self
-    }
-
-    pub fn register_mutation_plugin<
-        'a,
-        E: EntryPoint<'a> + 'static + Send,
-        A: Operation<'a, E> + 'static + Send,
-    >(
-        self,
-        name: &str,
-    ) -> Self {
-        E::lock_plugins().insert(name.to_string(), Box::new(A::register_operation));
         self
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Server plugins now no longer require you to create a server to register them.
### Why are the changes needed?
This is much more in line with what is actually going on under the hood as the plugins are globally registered anyway.

### Does this PR introduce any user-facing change? If yes is this documented?
Yes and within the examples

### How was this patch tested?
Existing tests
### Are there any further changes required?


