### PR TITLE
Switch node/edge resolution to be sequential when loading from dataframes

### DIFF
--- a/python/tests/test_base_install/test_graphql/test_filters/test_graph_nodes_property_filter.py
+++ b/python/tests/test_base_install/test_graphql/test_filters/test_graph_nodes_property_filter.py
@@ -807,7 +807,7 @@ def test_graph_node_not_property_filter(graph):
       graph(path: "g") {
         nodeFilter (
           filter: {
-            not: 
+            not:
               {
                 property: {
                   name: "prop5"

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -344,8 +344,8 @@ type Graph {
 }
 
 type GraphAlgorithmPlugin {
-	pagerank(iterCount: Int!, threads: Int, tol: Float): [PagerankOutput!]!
 	shortest_path(source: String!, targets: [String!]!, direction: String): [ShortestPathOutput!]!
+	pagerank(iterCount: Int!, threads: Int, tol: Float): [PagerankOutput!]!
 }
 
 type GraphSchema {

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -344,8 +344,8 @@ type Graph {
 }
 
 type GraphAlgorithmPlugin {
-	shortest_path(source: String!, targets: [String!]!, direction: String): [ShortestPathOutput!]!
 	pagerank(iterCount: Int!, threads: Int, tol: Float): [PagerankOutput!]!
+	shortest_path(source: String!, targets: [String!]!, direction: String): [ShortestPathOutput!]!
 }
 
 type GraphSchema {

--- a/raphtory/src/io/arrow/df_loaders.rs
+++ b/raphtory/src/io/arrow/df_loaders.rs
@@ -105,10 +105,8 @@ pub(crate) fn load_nodes_from_df<
     let mut node_type_col_resolved = vec![];
 
     let mut write_locked_graph = graph.write_lock().map_err(into_graph_err)?;
+    let mut start_id = session.reserve_event_ids(df_view.num_rows).map_err(into_graph_err)?;
 
-    let mut start_id = session
-        .reserve_event_ids(df_view.num_rows)
-        .map_err(into_graph_err)?;
     for chunk in df_view.chunks {
         let df = chunk?;
         let prop_cols = combine_properties(properties, &properties_indices, &df, |key, dtype| {

--- a/raphtory/src/io/arrow/layer_col.rs
+++ b/raphtory/src/io/arrow/layer_col.rs
@@ -47,6 +47,23 @@ impl<'a> LayerCol<'a> {
         }
     }
 
+    pub fn iter(self) -> impl Iterator<Item = Option<&'a str>> {
+        match self {
+            LayerCol::Name { name, len } => {
+                LayerColVariants::Name((0..len).map(move |_| name))
+            }
+            LayerCol::Utf8 { col } => {
+                LayerColVariants::Utf8((0..col.len()).map(|i| col.get(i)))
+            }
+            LayerCol::LargeUtf8 { col } => {
+                LayerColVariants::LargeUtf8((0..col.len()).map(|i| col.get(i)))
+            }
+            LayerCol::Utf8View { col } => {
+                LayerColVariants::Utf8View((0..col.len()).map(|i| col.get(i)))
+            }
+        }
+    }
+
     pub fn resolve(
         self,
         graph: &(impl AdditionOps + Send + Sync),

--- a/raphtory/src/serialise/parquet/mod.rs
+++ b/raphtory/src/serialise/parquet/mod.rs
@@ -58,7 +58,7 @@ pub trait ParquetDecoder {
         Self: Sized;
 }
 
-const NODE_ID: &str = "rap_node_id";
+const NODE_ID_COL: &str = "rap_node_id";
 const TYPE_COL: &str = "rap_node_type";
 const TIME_COL: &str = "rap_time";
 const SRC_COL: &str = "rap_src";
@@ -327,7 +327,7 @@ fn decode_graph_storage(
 
     let t_node_path = path.as_ref().join(NODES_T_PATH);
     if std::fs::exists(&t_node_path)? {
-        let exclude = vec![NODE_ID, TIME_COL, TYPE_COL];
+        let exclude = vec![NODE_ID_COL, TIME_COL, TYPE_COL];
         let (t_prop_columns, _) = collect_prop_columns(&t_node_path, &exclude)?;
         let t_prop_columns = t_prop_columns
             .iter()
@@ -338,7 +338,7 @@ fn decode_graph_storage(
             &g,
             &t_node_path,
             TIME_COL,
-            NODE_ID,
+            NODE_ID_COL,
             None,
             Some(TYPE_COL),
             &t_prop_columns,
@@ -349,7 +349,7 @@ fn decode_graph_storage(
 
     let c_node_path = path.as_ref().join(NODES_C_PATH);
     if std::fs::exists(&c_node_path)? {
-        let exclude = vec![NODE_ID, TYPE_COL];
+        let exclude = vec![NODE_ID_COL, TYPE_COL];
         let (c_prop_columns, _) = collect_prop_columns(&c_node_path, &exclude)?;
         let c_prop_columns = c_prop_columns
             .iter()
@@ -359,7 +359,7 @@ fn decode_graph_storage(
         load_node_props_from_parquet(
             &g,
             &c_node_path,
-            NODE_ID,
+            NODE_ID_COL,
             None,
             Some(TYPE_COL),
             &c_prop_columns,

--- a/raphtory/src/serialise/parquet/model.rs
+++ b/raphtory/src/serialise/parquet/model.rs
@@ -1,4 +1,4 @@
-use super::{Prop, DST_COL, LAYER_COL, NODE_ID, SRC_COL, TIME_COL, TYPE_COL};
+use super::{Prop, DST_COL, LAYER_COL, NODE_ID_COL, SRC_COL, TIME_COL, TYPE_COL};
 use crate::{
     db::{
         api::view::StaticGraphViewOps,
@@ -167,7 +167,7 @@ impl<'a> Serialize for ParquetTNode<'a> {
     {
         let mut state = serializer.serialize_map(None)?;
 
-        state.serialize_entry(NODE_ID, &ParquetGID(self.node.id()))?;
+        state.serialize_entry(NODE_ID_COL, &ParquetGID(self.node.id()))?;
         state.serialize_entry(TIME_COL, &self.t.0)?;
         state.serialize_entry(TYPE_COL, &self.node.node_type())?;
 
@@ -190,7 +190,7 @@ impl<'a> Serialize for ParquetCNode<'a> {
     {
         let mut state = serializer.serialize_map(None)?;
 
-        state.serialize_entry(NODE_ID, &ParquetGID(self.node.id()))?;
+        state.serialize_entry(NODE_ID_COL, &ParquetGID(self.node.id()))?;
         state.serialize_entry(TYPE_COL, &self.node.node_type())?;
 
         for (name, prop) in self.node.metadata().iter_filtered() {

--- a/raphtory/src/serialise/parquet/nodes.rs
+++ b/raphtory/src/serialise/parquet/nodes.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::GraphError,
     serialise::parquet::{
         model::{ParquetCNode, ParquetTNode},
-        run_encode, NODES_C_PATH, NODES_T_PATH, NODE_ID, TIME_COL, TYPE_COL,
+        run_encode, NODES_C_PATH, NODES_T_PATH, NODE_ID_COL, TIME_COL, TYPE_COL,
     },
 };
 use arrow_schema::{DataType, Field};
@@ -25,7 +25,7 @@ pub(crate) fn encode_nodes_tprop(
         NODES_T_PATH,
         |id_type| {
             vec![
-                Field::new(NODE_ID, id_type.clone(), false),
+                Field::new(NODE_ID_COL, id_type.clone(), false),
                 Field::new(TIME_COL, DataType::Int64, false),
                 Field::new(TYPE_COL, DataType::Utf8, true),
             ]
@@ -78,7 +78,7 @@ pub(crate) fn encode_nodes_cprop(
         NODES_C_PATH,
         |id_type| {
             vec![
-                Field::new(NODE_ID, id_type.clone(), false),
+                Field::new(NODE_ID_COL, id_type.clone(), false),
                 Field::new(TYPE_COL, DataType::Utf8, true),
             ]
         },

--- a/raphtory/src/serialise/parquet/nodes.rs
+++ b/raphtory/src/serialise/parquet/nodes.rs
@@ -93,13 +93,17 @@ pub(crate) fn encode_nodes_cprop(
                 .chunks(row_group_size)
                 .into_iter()
                 .map(|chunk| chunk.collect_vec())
+
+            // scope for the decoder
             {
                 decoder.serialize(&node_rows)?;
+
                 if let Some(rb) = decoder.flush()? {
                     writer.write(&rb)?;
                     writer.flush()?;
                 }
             }
+
             Ok(())
         },
     )


### PR DESCRIPTION
Parallel node/edge resolution scrambles the order of node/edge additions in the final graph. Ideally the resolution should respect the input order of nodes/edges. 

Switch node/edge resolution to be sequential for now and revisit parallel resolution at a later time.

