### PR TITLE
bring back rust_fmt_check

### DIFF
--- a/.github/workflows/rust_format_check.yml
+++ b/.github/workflows/rust_format_check.yml
@@ -1,0 +1,28 @@
+# this workflow checks out the code, and installs nightly build of cargo and runs a cargo +nightly fmt --all -- --check and fails workflow if any code is not formatted
+#
+
+name: Rust format check
+on:
+  workflow_call:
+    inputs:
+      fail_if_not_formatted:
+        type: boolean
+        default: true
+        required: false
+        description: "Fail the workflow if any code is not formatted"
+
+jobs:
+  rust-format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup nightly rust
+        run: |
+          rustup toolchain install nightly --allow-downgrade -c rustfmt
+      - name: Run rust format check
+        run: |
+          if [ ${{ inputs.fail_if_not_formatted }} == true ]; then
+              cargo +nightly fmt --all -- --check
+          else
+              cargo +nightly fmt --all -- --check || true
+          fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bring back the rust_fmt_check workflow as it is being used by the post-merge tests

### Why are the changes needed?

failing CI

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


