### PR TITLE
optimise simple temporal intervals

### DIFF
--- a/raphtory-core/src/utils/time.rs
+++ b/raphtory-core/src/utils/time.rs
@@ -440,7 +440,11 @@ impl Sub<Interval> for i64 {
     type Output = i64;
     fn sub(self, rhs: Interval) -> Self::Output {
         match rhs.size {
-            IntervalSize::Discrete(number) => self - (number as i64),
+            IntervalSize::Discrete(number)
+            | IntervalSize::Temporal {
+                millis: number,
+                months: 0,
+            } => self - (number as i64),
             IntervalSize::Temporal { millis, months } => {
                 // first we subtract the number of milliseconds and then the number of months for
                 // consistency with the implementation of Add (we revert back the steps) so we
@@ -462,7 +466,11 @@ impl Add<Interval> for i64 {
     type Output = i64;
     fn add(self, rhs: Interval) -> Self::Output {
         match rhs.size {
-            IntervalSize::Discrete(number) => self + (number as i64),
+            IntervalSize::Discrete(number)
+            | IntervalSize::Temporal {
+                millis: number,
+                months: 0,
+            } => self + (number as i64),
             IntervalSize::Temporal { millis, months } => {
                 // first we add the number of months and then the number of milliseconds for
                 // consistency with the implementation of Sub (we revert back the steps) so we

--- a/raphtory/tests/time_tests.rs
+++ b/raphtory/tests/time_tests.rs
@@ -8,7 +8,7 @@ use raphtory::{
             views::deletion_graph::PersistentGraph,
         },
     },
-    prelude::{DeletionOps, GraphViewOps, TimeOps, NO_PROPS},
+    prelude::{DeletionOps, GraphViewOps, LayerOps, TimeOps, NO_PROPS},
 };
 use raphtory_core::utils::time::ParseTimeError;
 
@@ -22,10 +22,8 @@ fn graph_with_timeline(start: i64, end: i64) -> Graph {
     g
 }
 
-fn assert_bounds<'graph, G>(
-    windows: WindowSet<'graph, G>,
-    expected: Vec<(Option<i64>, Option<i64>)>,
-) where
+fn assert_bounds<'graph, G>(windows: WindowSet<'graph, G>, expected: &[(Option<i64>, Option<i64>)])
+where
     G: GraphViewOps<'graph>,
 {
     let window_bounds = windows.map(|w| (w.start(), w.end())).collect_vec();
@@ -58,14 +56,14 @@ fn rolling() {
     test_storage!(&graph, |graph| {
         let windows = graph.rolling(2, None).unwrap();
         let expected = vec![(Some(1), Some(3)), (Some(3), Some(5)), (Some(5), Some(7))];
-        assert_bounds(windows, expected);
+        assert_bounds(windows, &expected);
     });
 
     let graph = graph_with_timeline(1, 6);
     test_storage!(&graph, |graph| {
         let windows = graph.rolling(3, Some(2)).unwrap();
         let expected = vec![(Some(0), Some(3)), (Some(2), Some(5)), (Some(4), Some(7))];
-        assert_bounds(windows, expected.clone());
+        assert_bounds(windows, &expected);
     });
 
     let graph = graph_with_timeline(0, 9);
@@ -73,7 +71,42 @@ fn rolling() {
         let windows = graph.window(1, 6).rolling(3, Some(2)).unwrap();
         assert_bounds(
             windows,
-            vec![(Some(1), Some(3)), (Some(2), Some(5)), (Some(4), Some(6))],
+            &[(Some(1), Some(3)), (Some(2), Some(5)), (Some(4), Some(6))],
+        );
+    });
+}
+
+#[test]
+fn rolling_layered() {
+    let graph = Graph::new();
+    graph.add_edge(1, 0, 1, NO_PROPS, Some("1")).unwrap();
+    graph.add_edge(5, 0, 1, NO_PROPS, Some("1")).unwrap();
+
+    graph.add_edge(3, 0, 1, NO_PROPS, Some("2")).unwrap();
+    graph.add_edge(7, 0, 1, NO_PROPS, Some("2")).unwrap();
+
+    test_storage!(&graph, |graph| {
+        let windows = graph.rolling(2, None).unwrap();
+        let expected = vec![(Some(1), Some(3)), (Some(3), Some(5)), (Some(5), Some(7))];
+        assert_bounds(windows, &expected);
+
+        let windows = graph.layers("1").unwrap().rolling(2, None).unwrap();
+        assert_bounds(windows, &expected);
+    });
+
+    let graph = graph_with_timeline(1, 6);
+    test_storage!(&graph, |graph| {
+        let windows = graph.rolling(3, Some(2)).unwrap();
+        let expected = vec![(Some(0), Some(3)), (Some(2), Some(5)), (Some(4), Some(7))];
+        assert_bounds(windows, &expected);
+    });
+
+    let graph = graph_with_timeline(0, 9);
+    test_storage!(&graph, |graph| {
+        let windows = graph.window(1, 6).rolling(3, Some(2)).unwrap();
+        assert_bounds(
+            windows,
+            &[(Some(1), Some(3)), (Some(2), Some(5)), (Some(4), Some(6))],
         );
     });
 }
@@ -84,14 +117,14 @@ fn expanding() {
     test_storage!(&graph, |graph| {
         let windows = graph.expanding(2).unwrap();
         let expected = vec![(None, Some(3)), (None, Some(5)), (None, Some(7))];
-        assert_bounds(windows, expected);
+        assert_bounds(windows, &expected);
     });
 
     let graph = graph_with_timeline(1, 6);
     test_storage!(&graph, |graph| {
         let windows = graph.expanding(2).unwrap();
         let expected = vec![(None, Some(3)), (None, Some(5)), (None, Some(7))];
-        assert_bounds(windows, expected.clone());
+        assert_bounds(windows, &expected);
     });
 
     let graph = graph_with_timeline(0, 9);
@@ -99,7 +132,7 @@ fn expanding() {
         let windows = graph.window(1, 6).expanding(2).unwrap();
         assert_bounds(
             windows,
-            vec![(Some(1), Some(3)), (Some(1), Some(5)), (Some(1), Some(6))],
+            &[(Some(1), Some(3)), (Some(1), Some(5)), (Some(1), Some(6))],
         );
     });
 }
@@ -121,7 +154,7 @@ fn rolling_dates() {
                 "2020-06-08 00:00:00".try_into_time().ok(),
             ),
         ];
-        assert_bounds(windows, expected);
+        assert_bounds(windows, &expected);
     });
 
     let start = "2020-06-06 00:00:00".try_into_time().unwrap();
@@ -139,7 +172,7 @@ fn rolling_dates() {
                 "2020-06-08 00:00:00".try_into_time().ok(),
             ),
         ];
-        assert_bounds(windows, expected);
+        assert_bounds(windows, &expected);
     });
 
     // TODO: turn this back on if we bring bach epoch alignment for unwindowed graphs
@@ -233,7 +266,7 @@ fn expanding_dates() {
             (None, "2020-06-07 00:00:00".try_into_time().ok()),
             (None, "2020-06-08 00:00:00".try_into_time().ok()),
         ];
-        assert_bounds(windows, expected);
+        assert_bounds(windows, &expected);
     });
 
     let start = "2020-06-06 00:00:00".try_into_time().unwrap();
@@ -245,6 +278,6 @@ fn expanding_dates() {
             (None, "2020-06-07 00:00:00".try_into_time().ok()),
             (None, "2020-06-08 00:00:00".try_into_time().ok()),
         ];
-        assert_bounds(windows, expected);
+        assert_bounds(windows, &expected);
     });
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimisation in add/sub for temporal intervals without months

### Why are the changes needed?

Avoid unnecessary conversion to DateTime

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


