### PR TITLE
Fix explode layers for filtered persistent graph

### DIFF
--- a/raphtory/src/db/api/view/internal/time_semantics/filtered_edge.rs
+++ b/raphtory/src/db/api/view/internal/time_semantics/filtered_edge.rs
@@ -225,6 +225,12 @@ impl<'graph, G: GraphViewOps<'graph>, P: TPropOps<'graph>> TPropOps<'graph>
 }
 
 pub trait FilteredEdgeStorageOps<'a> {
+    fn filtered_layer_ids_iter<G: GraphView + 'a>(
+        self,
+        view: G,
+        layer_ids: &'a LayerIds,
+    ) -> impl Iterator<Item = usize> + 'a;
+
     fn filtered_additions_iter<G: GraphView + 'a>(
         self,
         view: G,
@@ -284,16 +290,22 @@ pub trait FilteredEdgeStorageOps<'a> {
 }
 
 impl<'a> FilteredEdgeStorageOps<'a> for EdgeStorageRef<'a> {
+    fn filtered_layer_ids_iter<G: GraphView + 'a>(
+        self,
+        view: G,
+        layer_ids: &'a LayerIds,
+    ) -> impl Iterator<Item = usize> + 'a {
+        self.layer_ids_iter(layer_ids)
+            .filter(move |layer_id| view.internal_filter_edge_layer(self, *layer_id))
+    }
+
     fn filtered_additions_iter<G: GraphView + 'a>(
         self,
         view: G,
         layer_ids: &'a LayerIds,
     ) -> impl Iterator<Item = (usize, FilteredEdgeTimeIndex<'a, G>)> {
-        self.layer_ids_iter(layer_ids).filter_map(move |layer| {
-            let view = view.clone();
-            view.internal_filter_edge_layer(self, layer)
-                .then(move || (layer, self.filtered_additions(layer, view.clone())))
-        })
+        self.filtered_layer_ids_iter(view.clone(), layer_ids)
+            .map(move |layer_id| (layer_id, self.filtered_additions(layer_id, view.clone())))
     }
 
     fn filtered_deletions_iter<G: GraphViewOps<'a>>(
@@ -301,11 +313,8 @@ impl<'a> FilteredEdgeStorageOps<'a> for EdgeStorageRef<'a> {
         view: G,
         layer_ids: &'a LayerIds,
     ) -> impl Iterator<Item = (usize, FilteredEdgeTimeIndex<'a, G>)> {
-        self.layer_ids_iter(layer_ids).filter_map(move |layer| {
-            let view = view.clone();
-            view.internal_filter_edge_layer(self, layer)
-                .then(move || (layer, self.filtered_deletions(layer, view.clone())))
-        })
+        self.filtered_layer_ids_iter(view.clone(), layer_ids)
+            .map(move |layer| (layer, self.filtered_deletions(layer, view.clone())))
     }
 
     fn filtered_updates_iter<G: GraphViewOps<'a>>(
@@ -319,17 +328,14 @@ impl<'a> FilteredEdgeStorageOps<'a> for EdgeStorageRef<'a> {
             FilteredEdgeTimeIndex<'a, G>,
         ),
     > + 'a {
-        self.layer_ids_iter(layer_ids).filter_map(move |layer_id| {
-            let view = view.clone();
-            view.internal_filter_edge_layer(self, layer_id)
-                .then(move || {
-                    (
-                        layer_id,
-                        self.filtered_additions(layer_id, view.clone()),
-                        self.filtered_deletions(layer_id, view.clone()),
-                    )
-                })
-        })
+        self.filtered_layer_ids_iter(view.clone(), layer_ids)
+            .map(move |layer_id| {
+                (
+                    layer_id,
+                    self.filtered_additions(layer_id, view.clone()),
+                    self.filtered_deletions(layer_id, view.clone()),
+                )
+            })
     }
 
     fn filtered_additions<G: GraphViewOps<'a>>(
@@ -375,16 +381,13 @@ impl<'a> FilteredEdgeStorageOps<'a> for EdgeStorageRef<'a> {
         view: G,
         layer_ids: &'a LayerIds,
     ) -> impl Iterator<Item = (usize, impl TPropOps<'a>)> + 'a {
-        self.layer_ids_iter(layer_ids).filter_map(move |layer_id| {
-            let view = view.clone();
-            view.internal_filter_edge_layer(self, layer_id)
-                .then(move || {
-                    (
-                        layer_id,
-                        self.filtered_temporal_prop_layer(layer_id, prop_id, view.clone()),
-                    )
-                })
-        })
+        self.filtered_layer_ids_iter(view.clone(), layer_ids)
+            .map(move |layer_id| {
+                (
+                    layer_id,
+                    self.filtered_temporal_prop_layer(layer_id, prop_id, view.clone()),
+                )
+            })
     }
 
     fn filtered_edge_metadata<'graph, G: GraphView + 'graph>(

--- a/raphtory/src/db/api/view/internal/time_semantics/persistent_semantics.rs
+++ b/raphtory/src/db/api/view/internal/time_semantics/persistent_semantics.rs
@@ -561,10 +561,10 @@ impl EdgeTimeSemanticsOps for PersistentSemantics {
     fn edge_layers<'graph, G: GraphViewOps<'graph>>(
         self,
         e: EdgeStorageRef<'graph>,
-        _view: G,
+        view: G,
         layer_ids: &'graph LayerIds,
     ) -> impl Iterator<Item = usize> + Send + Sync + 'graph {
-        e.layer_ids_iter(layer_ids)
+        e.filtered_layer_ids_iter(view, layer_ids)
     }
 
     fn edge_window_exploded<'graph, G: GraphViewOps<'graph>>(

--- a/raphtory/src/db/graph/views/valid_graph.rs
+++ b/raphtory/src/db/graph/views/valid_graph.rs
@@ -128,6 +128,21 @@ mod tests {
     }
 
     #[test]
+    fn test_explode_layers() {
+        let g = PersistentGraph::new();
+        g.add_edge(0, 0, 1, NO_PROPS, Some("a")).unwrap();
+        g.delete_edge(0, 0, 1, Some("b")).unwrap();
+        let gv = g.valid();
+        let edge = gv.edge(0, 1).unwrap();
+        let exploded = edge.explode_layers();
+        let layers = exploded
+            .layer_name()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(layers, ["a"]);
+    }
+
+    #[test]
     fn materialize_prop_test_events() {
         proptest!(|(graph_f in build_graph_strat(10, 10, true))| {
             let g = Graph::from(build_graph(&graph_f)).valid();


### PR DESCRIPTION
### What changes were proposed in this pull request?

`explode_layers` with persistent semantics was ignoring layer filters such as `valid`

### How was this patch tested?

added test for `explode_layers` on `ValidGraph`