### PR TITLE
Fix requests for the worker in subpaths

### DIFF
--- a/raphtory-graphql/src/routes.rs
+++ b/raphtory-graphql/src/routes.rs
@@ -83,8 +83,14 @@ where
                 .await
         } else {
             let path = req.uri().path().trim_start_matches('/');
+            let file_name = req.uri().path().split('/').last().unwrap_or("");
 
-            if !path.is_empty()
+            if file_name.contains("worker") && file_name.ends_with("js") {
+                // Always return the worker from root
+                EmbeddedFileEndpoint::<PublicFolder>::new(file_name)
+                    .call(req)
+                    .await
+            } else if !path.is_empty()
                 && PublicFolder::get(path).is_none()
                 && PublicFolder::get(&format!("{path}/index.html")).is_none()
             {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix for worker file requests from the UI

### Why are the changes needed?

The standard way of importing a worker appears to assume that if you are in a subdirectory of a website and make a request for a worker, the browser should make the request relative to that subdirectory (i.e.. if you are in `/saved-graphs`, and you call `new Worker('worker.js')`, then it makes the request to `/saved-graphs/worker.js`. The same is true regardless of if you call `new Worker('/worker.js')`, `new Worker(new URL('worker.js', import.meta.url))`, or any combination of the above).

See: https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker
> `url`
>
> A string representing the URL of the script the worker will execute. It must obey the same-origin policy. The URL is resolved relative to the current HTML page's location.

This doesn't work for us when refreshing the page in subdirectories that rely on workers, because we serve an SPA contained within a single index.html and several worker files at root, which means all paths such as `/saved-graphs` are actually still requests to that root index.html, and this subdirectory does not actually exist at the server so the worker request will fail if it actually requests for the worker file at `/saved-graphs/worker.js`.

This PR addresses that issue by intercepting requests to worker files from any directory and sends it to root instead.

### Does this PR introduce any user-facing change? If yes is this documented?

No

### How was this patch tested?

Not tested. (How does one do HTTP testing/HTTP mocks in rust?)

### Are there any further changes required?

No


