### PR TITLE
local clustering coefficient relax static graph requirement

### DIFF
--- a/docs/reference/graphql/graphql_API.md
+++ b/docs/reference/graphql/graphql_API.md
@@ -2479,26 +2479,6 @@ This allows you to specify multiple operations together.
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong id="graphalgorithmplugin.shortest_path">shortest_path</strong></td>
-<td valign="top">[<a href="#shortestpathoutput">ShortestPathOutput</a>!]!</td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" align="right" valign="top">source</td>
-<td valign="top"><a href="#string">String</a>!</td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" align="right" valign="top">targets</td>
-<td valign="top">[<a href="#string">String</a>!]!</td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" align="right" valign="top">direction</td>
-<td valign="top"><a href="#string">String</a></td>
-<td></td>
-</tr>
-<tr>
 <td colspan="2" valign="top"><strong id="graphalgorithmplugin.pagerank">pagerank</strong></td>
 <td valign="top">[<a href="#pagerankoutput">PagerankOutput</a>!]!</td>
 <td></td>
@@ -2516,6 +2496,26 @@ This allows you to specify multiple operations together.
 <tr>
 <td colspan="2" align="right" valign="top">tol</td>
 <td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="graphalgorithmplugin.shortest_path">shortest_path</strong></td>
+<td valign="top">[<a href="#shortestpathoutput">ShortestPathOutput</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">source</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">targets</td>
+<td valign="top">[<a href="#string">String</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">direction</td>
+<td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>
 </tbody>

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -978,8 +978,8 @@ type Graph {
 }
 
 type GraphAlgorithmPlugin {
-	shortest_path(source: String!, targets: [String!]!, direction: String): [ShortestPathOutput!]!
 	pagerank(iterCount: Int!, threads: Int, tol: Float): [PagerankOutput!]!
+	shortest_path(source: String!, targets: [String!]!, direction: String): [ShortestPathOutput!]!
 }
 
 type GraphSchema {

--- a/raphtory/src/algorithms/metrics/clustering_coefficient/local_clustering_coefficient.rs
+++ b/raphtory/src/algorithms/metrics/clustering_coefficient/local_clustering_coefficient.rs
@@ -50,9 +50,9 @@
 
 use crate::{
     algorithms::motifs::local_triangle_count::local_triangle_count,
-    core::entities::nodes::node_ref::AsNodeRef, db::api::view::*,
+    core::entities::nodes::node_ref::AsNodeRef,
+    db::api::view::{internal::GraphView, *},
 };
-use crate::db::api::view::internal::GraphView;
 
 /// Local clustering coefficient - measures the degree to which a single node in a graph tend to cluster together.
 ///
@@ -63,10 +63,7 @@ use crate::db::api::view::internal::GraphView;
 ///
 /// # Returns
 /// the local clustering coefficient of node v in g.
-pub fn local_clustering_coefficient<G: GraphView, V: AsNodeRef>(
-    graph: &G,
-    v: V,
-) -> Option<f64> {
+pub fn local_clustering_coefficient<G: GraphView, V: AsNodeRef>(graph: &G, v: V) -> Option<f64> {
     let v = v.as_node_ref();
     if let Some(node) = graph.node(v) {
         if let Some(triangle_count) = local_triangle_count(graph, v) {

--- a/raphtory/src/algorithms/motifs/local_triangle_count.rs
+++ b/raphtory/src/algorithms/motifs/local_triangle_count.rs
@@ -37,9 +37,11 @@
 //! println!("local_triangle_count: {:?}", result);
 //! ```
 
-use crate::{core::entities::nodes::node_ref::AsNodeRef, db::api::view::*};
+use crate::{
+    core::entities::nodes::node_ref::AsNodeRef,
+    db::api::view::{internal::GraphView, *},
+};
 use itertools::Itertools;
-use crate::db::api::view::internal::GraphView;
 
 /// Local triangle count - calculates the number of triangles (a cycle of length 3) a node participates in.
 ///


### PR DESCRIPTION
Local_clustering_coefficient and local_triangle_count should not require for StaticGraphViewOps

It causes funky behaviour with lifetimes requiring unnecessary cloning

The change was tested in private project using branch internal-4 and it does not require futher changes nor it impacts user-facing features.


