### PR TITLE
Fix/top k

### DIFF
--- a/raphtory/src/db/api/state/node_state_ops.rs
+++ b/raphtory/src/db/api/state/node_state_ops.rs
@@ -154,8 +154,8 @@ pub trait NodeStateOps<'graph>:
         cmp: F,
         k: usize,
     ) -> NodeState<'graph, Self::OwnedValue, Self::BaseGraph, Self::Graph> {
-        let values = node_state_ord_ops::par_top_k(
-            self.par_iter(),
+        let values = node_state_ord_ops::top_k(
+            self.iter(),
             |(_, v1), (_, v2)| cmp(v1.borrow(), v2.borrow()),
             k,
         );

--- a/raphtory/src/db/api/state/node_state_ord_ops.rs
+++ b/raphtory/src/db/api/state/node_state_ord_ops.rs
@@ -306,9 +306,7 @@ where
         else if heap.peek() > Some(&elem) {
             // May need to push this element, drop the read guard and wait for write access
             if let Some(mut first_mut) = heap.peek_mut() {
-                if first_mut.deref() >= &elem {
-                    *first_mut = elem;
-                }
+                *first_mut = elem;
             };
         }
     }

--- a/raphtory/src/db/api/state/node_state_ord_ops.rs
+++ b/raphtory/src/db/api/state/node_state_ord_ops.rs
@@ -12,6 +12,7 @@ use std::{
     fmt::{Debug, Formatter},
     ops::Deref,
 };
+use std::fmt::Binary;
 
 trait AsOrd {
     type Ordered: ?Sized + Ord;
@@ -283,6 +284,45 @@ where
     }
 }
 
+pub fn top_k<V: Send + Sync, F>(
+    iter: impl IntoIterator<Item = V>,
+    cmp: F,
+    k: usize,
+) -> Vec<V>
+where
+    F: Fn(&V, &V) -> Ordering + Send + Sync,
+{
+    let mut heap: BinaryHeap<Reverse<Ordered<V, &F>>> = BinaryHeap::with_capacity(k);
+
+    for v in iter {
+        let elem = Reverse(Ordered {
+            value: v,
+            cmp_fn: &cmp,
+        });
+        if heap.len() < k {
+                // heap is still not full, push the element and return
+            heap.push(elem);
+        }
+        else if heap.peek() > Some(&elem) {
+            // May need to push this element, drop the read guard and wait for write access
+            if let Some(mut first_mut) = heap.peek_mut() {
+                if first_mut.deref() >= &elem {
+                    *first_mut = elem;
+                }
+            };
+        }
+    }
+
+    let values: Vec<V> = heap
+        .into_sorted_vec()
+        .into_iter()
+        .map(|Reverse(Ordered { value, .. })| value)
+        .collect();
+
+    values
+}
+
+
 pub fn par_top_k<V: Send + Sync, F>(
     iter: impl IntoParallelIterator<Item = V>,
     cmp: F,
@@ -310,7 +350,7 @@ where
             // May need to push this element, drop the read guard and wait for write access
             let mut write_guard = heap.write();
             if let Some(mut first_mut) = write_guard.peek_mut() {
-                if first_mut.deref() >= &elem {
+                if first_mut.deref() > &elem {
                     *first_mut = elem;
                 }
             };
@@ -329,13 +369,36 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::db::api::state::node_state_ord_ops::par_top_k;
+    use crate::db::api::state::node_state_ord_ops::{par_top_k, top_k};
+
+    use rand; // 0.8.5
+
+    use rand::distributions::{Distribution, Uniform};
+    use tokio::time::Instant;
+
+    fn gen_x_ints(
+        count: u32,
+        distribution: impl Distribution<u32>,
+        rng: &mut (impl rand::Rng + ?Sized),
+    ) -> Vec<u32> {
+        let mut results = Vec::with_capacity(count as usize);
+        let iter = distribution.sample_iter(rng);
+        for (_, sample) in (0..count).zip(iter) {
+            results.push(sample);
+        }
+        results
+    }
 
     #[test]
     fn test_top_k() {
-        let values = [4i32, 2, 3, 100, 4, 2];
-        let res = par_top_k(values, |a, b| a.cmp(b), 3);
-
-        assert_eq!(res, [100, 4, 4])
+        let values = gen_x_ints(100000000, Uniform::new(0, 10000000), &mut rand::thread_rng()); // [4i32, 2, 3, 100, 4, 2];
+        let timer = Instant::now();
+        let res1 = top_k(values.clone(), |a, b| a.cmp(b), 100);
+        println!("Top K in: {:?}", timer.elapsed());
+        let timer = Instant::now();
+        let res2 = par_top_k(values, |a, b| a.cmp(b), 100);
+        println!("Par Top K in: {:?}", timer.elapsed());
+        assert_eq!(res1, res2);
+        //assert_eq!(res, par_top_k(values, |a, b| a.cmp(b), 100))  //[100, 4, 4])
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changing par_top_k to linear top_k and changing the comparison when adding elements to be strict rather than loose.

### Why are the changes needed?
This is 50x faster (testing up to 1,000,000,000 elements) than the previous parallel version.

### Does this PR introduce any user-facing change? If yes is this documented?
Not in the NodeState API, but internally I have added a top_k method in node_state_ord_ops.

### How was this patch tested?
It was tested on the same toy example as par_top_k and evaluated on much larger examples against the output of par_top_k.

### Are there any further changes required?
For large enough inputs, we should do a k-merge of k linearly calculated top-k binary heaps. We can also perform some summary stat calculations like avg, min, max, and some bucketing to reduce the search space, but this performs the operation of finding the top 100 elements of 1 billion elements in 14 seconds, so these changes are fairly low priority at the moment.

