### PR TITLE
Dbv4 bulk optim2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4625,6 +4625,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "uuid",

--- a/db4-storage/src/api/edges.rs
+++ b/db4-storage/src/api/edges.rs
@@ -66,6 +66,8 @@ pub trait EdgeSegmentOps: Send + Sync + std::fmt::Debug + 'static {
 
     fn set_dirty(&self, dirty: bool);
 
+    fn is_dirty(&self) -> bool;
+
     /// notify that an edge was added (might need to write to disk)
     fn notify_write(
         &self,

--- a/db4-storage/src/api/nodes.rs
+++ b/db4-storage/src/api/nodes.rs
@@ -114,6 +114,8 @@ pub trait NodeSegmentOps: Send + Sync + Debug + 'static {
 
     fn flush(&self) -> Result<(), StorageError>;
 
+    fn is_dirty(&self) -> bool;
+
     fn vacuum(
         &self,
         locked_head: impl DerefMut<Target = MemNodeSegment>,

--- a/db4-storage/src/lib.rs
+++ b/db4-storage/src/lib.rs
@@ -79,9 +79,7 @@ pub type EdgeTProps<'a> = GenericTProps<'a, MemEdgeRef<'a>>;
 pub type GraphTProps<'a> = GenericTProps<'a, MemGraphPropRef<'a>>;
 
 pub mod error {
-    use std::io;
-    use std::panic::Location;
-    use std::{path::PathBuf, sync::Arc};
+    use std::{io, panic::Location, path::PathBuf, sync::Arc};
 
     use crate::resolver::mapping_resolver::InvalidNodeId;
     use raphtory_api::core::{entities::properties::prop::PropError, utils::time::ParseTimeError};

--- a/db4-storage/src/lib.rs
+++ b/db4-storage/src/lib.rs
@@ -79,6 +79,8 @@ pub type EdgeTProps<'a> = GenericTProps<'a, MemEdgeRef<'a>>;
 pub type GraphTProps<'a> = GenericTProps<'a, MemGraphPropRef<'a>>;
 
 pub mod error {
+    use std::io;
+    use std::panic::Location;
     use std::{path::PathBuf, sync::Arc};
 
     use crate::resolver::mapping_resolver::InvalidNodeId;
@@ -89,8 +91,11 @@ pub mod error {
     pub enum StorageError {
         #[error("External Storage Error {0}")]
         External(#[from] Arc<dyn std::error::Error + Send + Sync>),
-        #[error("IO error: {0}")]
-        IO(#[from] std::io::Error),
+        #[error("{source} at {location}")]
+        IO {
+            source: io::Error,
+            location: &'static Location<'static>,
+        },
         #[error("Serde error: {0}")]
         Serde(#[from] serde_json::Error),
         #[error("Arrow-rs error: {0}")]
@@ -125,6 +130,14 @@ pub mod error {
     impl StorageError {
         pub fn from_external<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
             Self::External(Arc::new(error))
+        }
+    }
+
+    impl From<io::Error> for StorageError {
+        #[track_caller]
+        fn from(source: io::Error) -> Self {
+            let location = Location::caller();
+            StorageError::IO { source, location }
         }
     }
 }

--- a/db4-storage/src/pages/edge_store.rs
+++ b/db4-storage/src/pages/edge_store.rs
@@ -162,6 +162,10 @@ impl<ES: EdgeSegmentOps<Extension = EXT>, EXT: PersistenceStrategy<ES = ES>>
         &self.segments
     }
 
+    pub fn num_segments(&self) -> usize {
+        self.segments.count()
+    }
+
     pub fn new_with_meta(edges_path: Option<PathBuf>, edge_meta: Arc<Meta>, ext: EXT) -> Self {
         let free_pages = (0..(*N)).map(RwLock::new).collect::<Box<[_]>>();
         let empty = Self {
@@ -640,7 +644,7 @@ impl<ES: EdgeSegmentOps<Extension = EXT>, EXT: PersistenceStrategy<ES = ES>>
             })
     }
 
-    pub(crate) fn segment_counts(&self) -> SegmentCounts<EID> {
+    pub fn segment_counts(&self) -> SegmentCounts<EID> {
         SegmentCounts::new(
             self.max_page_len(),
             self.pages().iter().map(|(_, seg)| seg.num_edges()),

--- a/db4-storage/src/pages/mod.rs
+++ b/db4-storage/src/pages/mod.rs
@@ -529,7 +529,7 @@ impl<I: From<usize> + Into<usize>> SegmentCounts<I> {
         StateIndex::from(self)
     }
 
-    pub(crate) fn counts(&self) -> &[u32] {
+    pub fn counts(&self) -> &[u32] {
         &self.counts
     }
 

--- a/db4-storage/src/pages/node_store.rs
+++ b/db4-storage/src/pages/node_store.rs
@@ -166,7 +166,7 @@ impl<NS: NodeSegmentOps<Extension = EXT>, EXT: PersistenceStrategy<NS = NS>>
         })
     }
 
-    pub fn segments_count(&self) -> usize {
+    pub fn num_segments(&self) -> usize {
         self.segments.count()
     }
 

--- a/db4-storage/src/pages/test_utils/checkers.rs
+++ b/db4-storage/src/pages/test_utils/checkers.rs
@@ -136,7 +136,7 @@ pub fn check_edges_support<
         let edges = graph.edges();
 
         if !expected_edges.is_empty() {
-            assert!(nodes.segments_count() > 0, "{stage}");
+            assert!(nodes.num_segments() > 0, "{stage}");
         }
 
         // Group edges by layer_id first

--- a/db4-storage/src/resolver/mod.rs
+++ b/db4-storage/src/resolver/mod.rs
@@ -58,6 +58,14 @@ pub trait GIDResolverOps {
         gid: GidRef<'a>,
     ) -> Result<MaybeInit<Self::Init<'a>>, StorageError>;
 
+    //
+    fn get_or_init_optimistic<'a>(
+        &'a self,
+        gid: GidRef<'a>,
+    ) -> Result<MaybeInit<Self::Init<'a>>, StorageError> {
+        self.get_or_init(gid)
+    }
+
     fn validate_gids<'a>(
         &self,
         gids: impl IntoIterator<Item = GidRef<'a>>,

--- a/db4-storage/src/resolver/mod.rs
+++ b/db4-storage/src/resolver/mod.rs
@@ -58,14 +58,6 @@ pub trait GIDResolverOps {
         gid: GidRef<'a>,
     ) -> Result<MaybeInit<Self::Init<'a>>, StorageError>;
 
-    //
-    fn get_or_init_optimistic<'a>(
-        &'a self,
-        gid: GidRef<'a>,
-    ) -> Result<MaybeInit<Self::Init<'a>>, StorageError> {
-        self.get_or_init(gid)
-    }
-
     fn validate_gids<'a>(
         &self,
         gids: impl IntoIterator<Item = GidRef<'a>>,

--- a/db4-storage/src/segments/edge/segment.rs
+++ b/db4-storage/src/segments/edge/segment.rs
@@ -500,7 +500,7 @@ impl<P: PersistenceStrategy<ES = EdgeSegmentView<P>>> EdgeSegmentOps for EdgeSeg
             .into(),
             segment_id: page_id,
             num_edges: AtomicU32::new(0),
-            ext: ext,
+            ext,
         }
     }
 
@@ -529,6 +529,10 @@ impl<P: PersistenceStrategy<ES = EdgeSegmentView<P>>> EdgeSegmentOps for EdgeSeg
     }
 
     fn set_dirty(&self, _dirty: bool) {}
+
+    fn is_dirty(&self) -> bool {
+        true
+    }
 
     fn notify_write(
         &self,

--- a/db4-storage/src/segments/node/segment.rs
+++ b/db4-storage/src/segments/node/segment.rs
@@ -400,7 +400,7 @@ pub struct NodeSegmentView<EXT> {
     inner: Arc<RwLock<MemNodeSegment>>,
     segment_id: usize,
     max_num_node: AtomicU32,
-    ext: EXT,
+    _ext: EXT,
 }
 
 #[derive(Debug)]
@@ -484,13 +484,17 @@ impl<P: PersistenceStrategy<NS = NodeSegmentView<P>>> NodeSegmentOps for NodeSeg
         Self {
             inner,
             segment_id,
-            ext: ext,
+            _ext: ext,
             max_num_node: AtomicU32::new(0),
         }
     }
 
     fn segment_id(&self) -> usize {
         self.segment_id
+    }
+
+    fn is_dirty(&self) -> bool {
+        true
     }
 
     #[inline(always)]

--- a/raphtory-storage/src/graph/graph.rs
+++ b/raphtory-storage/src/graph/graph.rs
@@ -134,6 +134,20 @@ impl GraphStorage {
         }
     }
 
+    pub fn num_node_segments(&self) -> usize {
+        match self {
+            GraphStorage::Mem(storage) => storage.graph.storage().nodes().num_segments(),
+            GraphStorage::Unlocked(storage) => storage.storage().nodes().num_segments(),
+        }
+    }
+
+    pub fn num_edge_segments(&self) -> usize {
+        match self {
+            GraphStorage::Mem(storage) => storage.graph.storage().edges().num_segments(),
+            GraphStorage::Unlocked(storage) => storage.storage().edges().num_segments(),
+        }
+    }
+
     #[inline(always)]
     pub fn internalise_node(&self, v: NodeRef) -> Option<VID> {
         match v {

--- a/raphtory-storage/src/mutation/addition_ops.rs
+++ b/raphtory-storage/src/mutation/addition_ops.rs
@@ -56,11 +56,8 @@ pub trait InternalAdditionOps {
         node_type: Option<&str>,
     ) -> Result<(VID, usize), Self::Error>;
 
-    fn bulk_load_resolve_node_and_type(
-        &self,
-        id: NodeRef,
-        node_type: Option<&str>,
-    ) -> Result<(VID, usize), Self::Error>;
+    /// SAFETY this function assumes it is called from behind a sharded structure that does not allow the same id to be resolved at the same time by more than 1 thread
+    unsafe fn bulk_load_resolve_node(&self, id: GidRef<'_>) -> Result<VID, Self::Error>;
 
     /// validate the GidRef is the correct type
     fn validate_gids<'a>(
@@ -278,13 +275,9 @@ impl InternalAdditionOps for GraphStorage {
             .map_err(MutationError::from)
     }
 
-    fn bulk_load_resolve_node_and_type(
-        &self,
-        id: NodeRef,
-        node_type: Option<&str>,
-    ) -> Result<(VID, usize), Self::Error> {
+    unsafe fn bulk_load_resolve_node(&self, id: GidRef<'_>) -> Result<VID, Self::Error> {
         self.mutable()?
-            .bulk_load_resolve_node_and_type(id, node_type)
+            .bulk_load_resolve_node(id)
             .map_err(MutationError::from)
     }
 
@@ -398,12 +391,8 @@ where
         self.base().resolve_node_and_type(id, node_type)
     }
 
-    fn bulk_load_resolve_node_and_type(
-        &self,
-        id: NodeRef,
-        node_type: Option<&str>,
-    ) -> Result<(VID, usize), Self::Error> {
-        self.base().bulk_load_resolve_node_and_type(id, node_type)
+    unsafe fn bulk_load_resolve_node(&self, id: GidRef<'_>) -> Result<VID, Self::Error> {
+        self.base().bulk_load_resolve_node(id)
     }
 
     fn atomic_add_node(&self, node: NodeRef) -> Result<AtomicAddNode<'_>, Self::Error> {

--- a/raphtory-storage/src/mutation/addition_ops.rs
+++ b/raphtory-storage/src/mutation/addition_ops.rs
@@ -56,6 +56,12 @@ pub trait InternalAdditionOps {
         node_type: Option<&str>,
     ) -> Result<(VID, usize), Self::Error>;
 
+    fn bulk_load_resolve_node_and_type(
+        &self,
+        id: NodeRef,
+        node_type: Option<&str>,
+    ) -> Result<(VID, usize), Self::Error>;
+
     /// validate the GidRef is the correct type
     fn validate_gids<'a>(
         &self,
@@ -272,6 +278,16 @@ impl InternalAdditionOps for GraphStorage {
             .map_err(MutationError::from)
     }
 
+    fn bulk_load_resolve_node_and_type(
+        &self,
+        id: NodeRef,
+        node_type: Option<&str>,
+    ) -> Result<(VID, usize), Self::Error> {
+        self.mutable()?
+            .bulk_load_resolve_node_and_type(id, node_type)
+            .map_err(MutationError::from)
+    }
+
     fn atomic_add_node(&self, node: NodeRef) -> Result<AtomicAddNode<'_>, Self::Error> {
         self.mutable()?.atomic_add_node(node)
     }
@@ -380,6 +396,14 @@ where
         node_type: Option<&str>,
     ) -> Result<(VID, usize), Self::Error> {
         self.base().resolve_node_and_type(id, node_type)
+    }
+
+    fn bulk_load_resolve_node_and_type(
+        &self,
+        id: NodeRef,
+        node_type: Option<&str>,
+    ) -> Result<(VID, usize), Self::Error> {
+        self.base().bulk_load_resolve_node_and_type(id, node_type)
     }
 
     fn atomic_add_node(&self, node: NodeRef) -> Result<AtomicAddNode<'_>, Self::Error> {

--- a/raphtory-storage/src/mutation/addition_ops_ext.rs
+++ b/raphtory-storage/src/mutation/addition_ops_ext.rs
@@ -331,34 +331,21 @@ impl InternalAdditionOps for TemporalGraph {
         Ok((vid, node_type_id))
     }
 
-    fn bulk_load_resolve_node_and_type(
-        &self,
-        id: NodeRef,
-        node_type: Option<&str>,
-    ) -> Result<(VID, usize), Self::Error> {
-        let vid = match id {
-            NodeRef::External(id) => match self.logical_to_physical.get(id) {
-                Some(vid) => vid,
-                None => {
-                    let (seg, pos) = self
-                        .storage()
-                        .nodes()
-                        .reserve_free_pos(self.round_robin_counter.fetch_add(1, Ordering::Relaxed));
-                    pos.as_vid(seg, self.extension().config().max_node_page_len())
-                }
-            },
-            NodeRef::Internal(id) => id,
+    unsafe fn bulk_load_resolve_node(&self, id: GidRef<'_>) -> Result<VID, Self::Error> {
+        let vid = match self.logical_to_physical.get(id) {
+            Some(vid) => vid,
+            None => {
+                let (seg, pos) = self
+                    .storage()
+                    .nodes()
+                    .reserve_free_pos(self.round_robin_counter.fetch_add(1, Ordering::Relaxed));
+                let new_vid = pos.as_vid(seg, self.extension().config().max_node_page_len());
+                self.logical_to_physical.set(id, new_vid)?;
+                new_vid
+            }
         };
 
-        let node_type_id = match node_type {
-            Some(node_type) => self
-                .node_meta()
-                .get_or_create_node_type_id(node_type)
-                .inner(),
-            None => DEFAULT_NODE_TYPE_ID,
-        };
-
-        Ok((vid, node_type_id))
+        Ok(vid)
     }
 
     fn validate_gids<'a>(

--- a/raphtory-storage/src/mutation/addition_ops_ext.rs
+++ b/raphtory-storage/src/mutation/addition_ops_ext.rs
@@ -331,6 +331,36 @@ impl InternalAdditionOps for TemporalGraph {
         Ok((vid, node_type_id))
     }
 
+    fn bulk_load_resolve_node_and_type(
+        &self,
+        id: NodeRef,
+        node_type: Option<&str>,
+    ) -> Result<(VID, usize), Self::Error> {
+        let vid = match id {
+            NodeRef::External(id) => match self.logical_to_physical.get(id) {
+                Some(vid) => vid,
+                None => {
+                    let (seg, pos) = self
+                        .storage()
+                        .nodes()
+                        .reserve_free_pos(self.round_robin_counter.fetch_add(1, Ordering::Relaxed));
+                    pos.as_vid(seg, self.extension().config().max_node_page_len())
+                }
+            },
+            NodeRef::Internal(id) => id,
+        };
+
+        let node_type_id = match node_type {
+            Some(node_type) => self
+                .node_meta()
+                .get_or_create_node_type_id(node_type)
+                .inner(),
+            None => DEFAULT_NODE_TYPE_ID,
+        };
+
+        Ok((vid, node_type_id))
+    }
+
     fn validate_gids<'a>(
         &self,
         gids: impl IntoIterator<Item = GidRef<'a>>,

--- a/raphtory/Cargo.toml
+++ b/raphtory/Cargo.toml
@@ -110,8 +110,8 @@ streaming-stats = { workspace = true }
 indoc = { workspace = true }
 raphtory = { workspace = true, features = ["test-utils"] } # enable test-utils for integration tests
 
-#[target.'cfg(not(target_env = "msvc"))'.dependencies]
-#tikv-jemallocator = "0.6.1"
+[target.'cfg(target_os = "macos")'.dependencies]
+tikv-jemallocator = "0.6.1"
 
 [build-dependencies]
 prost-build = { workspace = true, optional = true }

--- a/raphtory/examples/snb_loader.rs
+++ b/raphtory/examples/snb_loader.rs
@@ -11,300 +11,307 @@ fn pq(parquet_dir: &Path, name: &str) -> PathBuf {
     parquet_dir.join(format!("{}.parquet", name))
 }
 
+#[cfg(target_os = "macos")]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(target_os = "macos")]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 /// Load SNB data from Parquet files into a Raphtory Graph.
 #[cfg(feature = "io")]
 fn load_snb_graph(parquet_dir: &Path, graph: &Graph) -> Result<(), GraphError> {
     // ── Static Nodes ──────────────────────────────────────────────────────
 
-    println!("Loading Places...");
-    load_nodes_from_parquet(
-        graph,
-        &pq(parquet_dir, "place"),
-        "_time",
-        None,
-        "_node_id",
-        None,
-        Some("type"),
-        &["name", "url", "id"],
-        &[],
-        None,
-        None,
-        true,
-        None,
-    )?;
-    println!("  ✓ places");
+    // println!("Loading Places...");
+    // load_nodes_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "place"),
+    //     "_time",
+    //     None,
+    //     "_node_id",
+    //     None,
+    //     Some("type"),
+    //     &["name", "url", "id"],
+    //     &[],
+    //     None,
+    //     None,
+    //     true,
+    //     None,
+    // )?;
+    // println!("  ✓ places");
 
-    let fp = pq(parquet_dir, "place_IS_PART_OF_place");
-    if fp.exists() {
-        load_edges_from_parquet(
-            graph,
-            &fp,
-            ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-            true,
-            &[],
-            &[],
-            None,
-            Some("IS_PART_OF"),
-            None,
-            None,
-        )?;
-        graph.flush()?;
-        println!("  ✓ IS_PART_OF edges");
-    }
+    // let fp = pq(parquet_dir, "place_IS_PART_OF_place");
+    // if fp.exists() {
+    //     load_edges_from_parquet(
+    //         graph,
+    //         &fp,
+    //         ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //         true,
+    //         &[],
+    //         &[],
+    //         None,
+    //         Some("IS_PART_OF"),
+    //         None,
+    //         None,
+    //     )?;
+    //     graph.flush()?;
+    //     println!("  ✓ IS_PART_OF edges");
+    // }
 
-    println!("Loading Organisations...");
-    load_nodes_from_parquet(
-        graph,
-        &pq(parquet_dir, "organisation"),
-        "_time",
-        None,
-        "_node_id",
-        None,
-        Some("type"),
-        &["name", "url", "id"],
-        &[],
-        None,
-        None,
-        true,
-        None,
-    )?;
-    println!("  ✓ organisations");
+    // println!("Loading Organisations...");
+    // load_nodes_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "organisation"),
+    //     "_time",
+    //     None,
+    //     "_node_id",
+    //     None,
+    //     Some("type"),
+    //     &["name", "url", "id"],
+    //     &[],
+    //     None,
+    //     None,
+    //     true,
+    //     None,
+    // )?;
+    // println!("  ✓ organisations");
 
-    load_edges_from_parquet(
-        graph,
-        &pq(parquet_dir, "organisation_IS_LOCATED_IN_place"),
-        ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-        true,
-        &[],
-        &[],
-        None,
-        Some("IS_LOCATED_IN"),
-        None,
-        None,
-    )?;
-    graph.flush()?;
-    println!("  ✓ Organisation IS_LOCATED_IN edges");
+    // load_edges_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "organisation_IS_LOCATED_IN_place"),
+    //     ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //     true,
+    //     &[],
+    //     &[],
+    //     None,
+    //     Some("IS_LOCATED_IN"),
+    //     None,
+    //     None,
+    // )?;
+    // graph.flush()?;
+    // println!("  ✓ Organisation IS_LOCATED_IN edges");
 
-    println!("Loading Tags...");
-    load_nodes_from_parquet(
-        graph,
-        &pq(parquet_dir, "tag"),
-        "_time",
-        None,
-        "_node_id",
-        Some("Tag"),
-        None,
-        &["name", "url", "id"],
-        &[],
-        None,
-        None,
-        true,
-        None,
-    )?;
-    println!("  ✓ tags");
+    // println!("Loading Tags...");
+    // load_nodes_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "tag"),
+    //     "_time",
+    //     None,
+    //     "_node_id",
+    //     Some("Tag"),
+    //     None,
+    //     &["name", "url", "id"],
+    //     &[],
+    //     None,
+    //     None,
+    //     true,
+    //     None,
+    // )?;
+    // println!("  ✓ tags");
 
-    let fp = pq(parquet_dir, "tagclass");
-    if fp.exists() {
-        println!("Loading TagClasses...");
-        load_nodes_from_parquet(
-            graph,
-            &fp,
-            "_time",
-            None,
-            "_node_id",
-            Some("TagClass"),
-            None,
-            &["name", "url", "id"],
-            &[],
-            None,
-            None,
-            true,
-            None,
-        )?;
-        println!("  ✓ tag classes");
-    }
+    // let fp = pq(parquet_dir, "tagclass");
+    // if fp.exists() {
+    //     println!("Loading TagClasses...");
+    //     load_nodes_from_parquet(
+    //         graph,
+    //         &fp,
+    //         "_time",
+    //         None,
+    //         "_node_id",
+    //         Some("TagClass"),
+    //         None,
+    //         &["name", "url", "id"],
+    //         &[],
+    //         None,
+    //         None,
+    //         true,
+    //         None,
+    //     )?;
+    //     println!("  ✓ tag classes");
+    // }
 
-    let fp = pq(parquet_dir, "tag_HAS_TYPE_tagclass");
-    if fp.exists() {
-        load_edges_from_parquet(
-            graph,
-            &fp,
-            ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-            true,
-            &[],
-            &[],
-            None,
-            Some("HAS_TYPE"),
-            None,
-            None,
-        )?;
-        graph.flush()?;
-        println!("  ✓ HAS_TYPE edges");
-    }
+    // let fp = pq(parquet_dir, "tag_HAS_TYPE_tagclass");
+    // if fp.exists() {
+    //     load_edges_from_parquet(
+    //         graph,
+    //         &fp,
+    //         ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //         true,
+    //         &[],
+    //         &[],
+    //         None,
+    //         Some("HAS_TYPE"),
+    //         None,
+    //         None,
+    //     )?;
+    //     graph.flush()?;
+    //     println!("  ✓ HAS_TYPE edges");
+    // }
 
-    let fp = pq(parquet_dir, "tagclass_IS_SUBCLASS_OF_tagclass");
-    if fp.exists() {
-        load_edges_from_parquet(
-            graph,
-            &fp,
-            ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-            true,
-            &[],
-            &[],
-            None,
-            Some("IS_SUBCLASS_OF"),
-            None,
-            None,
-        )?;
-        graph.flush()?;
-        println!("  ✓ IS_SUBCLASS_OF edges");
-    }
+    // let fp = pq(parquet_dir, "tagclass_IS_SUBCLASS_OF_tagclass");
+    // if fp.exists() {
+    //     load_edges_from_parquet(
+    //         graph,
+    //         &fp,
+    //         ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //         true,
+    //         &[],
+    //         &[],
+    //         None,
+    //         Some("IS_SUBCLASS_OF"),
+    //         None,
+    //         None,
+    //     )?;
+    //     graph.flush()?;
+    //     println!("  ✓ IS_SUBCLASS_OF edges");
+    // }
 
-    // ── Dynamic Nodes ─────────────────────────────────────────────────────
+    // // ── Dynamic Nodes ─────────────────────────────────────────────────────
 
-    println!("Loading Persons...");
-    load_nodes_from_parquet(
-        graph,
-        &pq(parquet_dir, "person"),
-        "creationDate",
-        None,
-        "_node_id",
-        Some("Person"),
-        None,
-        &[
-            "firstName",
-            "lastName",
-            "gender",
-            "birthday",
-            "locationIP",
-            "browserUsed",
-            "language",
-            "email",
-            "id",
-            "creationDate",
-        ],
-        &[],
-        None,
-        None,
-        true,
-        None,
-    )?;
-    println!("  ✓ persons");
+    // println!("Loading Persons...");
+    // load_nodes_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "person"),
+    //     "creationDate",
+    //     None,
+    //     "_node_id",
+    //     Some("Person"),
+    //     None,
+    //     &[
+    //         "firstName",
+    //         "lastName",
+    //         "gender",
+    //         "birthday",
+    //         "locationIP",
+    //         "browserUsed",
+    //         "language",
+    //         "email",
+    //         "id",
+    //         "creationDate",
+    //     ],
+    //     &[],
+    //     None,
+    //     None,
+    //     true,
+    //     None,
+    // )?;
+    // println!("  ✓ persons");
 
-    load_edges_from_parquet(
-        graph,
-        &pq(parquet_dir, "person_IS_LOCATED_IN_place"),
-        ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-        true,
-        &[],
-        &[],
-        None,
-        Some("IS_LOCATED_IN"),
-        None,
-        None,
-    )?;
-    graph.flush()?;
+    // load_edges_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "person_IS_LOCATED_IN_place"),
+    //     ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //     true,
+    //     &[],
+    //     &[],
+    //     None,
+    //     Some("IS_LOCATED_IN"),
+    //     None,
+    //     None,
+    // )?;
+    // graph.flush()?;
 
-    println!("Loading Forums...");
-    load_nodes_from_parquet(
-        graph,
-        &pq(parquet_dir, "forum"),
-        "creationDate",
-        None,
-        "_node_id",
-        Some("Forum"),
-        None,
-        &["title", "id", "creationDate"],
-        &[],
-        None,
-        None,
-        true,
-        None,
-    )?;
-    println!("  ✓ forums");
+    // println!("Loading Forums...");
+    // load_nodes_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "forum"),
+    //     "creationDate",
+    //     None,
+    //     "_node_id",
+    //     Some("Forum"),
+    //     None,
+    //     &["title", "id", "creationDate"],
+    //     &[],
+    //     None,
+    //     None,
+    //     true,
+    //     None,
+    // )?;
+    // println!("  ✓ forums");
 
-    load_edges_from_parquet(
-        graph,
-        &pq(parquet_dir, "forum_HAS_MODERATOR_person"),
-        ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-        true,
-        &[],
-        &[],
-        None,
-        Some("HAS_MODERATOR"),
-        None,
-        None,
-    )?;
-    graph.flush()?;
+    // load_edges_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "forum_HAS_MODERATOR_person"),
+    //     ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //     true,
+    //     &[],
+    //     &[],
+    //     None,
+    //     Some("HAS_MODERATOR"),
+    //     None,
+    //     None,
+    // )?;
+    // graph.flush()?;
 
-    println!("Loading Posts...");
-    load_nodes_from_parquet(
-        graph,
-        &pq(parquet_dir, "post"),
-        "creationDate",
-        None,
-        "_node_id",
-        Some("Post"),
-        None,
-        &[
-            "imageFile",
-            "locationIP",
-            "browserUsed",
-            "language",
-            "content",
-            "length",
-            "id",
-            "creationDate",
-        ],
-        &[],
-        None,
-        None,
-        true,
-        None,
-    )?;
-    println!("  ✓ posts");
+    // println!("Loading Posts...");
+    // load_nodes_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "post"),
+    //     "creationDate",
+    //     None,
+    //     "_node_id",
+    //     Some("Post"),
+    //     None,
+    //     &[
+    //         "imageFile",
+    //         "locationIP",
+    //         "browserUsed",
+    //         "language",
+    //         "content",
+    //         "length",
+    //         "id",
+    //         "creationDate",
+    //     ],
+    //     &[],
+    //     None,
+    //     None,
+    //     true,
+    //     None,
+    // )?;
+    // println!("  ✓ posts");
 
-    load_edges_from_parquet(
-        graph,
-        &pq(parquet_dir, "post_HAS_CREATOR_person"),
-        ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-        true,
-        &[],
-        &[],
-        None,
-        Some("HAS_CREATOR"),
-        None,
-        None,
-    )?;
-    graph.flush()?;
+    // load_edges_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "post_HAS_CREATOR_person"),
+    //     ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //     true,
+    //     &[],
+    //     &[],
+    //     None,
+    //     Some("HAS_CREATOR"),
+    //     None,
+    //     None,
+    // )?;
+    // graph.flush()?;
 
-    load_edges_from_parquet(
-        graph,
-        &pq(parquet_dir, "post_IS_LOCATED_IN_place"),
-        ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-        true,
-        &[],
-        &[],
-        None,
-        Some("IS_LOCATED_IN"),
-        None,
-        None,
-    )?;
-    graph.flush()?;
+    // load_edges_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "post_IS_LOCATED_IN_place"),
+    //     ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //     true,
+    //     &[],
+    //     &[],
+    //     None,
+    //     Some("IS_LOCATED_IN"),
+    //     None,
+    //     None,
+    // )?;
+    // graph.flush()?;
 
-    load_edges_from_parquet(
-        graph,
-        &pq(parquet_dir, "forum_CONTAINER_OF_post"),
-        ColumnNames::new("_time", None, "START_ID", "END_ID", None),
-        true,
-        &[],
-        &[],
-        None,
-        Some("CONTAINER_OF"),
-        None,
-        None,
-    )?;
-    graph.flush()?;
+    // load_edges_from_parquet(
+    //     graph,
+    //     &pq(parquet_dir, "forum_CONTAINER_OF_post"),
+    //     ColumnNames::new("_time", None, "START_ID", "END_ID", None),
+    //     true,
+    //     &[],
+    //     &[],
+    //     None,
+    //     Some("CONTAINER_OF"),
+    //     None,
+    //     None,
+    // )?;
+    // graph.flush()?;
 
     println!("Loading Comments...");
     load_nodes_from_parquet(
@@ -330,7 +337,7 @@ fn load_snb_graph(parquet_dir: &Path, graph: &Graph) -> Result<(), GraphError> {
         None,
     )?;
     println!("  ✓ comments");
-    graph.flush()?;
+    // graph.flush()?;
 
     load_edges_from_parquet(
         graph,
@@ -344,7 +351,7 @@ fn load_snb_graph(parquet_dir: &Path, graph: &Graph) -> Result<(), GraphError> {
         None,
         None,
     )?;
-    graph.flush()?;
+    // graph.flush()?;
 
     load_edges_from_parquet(
         graph,
@@ -358,7 +365,7 @@ fn load_snb_graph(parquet_dir: &Path, graph: &Graph) -> Result<(), GraphError> {
         None,
         None,
     )?;
-    graph.flush()?;
+    // graph.flush()?;
 
     load_edges_from_parquet(
         graph,
@@ -385,7 +392,7 @@ fn load_snb_graph(parquet_dir: &Path, graph: &Graph) -> Result<(), GraphError> {
         None,
         None,
     )?;
-    graph.flush()?;
+    // graph.flush()?;
 
     // ── Edge-only relationships ───────────────────────────────────────────
 

--- a/raphtory/src/db/api/storage/storage.rs
+++ b/raphtory/src/db/api/storage/storage.rs
@@ -562,12 +562,8 @@ impl InternalAdditionOps for Storage {
         Ok(self.graph.resolve_node_and_type(id, node_type)?)
     }
 
-    fn bulk_load_resolve_node_and_type(
-        &self,
-        id: NodeRef,
-        node_type: Option<&str>,
-    ) -> Result<(VID, usize), Self::Error> {
-        Ok(self.graph.bulk_load_resolve_node_and_type(id, node_type)?)
+    unsafe fn bulk_load_resolve_node(&self, id: GidRef<'_>) -> Result<VID, Self::Error> {
+        Ok(self.graph.bulk_load_resolve_node(id)?)
     }
 
     fn atomic_add_node(&self, node: NodeRef) -> Result<AtomicAddNode<'_>, Self::Error> {

--- a/raphtory/src/db/api/storage/storage.rs
+++ b/raphtory/src/db/api/storage/storage.rs
@@ -562,6 +562,14 @@ impl InternalAdditionOps for Storage {
         Ok(self.graph.resolve_node_and_type(id, node_type)?)
     }
 
+    fn bulk_load_resolve_node_and_type(
+        &self,
+        id: NodeRef,
+        node_type: Option<&str>,
+    ) -> Result<(VID, usize), Self::Error> {
+        Ok(self.graph.bulk_load_resolve_node_and_type(id, node_type)?)
+    }
+
     fn atomic_add_node(&self, node: NodeRef) -> Result<AtomicAddNode<'_>, Self::Error> {
         self.graph.atomic_add_node(node).map_err(into_graph_err)
     }

--- a/raphtory/src/errors.rs
+++ b/raphtory/src/errors.rs
@@ -122,7 +122,7 @@ pub fn into_graph_err(err: impl Into<GraphError>) -> GraphError {
 #[derive(thiserror::Error, Debug)]
 pub enum GraphError {
     #[error(transparent)]
-    ExternalError(#[from] Arc<dyn std::error::Error + Send + Sync>),
+    ExternalError(Arc<dyn std::error::Error + Send + Sync>),
 
     #[error(transparent)]
     MutationError(#[from] MutationError),

--- a/raphtory/src/io/arrow/df_loaders/edges.rs
+++ b/raphtory/src/io/arrow/df_loaders/edges.rs
@@ -9,7 +9,6 @@ use crate::{
             dataframe::{DFChunk, DFView},
             df_loaders::{
                 extract_secondary_index_col, process_shared_properties, resolve_nodes_with_cache,
-                GidKey,
             },
             layer_col::lift_layer_col,
             node_col::NodeCol,
@@ -28,10 +27,10 @@ use raphtory_api::{
     atomic_extra::{atomic_usize_from_mut_slice, atomic_vid_from_mut_slice},
     core::{
         entities::{properties::meta::STATIC_GRAPH_LAYER_ID, EID},
-        storage::{dict_mapper::MaybeNew, timeindex::EventTime, FxDashMap},
+        storage::{dict_mapper::MaybeNew, timeindex::EventTime},
     },
 };
-use raphtory_core::entities::VID;
+use raphtory_core::entities::{GidRef, VID};
 use raphtory_storage::mutation::addition_ops::SessionAdditionOps;
 use rayon::prelude::*;
 use std::{
@@ -43,12 +42,17 @@ use std::{
 };
 use storage::{
     api::{edges::EdgeSegmentOps, nodes::NodeSegmentOps},
-    pages::locked::{
-        edges::{LockedEdgePage, WriteLockedEdgePages},
-        nodes::LockedNodePage,
+    pages::{
+        edge_store::EdgeStorageInner,
+        locked::{
+            edges::{LockedEdgePage, WriteLockedEdgePages},
+            nodes::LockedNodePage,
+        },
+        resolve_pos,
     },
     Extension,
 };
+use zip::write;
 
 #[derive(Debug, Copy, Clone)]
 pub struct ColumnNames<'a> {
@@ -166,6 +170,7 @@ pub fn load_edges_from_df<G: StaticGraphViewOps + PropertyAdditionOps + Addition
     if df_view.is_empty() {
         return Ok(());
     }
+    graph.flush().map_err(into_graph_err)?;
 
     let ColumnNames {
         time,
@@ -222,7 +227,16 @@ pub fn load_edges_from_df<G: StaticGraphViewOps + PropertyAdditionOps + Addition
     let mut eids_exist: Vec<AtomicBool> = vec![]; // exists or needs to be created
     let mut layer_eids_exist: Vec<AtomicBool> = vec![]; // exists or needs to be created
 
-    for chunk in df_view.chunks {
+    // I want to find out which of the segments are touched by every chunk
+    let mut edge_segments_touched = (0..graph.core_graph().num_edge_segments())
+        .map(|_| AtomicBool::new(false))
+        .collect::<Vec<_>>();
+
+    let mut node_segments_touched = (0..graph.core_graph().num_node_segments())
+        .map(|_| AtomicBool::new(false))
+        .collect::<Vec<_>>();
+
+    for chunk in df_view.chunks.into_iter() {
         let df = chunk?;
         let prop_cols =
             combine_properties_arrow(properties, &properties_indices, &df, |key, dtype| {
@@ -273,6 +287,30 @@ pub fn load_edges_from_df<G: StaticGraphViewOps + PropertyAdditionOps + Addition
             extract_secondary_index_col::<G>(secondary_index_index, &session, &df)?;
 
         let mut write_locked_graph = graph.write_lock().map_err(into_graph_err)?;
+        let max_node_segment_len = write_locked_graph
+            .graph()
+            .storage()
+            .nodes()
+            .max_segment_len() as usize;
+
+        node_segments_touched.resize_with(write_locked_graph.nodes.len(), || AtomicBool::new(true));
+
+        if !gid_str_cache.is_empty() {
+            for (_, vid) in &gid_str_cache {
+                let (node_segment, _) = resolve_pos(vid.index(), max_node_segment_len as u32);
+                node_segments_touched[node_segment].store(true, Ordering::Relaxed);
+            }
+        } else {
+            // loading from our own parquet files here
+            let mut last_segment = usize::MAX;
+            for vid in src_vids.iter().chain(dst_vids) {
+                let (segment, _) = resolve_pos(vid.0, max_node_segment_len as u32);
+                if segment != last_segment {
+                    node_segments_touched[segment].store(true, Ordering::Relaxed);
+                }
+                last_segment = segment;
+            }
+        }
 
         eid_col_resolved.resize_with(df.len(), Default::default);
         eids_exist.resize_with(df.len(), Default::default);
@@ -280,11 +318,13 @@ pub fn load_edges_from_df<G: StaticGraphViewOps + PropertyAdditionOps + Addition
         let eid_col_shared = atomic_usize_from_mut_slice(cast_slice_mut(&mut eid_col_resolved));
 
         let arc_edges = write_locked_graph.graph().storage().edges().clone();
+
         let next_edge_id = |row: usize| {
             let (page, pos) = arc_edges.reserve_free_pos(row);
             pos.as_eid(page, arc_edges.max_page_len())
         };
 
+        let max_edge_page_len = arc_edges.max_page_len();
         let WriteLockedGraph {
             nodes, ref edges, ..
         } = &mut write_locked_graph;
@@ -299,108 +339,132 @@ pub fn load_edges_from_df<G: StaticGraphViewOps + PropertyAdditionOps + Addition
         });
 
         // Generate all edge_ids + add outbound edges
-        nodes.par_iter_mut().for_each(|locked_page| {
-            // Zip all columns for iteration.
-            let zip = izip!(
-                src_vids.iter(),
-                dst_vids.iter(),
-                time_col.iter(),
-                secondary_index_col.iter(),
-                layer_col_resolved.iter()
-            );
+        nodes
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(segment_id, locked_page)| {
+                if !node_segments_touched[segment_id].load(Ordering::Relaxed) {
+                    // we still need the writer in case we need to flush
+                    if locked_page.segment().is_dirty() {
+                        let mut _writer = locked_page.writer();
+                    }
+                    return;
+                }
 
-            // resolve_nodes=false
-            // assumes we are loading our own graph, via the parquet loaders,
-            // so previous calls have already stored the node ids and types
-            if resolve_nodes {
-                store_node_ids(&gid_str_cache, locked_page);
-            }
-
-            if resolve_nodes {
-                add_and_resolve_outbound_edges(
-                    &eids_exist,
-                    &layer_eids_exist,
-                    &eid_col_shared,
-                    next_edge_id,
-                    edges,
-                    locked_page,
-                    zip,
-                    delete,
+                // Zip all columns for iteration.
+                let zip = izip!(
+                    src_vids.iter(),
+                    dst_vids.iter(),
+                    time_col.iter(),
+                    secondary_index_col.iter(),
+                    layer_col_resolved.iter()
                 );
-            } else if let Some(edge_ids) = eids {
-                add_and_resolve_outbound_edges(
-                    &eids_exist,
-                    &layer_eids_exist,
-                    &eid_col_shared,
-                    |row| {
-                        let eid = EID(edge_ids[row] as usize);
-                        arc_edges.increment_edge_segment_count(eid);
-                        eid
-                    },
-                    edges,
-                    locked_page,
-                    zip,
-                    delete,
+
+                // resolve_nodes=false
+                // assumes we are loading our own graph, via the parquet loaders,
+                // so previous calls have already stored the node ids and types
+                if resolve_nodes {
+                    store_node_ids(&gid_str_cache, locked_page);
+                }
+
+                if resolve_nodes {
+                    add_and_resolve_outbound_edges(
+                        &eids_exist,
+                        &layer_eids_exist,
+                        &eid_col_shared,
+                        &edge_segments_touched,
+                        max_edge_page_len,
+                        next_edge_id,
+                        edges,
+                        locked_page,
+                        zip,
+                        delete,
+                    );
+                } else if let Some(edge_ids) = eids {
+                    add_and_resolve_outbound_edges(
+                        &eids_exist,
+                        &layer_eids_exist,
+                        &eid_col_shared,
+                        &edge_segments_touched,
+                        max_edge_page_len,
+                        |row| {
+                            let eid = EID(edge_ids[row] as usize);
+                            arc_edges.increment_edge_segment_count(eid);
+                            eid
+                        },
+                        edges,
+                        locked_page,
+                        zip,
+                        delete,
+                    );
+                }
+            });
+
+        write_locked_graph
+            .nodes
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(segment_id, shard)| {
+                if !node_segments_touched[segment_id].load(Ordering::Relaxed) {
+                    // we still need the writer in case we need to flush
+                    if shard.segment().is_dirty() {
+                        let mut _writer = shard.writer();
+                    }
+                    return;
+                }
+
+                let zip = izip!(
+                    src_vids.iter(),
+                    dst_vids.iter(),
+                    eid_col_resolved.iter(),
+                    time_col.iter(),
+                    secondary_index_col.iter(),
+                    layer_col_resolved.iter(),
+                    layer_eids_exist.iter().map(|a| a.load(Ordering::Relaxed)),
+                    eids_exist.iter().map(|b| b.load(Ordering::Relaxed))
                 );
-            }
-        });
 
-        write_locked_graph.nodes.par_iter_mut().for_each(|shard| {
-            let zip = izip!(
-                src_vids.iter(),
-                dst_vids.iter(),
-                eid_col_resolved.iter(),
-                time_col.iter(),
-                secondary_index_col.iter(),
-                layer_col_resolved.iter(),
-                layer_eids_exist.iter().map(|a| a.load(Ordering::Relaxed)),
-                eids_exist.iter().map(|b| b.load(Ordering::Relaxed))
-            );
-
-            update_inbound_edges(shard, zip, delete);
-        });
+                update_inbound_edges(shard, zip, delete);
+                node_segments_touched[segment_id].store(false, Ordering::Relaxed)
+            });
 
         drop(write_locked_graph);
         let mut write_locked_graph = graph.write_lock().map_err(into_graph_err)?;
 
-        write_locked_graph.edges.par_iter_mut().for_each(|shard| {
-            let zip = izip!(
-                src_vids.iter(),
-                dst_vids.iter(),
-                time_col.iter(),
-                secondary_index_col.iter(),
-                eid_col_resolved.iter(),
-                layer_col_resolved.iter(),
-                eids_exist
-                    .iter()
-                    .map(|exists| exists.load(Ordering::Relaxed))
-            );
-            update_edge_properties(
-                &shared_metadata,
-                &prop_cols,
-                &metadata_cols,
-                shard,
-                zip,
-                delete,
-            );
-        });
+        edge_segments_touched.resize_with(write_locked_graph.edges.len(), || AtomicBool::new(true));
 
-        // if graph.core_graph().extension().should_flush() {
-        //     println!(
-        //         "triggered global pause at size {}",
-        //         graph.core_graph().extension().estimated_size()
-        //     );
-        //     write_locked_graph
-        //         .edges
-        //         .attempt_flush(graph.core_graph().extension(), true);
-        //     write_locked_graph
-        //         .nodes
-        //         .attempt_flush(graph.core_graph().extension(), true);
-        //     println!(
-        //         "estimated size after completed flush {}",
-        //         graph.core_graph().extension().estimated_size()
-        //     );
-        // }
+        write_locked_graph
+            .edges
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(segment_id, shard)| {
+                if !edge_segments_touched[segment_id].load(Ordering::Relaxed) {
+                    // we still need the writer in case we need to flush
+                    let mut _writer = shard.writer();
+                    return;
+                }
+
+                let zip = izip!(
+                    src_vids.iter(),
+                    dst_vids.iter(),
+                    time_col.iter(),
+                    secondary_index_col.iter(),
+                    eid_col_resolved.iter(),
+                    layer_col_resolved.iter(),
+                    eids_exist
+                        .iter()
+                        .map(|exists| exists.load(Ordering::Relaxed))
+                );
+                update_edge_properties(
+                    &shared_metadata,
+                    &prop_cols,
+                    &metadata_cols,
+                    shard,
+                    zip,
+                    delete,
+                );
+                edge_segments_touched[segment_id].store(false, Ordering::Relaxed)
+            });
 
         #[cfg(feature = "progress")]
         let _ = pb.update(df.len());
@@ -408,7 +472,6 @@ pub fn load_edges_from_df<G: StaticGraphViewOps + PropertyAdditionOps + Addition
     Ok::<_, GraphError>(())
 }
 
-#[inline(never)]
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn get_or_resolve_node_vids<
     'a: 'c,
@@ -425,7 +488,7 @@ pub fn get_or_resolve_node_vids<
     df: &'b DFChunk,
     src_col: &'a NodeCol,
     dst_col: &'a NodeCol,
-) -> Result<(&'c [VID], &'c [VID], Vec<(GID, MaybeNew<VID>)>), GraphError> {
+) -> Result<(&'c [VID], &'c [VID], Vec<(GidRef<'a>, VID)>), GraphError> {
     let (src_vids, dst_vids, gid_str_cache) = if resolve_nodes {
         src_col_resolved.resize_with(df.len(), Default::default);
         dst_col_resolved.resize_with(df.len(), Default::default);
@@ -441,7 +504,7 @@ pub fn get_or_resolve_node_vids<
         (
             src_col_resolved.as_slice(),
             dst_col_resolved.as_slice(),
-            gid_str_cache.into_iter().map(|(_, v)| v).collect(),
+            gid_str_cache.into_iter().collect(),
         )
     } else {
         let srcs = df.chunk[src_index]
@@ -463,7 +526,6 @@ pub fn get_or_resolve_node_vids<
     Ok((src_vids, dst_vids, gid_str_cache))
 }
 
-#[inline(never)]
 fn update_edge_properties<'a, ES: EdgeSegmentOps<Extension = Extension>>(
     shared_metadata: &[(usize, Prop)],
     prop_cols: &PropCols,
@@ -505,7 +567,6 @@ fn update_edge_properties<'a, ES: EdgeSegmentOps<Extension = Extension>>(
     }
 }
 
-#[inline(never)]
 fn update_inbound_edges<'a, NS: NodeSegmentOps<Extension = Extension>>(
     shard: &mut LockedNodePage<'_, NS>,
     zip: impl Iterator<Item = (&'a VID, &'a VID, &'a EID, i64, usize, &'a usize, bool, bool)>,
@@ -551,7 +612,7 @@ fn update_inbound_edges<'a, NS: NodeSegmentOps<Extension = Extension>>(
     }
 }
 
-#[inline(never)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 fn add_and_resolve_outbound_edges<
     'a,
     EXT: PersistenceStrategy<NS = NS, ES = ES>,
@@ -561,6 +622,8 @@ fn add_and_resolve_outbound_edges<
     eids_exist: &[AtomicBool],
     layer_eids_exist: &[AtomicBool],
     eid_col_shared: &&mut [AtomicUsize],
+    edge_touched_segments: &[AtomicBool],
+    max_edge_page_len: u32,
     next_edge_id: impl Fn(usize) -> EID,
     edges: &WriteLockedEdgePages<'_, ES>,
     locked_page: &mut LockedNodePage<'_, NS>,
@@ -568,6 +631,7 @@ fn add_and_resolve_outbound_edges<
     delete: bool,
 ) {
     let mut writer = locked_page.writer();
+    let mut last_edge_segment = usize::MAX;
     for (row, (src, dst, time, secondary_index, layer)) in zip.enumerate() {
         if let Some(src_pos) = writer.resolve_pos(*src) {
             let t = EventTime(time, secondary_index);
@@ -594,6 +658,14 @@ fn add_and_resolve_outbound_edges<
                 }
             });
 
+            let (edge_segment, _) = resolve_pos(edge_id.inner().edge, max_edge_page_len);
+            if edge_segment != last_edge_segment {
+                if let Some(touched) = edge_touched_segments.get(edge_segment) {
+                    touched.store(true, Ordering::Relaxed);
+                }
+            }
+            last_edge_segment = edge_segment;
+
             let exists = !edge_id.is_new()
                 && (edges.exists(edge_id.inner())
                     || writer
@@ -612,13 +684,13 @@ fn add_and_resolve_outbound_edges<
 }
 
 pub fn store_node_ids<NS: NodeSegmentOps<Extension = Extension>>(
-    gid_str_cache: &[(GID, MaybeNew<VID>)],
+    gid_str_cache: &[(GidRef<'_>, VID)],
     locked_page: &mut LockedNodePage<'_, NS>,
 ) {
     let mut writer = locked_page.writer();
     for (src_gid, vid) in gid_str_cache.iter() {
-        if let Some(src_pos) = writer.resolve_pos(vid.inner()) {
-            writer.store_node_id(src_pos, STATIC_GRAPH_LAYER_ID, src_gid.clone());
+        if let Some(src_pos) = writer.resolve_pos(*vid) {
+            writer.store_node_id(src_pos, STATIC_GRAPH_LAYER_ID, (*src_gid).into());
         }
     }
 }

--- a/raphtory/src/io/arrow/df_loaders/edges.rs
+++ b/raphtory/src/io/arrow/df_loaders/edges.rs
@@ -43,7 +43,6 @@ use std::{
 use storage::{
     api::{edges::EdgeSegmentOps, nodes::NodeSegmentOps},
     pages::{
-        edge_store::EdgeStorageInner,
         locked::{
             edges::{LockedEdgePage, WriteLockedEdgePages},
             nodes::LockedNodePage,
@@ -52,7 +51,6 @@ use storage::{
     },
     Extension,
 };
-use zip::write;
 
 #[derive(Debug, Copy, Clone)]
 pub struct ColumnNames<'a> {

--- a/raphtory/src/io/arrow/df_loaders/edges.rs
+++ b/raphtory/src/io/arrow/df_loaders/edges.rs
@@ -425,14 +425,7 @@ pub fn get_or_resolve_node_vids<
     df: &'b DFChunk,
     src_col: &'a NodeCol,
     dst_col: &'a NodeCol,
-) -> Result<
-    (
-        &'c [VID],
-        &'c [VID],
-        FxDashMap<GidKey<'a>, (GID, MaybeNew<VID>)>,
-    ),
-    GraphError,
-> {
+) -> Result<(&'c [VID], &'c [VID], Vec<(GID, MaybeNew<VID>)>), GraphError> {
     let (src_vids, dst_vids, gid_str_cache) = if resolve_nodes {
         src_col_resolved.resize_with(df.len(), Default::default);
         dst_col_resolved.resize_with(df.len(), Default::default);
@@ -448,7 +441,7 @@ pub fn get_or_resolve_node_vids<
         (
             src_col_resolved.as_slice(),
             dst_col_resolved.as_slice(),
-            gid_str_cache,
+            gid_str_cache.into_iter().map(|(_, v)| v).collect(),
         )
     } else {
         let srcs = df.chunk[src_index]
@@ -464,7 +457,7 @@ pub fn get_or_resolve_node_vids<
         (
             bytemuck::cast_slice(srcs),
             bytemuck::cast_slice(dsts),
-            FxDashMap::default(),
+            vec![],
         )
     };
     Ok((src_vids, dst_vids, gid_str_cache))
@@ -618,14 +611,12 @@ fn add_and_resolve_outbound_edges<
     }
 }
 
-pub fn store_node_ids<K: Eq + std::hash::Hash, NS: NodeSegmentOps<Extension = Extension>>(
-    gid_str_cache: &FxDashMap<K, (GID, MaybeNew<VID>)>,
+pub fn store_node_ids<NS: NodeSegmentOps<Extension = Extension>>(
+    gid_str_cache: &[(GID, MaybeNew<VID>)],
     locked_page: &mut LockedNodePage<'_, NS>,
 ) {
     let mut writer = locked_page.writer();
-    for entry in gid_str_cache.iter() {
-        let (src_gid, vid) = entry.value();
-
+    for (src_gid, vid) in gid_str_cache.iter() {
         if let Some(src_pos) = writer.resolve_pos(vid.inner()) {
             writer.store_node_id(src_pos, STATIC_GRAPH_LAYER_ID, src_gid.clone());
         }

--- a/raphtory/src/io/arrow/df_loaders/mod.rs
+++ b/raphtory/src/io/arrow/df_loaders/mod.rs
@@ -1,11 +1,9 @@
 use crate::{
-    core::entities::nodes::node_ref::AsNodeRef,
     db::api::view::StaticGraphViewOps,
     errors::{into_graph_err, GraphError},
     io::arrow::{
         dataframe::{DFChunk, DFView, SecondaryIndexCol},
         df_loaders::edges::ColumnNames,
-        layer_col::LayerCol,
         node_col::NodeCol,
         prop_handler::*,
     },
@@ -259,21 +257,15 @@ fn resolve_nodes_with_cache<'a, G: StaticGraphViewOps + PropertyAdditionOps + Ad
     graph: &G,
     cols_to_resolve: &[&'a NodeCol],
     resolved_cols: &[&mut [AtomicUsize]],
-) -> Result<FxDashMap<GidKey<'a>, (GID, MaybeNew<VID>)>, GraphError> {
-    let node_type_col = vec![None; cols_to_resolve.len()];
+) -> Result<FxDashMap<GidRef<'a>, VID>, GraphError> {
     resolve_nodes_with_cache_generic(
         cols_to_resolve,
-        &node_type_col,
-        |v: &(GID, MaybeNew<VID>), idx, col_idx| {
-            let (_, vid) = v;
-            resolved_cols[col_idx][idx].store(vid.inner().0, Ordering::Relaxed);
+        |vid: &VID, idx, col_idx| {
+            resolved_cols[col_idx][idx].store(vid.0, Ordering::Relaxed);
         },
         |gid, _idx| {
-            let GidKey { gid, .. } = gid;
-            let vid = graph
-                .resolve_node(gid.as_node_ref())
-                .map_err(into_graph_err)?;
-            Ok((GID::from(gid), vid))
+            let vid = unsafe { graph.bulk_load_resolve_node(gid).map_err(into_graph_err)? };
+            Ok(vid)
         },
     )
 }
@@ -286,47 +278,26 @@ fn resolve_nodes_and_type_with_cache<
     graph: &G,
     cols_to_resolve: &[&'a NodeCol],
     resolved_cols: &[&mut [AtomicUsize]],
-    node_type_col: LayerCol<'a>,
-) -> Result<FxDashMap<GidKey<'a>, (VID, usize)>, GraphError> {
-    let node_type_cols = vec![Some(node_type_col); cols_to_resolve.len()];
+) -> Result<FxDashMap<GidRef<'a>, VID>, GraphError> {
     resolve_nodes_with_cache_generic(
         cols_to_resolve,
-        &node_type_cols,
-        |v: &(VID, usize), row, col_idx| {
-            let (vid, _) = v;
+        |vid: &VID, row, col_idx| {
             resolved_cols[col_idx][row].store(vid.index(), Ordering::Relaxed);
         },
         |gid, _| {
-            let GidKey { gid, node_type } = gid;
-            let (vid, node_type) = graph
-                .bulk_load_resolve_node_and_type(gid.as_node_ref(), node_type)
-                .map_err(into_graph_err)?;
-            Ok((vid, node_type))
+            let vid = unsafe { graph.bulk_load_resolve_node(gid).map_err(into_graph_err)? };
+            Ok(vid)
         },
     )
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
-pub struct GidKey<'a> {
-    gid: GidRef<'a>,
-    node_type: Option<&'a str>,
-}
-
-impl<'a> GidKey<'a> {
-    pub fn new(gid: GidRef<'a>, node_type: Option<&'a str>) -> Self {
-        Self { gid, node_type }
-    }
 }
 
 #[inline(always)]
 fn resolve_nodes_with_cache_generic<'a, V: Send + Sync>(
     cols_to_resolve: &[&'a NodeCol],
-    node_type_cols: &[Option<LayerCol<'a>>],
     update_fn: impl Fn(&V, usize, usize) + Send + Sync,
-    new_fn: impl Fn(GidKey<'a>, usize) -> Result<V, GraphError> + Send + Sync,
-) -> Result<FxDashMap<GidKey<'a>, V>, GraphError> {
-    assert_eq!(cols_to_resolve.len(), node_type_cols.len());
-    let gid_str_cache: dashmap::DashMap<GidKey<'_>, V, _> = FxDashMap::default();
+    new_fn: impl Fn(GidRef<'a>, usize) -> Result<V, GraphError> + Send + Sync,
+) -> Result<FxDashMap<GidRef<'a>, V>, GraphError> {
+    let gid_str_cache: dashmap::DashMap<GidRef<'_>, V, _> = FxDashMap::default();
     let hasher_factory = gid_str_cache.hasher().clone();
     gid_str_cache
         .shards()
@@ -338,18 +309,14 @@ fn resolve_nodes_with_cache_generic<'a, V: Send + Sync>(
             use std::hash::BuildHasher;
 
             // Create hasher function for this shard
-            let hash_key = |key: &GidKey<'_>| -> u64 { hasher_factory.hash_one(key) };
+            let hash_key = |key: &GidRef<'_>| -> u64 { hasher_factory.hash_one(key) };
 
             let hasher_fn =
-                |tuple: &(GidKey<'_>, SharedValue<V>)| -> u64 { hasher_factory.hash_one(tuple.0) };
+                |tuple: &(GidRef<'_>, SharedValue<V>)| -> u64 { hasher_factory.hash_one(tuple.0) };
 
-            for (col_id, (node_col, layer_col)) in
-                cols_to_resolve.iter().zip(node_type_cols).enumerate()
-            {
+            for (col_id, node_col) in cols_to_resolve.iter().enumerate() {
                 // Process src_col sequentially for this shard
                 for (idx, gid) in node_col.iter().enumerate() {
-                    let node_type = layer_col.as_ref().and_then(|lc| lc.get(idx));
-                    let gid = GidKey::new(gid, node_type);
                     // Check if this key belongs to this shard
                     if gid_str_cache.determine_map(&gid) != shard_idx {
                         continue; // Skip, not our shard

--- a/raphtory/src/io/arrow/df_loaders/mod.rs
+++ b/raphtory/src/io/arrow/df_loaders/mod.rs
@@ -261,7 +261,7 @@ fn resolve_nodes_with_cache<'a, G: StaticGraphViewOps + PropertyAdditionOps + Ad
         |vid: &VID, idx, col_idx| {
             resolved_cols[col_idx][idx].store(vid.0, Ordering::Relaxed);
         },
-        |gid, _idx| {
+        |gid, _, _| {
             let vid = unsafe { graph.bulk_load_resolve_node(gid).map_err(into_graph_err)? };
             Ok(vid)
         },
@@ -274,16 +274,19 @@ fn resolve_nodes_and_type_with_cache<
 >(
     graph: &G,
     cols_to_resolve: &[&'a NodeCol],
+    node_types: &[&'a [usize]],
     resolved_cols: &[&mut [AtomicUsize]],
-) -> Result<FxDashMap<GidRef<'a>, VID>, GraphError> {
+) -> Result<FxDashMap<GidRef<'a>, (VID, usize)>, GraphError> {
     resolve_nodes_with_cache_generic(
         cols_to_resolve,
-        |vid: &VID, row, col_idx| {
+        |vid: &(VID, usize), row, col_idx| {
+            let (vid, _) = vid;
             resolved_cols[col_idx][row].store(vid.index(), Ordering::Relaxed);
         },
-        |gid, _| {
+        |gid, row, col_idx| {
             let vid = unsafe { graph.bulk_load_resolve_node(gid).map_err(into_graph_err)? };
-            Ok(vid)
+            let node_type = node_types[col_idx][row];
+            Ok((vid, node_type))
         },
     )
 }
@@ -291,7 +294,7 @@ fn resolve_nodes_and_type_with_cache<
 fn resolve_nodes_with_cache_generic<'a, V: Send + Sync>(
     cols_to_resolve: &[&'a NodeCol],
     update_fn: impl Fn(&V, usize, usize) + Send + Sync,
-    new_fn: impl Fn(GidRef<'a>, usize) -> Result<V, GraphError> + Send + Sync,
+    new_fn: impl Fn(GidRef<'a>, usize, usize) -> Result<V, GraphError> + Send + Sync,
 ) -> Result<FxDashMap<GidRef<'a>, V>, GraphError> {
     let gid_str_cache: dashmap::DashMap<GidRef<'_>, V, _> = FxDashMap::default();
     let hasher_factory = gid_str_cache.hasher().clone();
@@ -312,7 +315,7 @@ fn resolve_nodes_with_cache_generic<'a, V: Send + Sync>(
 
             for (col_id, node_col) in cols_to_resolve.iter().enumerate() {
                 // Process src_col sequentially for this shard
-                for (idx, gid) in node_col.iter().enumerate() {
+                for (row, gid) in node_col.iter().enumerate() {
                     // Check if this key belongs to this shard
                     if gid_str_cache.determine_map(&gid) != shard_idx {
                         continue; // Skip, not our shard
@@ -323,11 +326,11 @@ fn resolve_nodes_with_cache_generic<'a, V: Send + Sync>(
                     // Check if exists in this shard
                     if let Some((_, value)) = shard_guard.get(hash, |(g, _)| g == &gid) {
                         let v = value.get();
-                        update_fn(v, idx, col_id);
+                        update_fn(v, row, col_id);
                     } else {
-                        let v = new_fn(gid, idx)?;
+                        let v = new_fn(gid, row, col_id)?;
 
-                        update_fn(&v, idx, col_id);
+                        update_fn(&v, row, col_id);
                         let data = (gid, SharedValue::new(v));
                         shard_guard.insert(hash, data, hasher_fn);
                     }

--- a/raphtory/src/io/arrow/df_loaders/mod.rs
+++ b/raphtory/src/io/arrow/df_loaders/mod.rs
@@ -227,7 +227,6 @@ pub(crate) fn load_graph_props_from_df<
     Ok(())
 }
 
-#[inline(never)]
 pub(crate) fn extract_secondary_index_col<G: InternalAdditionOps + AdditionOps>(
     secondary_index_index: Option<usize>,
     session: &<G as InternalAdditionOps>::WS<'_>,
@@ -252,7 +251,6 @@ pub(crate) fn extract_secondary_index_col<G: InternalAdditionOps + AdditionOps>(
     Ok(secondary_index_col)
 }
 
-#[inline(never)]
 fn resolve_nodes_with_cache<'a, G: StaticGraphViewOps + PropertyAdditionOps + AdditionOps>(
     graph: &G,
     cols_to_resolve: &[&'a NodeCol],
@@ -270,7 +268,6 @@ fn resolve_nodes_with_cache<'a, G: StaticGraphViewOps + PropertyAdditionOps + Ad
     )
 }
 
-#[inline(never)]
 fn resolve_nodes_and_type_with_cache<
     'a,
     G: StaticGraphViewOps + PropertyAdditionOps + AdditionOps,
@@ -291,7 +288,6 @@ fn resolve_nodes_and_type_with_cache<
     )
 }
 
-#[inline(always)]
 fn resolve_nodes_with_cache_generic<'a, V: Send + Sync>(
     cols_to_resolve: &[&'a NodeCol],
     update_fn: impl Fn(&V, usize, usize) + Send + Sync,

--- a/raphtory/src/io/arrow/df_loaders/mod.rs
+++ b/raphtory/src/io/arrow/df_loaders/mod.rs
@@ -299,7 +299,7 @@ fn resolve_nodes_and_type_with_cache<
         |gid, _| {
             let GidKey { gid, node_type } = gid;
             let (vid, node_type) = graph
-                .resolve_node_and_type(gid.as_node_ref(), node_type)
+                .bulk_load_resolve_node_and_type(gid.as_node_ref(), node_type)
                 .map_err(into_graph_err)?;
             Ok((vid, node_type))
         },
@@ -360,7 +360,7 @@ fn resolve_nodes_with_cache_generic<'a, V: Send + Sync>(
                     // Check if exists in this shard
                     if let Some((_, value)) = shard_guard.get(hash, |(g, _)| g == &gid) {
                         let v = value.get();
-                        update_fn(&v, idx, col_id);
+                        update_fn(v, idx, col_id);
                     } else {
                         let v = new_fn(gid, idx)?;
 

--- a/raphtory/src/io/arrow/df_loaders/nodes.rs
+++ b/raphtory/src/io/arrow/df_loaders/nodes.rs
@@ -7,7 +7,7 @@ use crate::{
             dataframe::{DFChunk, DFView},
             df_loaders::{
                 extract_secondary_index_col, process_shared_properties,
-                resolve_nodes_and_type_with_cache, GidKey,
+                resolve_nodes_and_type_with_cache,
             },
             layer_col::{lift_node_type_col, LayerCol},
             node_col::NodeCol,
@@ -23,17 +23,28 @@ use raphtory_api::{
     atomic_extra::atomic_vid_from_mut_slice,
     core::{entities::properties::meta::STATIC_GRAPH_LAYER_ID, storage::timeindex::EventTime},
 };
-use raphtory_core::{entities::VID, storage::timeindex::AsTime};
+use raphtory_core::{
+    entities::{GidRef, VID},
+    storage::timeindex::AsTime,
+};
 use raphtory_storage::mutation::addition_ops::{InternalAdditionOps, SessionAdditionOps};
 use rayon::prelude::*;
-use std::collections::HashMap;
-use storage::{api::nodes::NodeSegmentOps, pages::locked::nodes::LockedNodePage, Extension};
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicBool, Ordering},
+};
+use storage::{
+    api::nodes::NodeSegmentOps,
+    pages::{locked::nodes::LockedNodePage, resolve_pos},
+    Extension,
+};
 
 #[cfg(feature = "progress")]
 use crate::io::arrow::df_loaders::build_progress_bar;
 #[cfg(feature = "progress")]
 use kdam::BarExt;
 
+#[allow(clippy::too_many_arguments)]
 pub fn load_nodes_from_df<
     G: StaticGraphViewOps + PropertyAdditionOps + AdditionOps + std::fmt::Debug,
 >(
@@ -52,6 +63,7 @@ pub fn load_nodes_from_df<
     if df_view.is_empty() {
         return Ok(());
     }
+    graph.flush().map_err(into_graph_err)?;
 
     LOAD_POOL.install(move || {
         let properties_indices = properties
@@ -85,6 +97,10 @@ pub fn load_nodes_from_df<
 
         let mut node_col_resolved = vec![];
 
+        let mut node_segments_touched = (0..graph.core_graph().num_node_segments())
+            .map(|_| AtomicBool::new(false))
+            .collect::<Vec<_>>();
+
         for chunk in df_view.chunks {
             let df = chunk?;
             let prop_cols =
@@ -100,6 +116,18 @@ pub fn load_nodes_from_df<
                         .map_err(into_graph_err)
                 })?;
             let node_type_col = lift_node_type_col(node_type, node_type_index, &df)?;
+            let node_type_id_values = node_type_index
+                .map(|idx| {
+                    df.chunk[idx]
+                        .as_primitive_opt::<UInt64Type>()
+                        .ok_or_else(|| {
+                            LoadError::InvalidLayerType(df.chunk[idx].data_type().clone())
+                        })
+                        .map(|array| array.values().as_ref())
+                })
+                .transpose()?;
+            let node_type_col_resolved =
+                node_type_col.resolve_node_type(node_type_id_values, graph)?;
 
             let time_col = df.time_col(time_index)?;
             let node_col = df.node_col(node_id_index)?;
@@ -116,10 +144,35 @@ pub fn load_nodes_from_df<
                 resolve_nodes,
                 &df,
                 &node_col,
-                node_type_col,
             )?;
 
             let mut write_locked_graph = graph.write_lock().map_err(into_graph_err)?;
+            node_segments_touched
+                .resize_with(write_locked_graph.nodes.len(), || AtomicBool::new(true));
+
+            let max_node_segment_len = write_locked_graph
+                .graph()
+                .storage()
+                .nodes()
+                .max_segment_len() as usize;
+
+            if !gid_str_cache.is_empty() {
+                for (_, vid) in &gid_str_cache {
+                    let (node_segment, _) = resolve_pos(vid.index(), max_node_segment_len as u32);
+                    node_segments_touched[node_segment].store(true, Ordering::Relaxed);
+                }
+            } else {
+                let mut last_vid = VID::default();
+                for vid in src_vids {
+                    if *vid != last_vid {
+                        let (node_segment, _) =
+                            resolve_pos(vid.index(), max_node_segment_len as u32);
+                        node_segments_touched[node_segment].store(true, Ordering::Relaxed);
+                    }
+                    last_vid = *vid
+                }
+            }
+
             let node_stats = write_locked_graph.node_stats().clone();
             let update_time = |time: EventTime| {
                 let time = time.t();
@@ -129,7 +182,15 @@ pub fn load_nodes_from_df<
             write_locked_graph
                 .nodes
                 .par_iter_mut()
-                .try_for_each(|shard| {
+                .enumerate()
+                .try_for_each(|(segment_id, shard)| {
+                    if !node_segments_touched[segment_id].load(Ordering::Relaxed) {
+                        // we need to graph a writer nevertheless as it may have old data that needs to flush
+                        if shard.segment().is_dirty() {
+                            let mut _writer = shard.writer();
+                        }
+                        return Ok::<_, GraphError>(());
+                    }
                     // Zip all columns for iteration.
                     let zip = izip!(src_vids.iter(), time_col.iter(), secondary_index_col.iter(),);
 
@@ -137,7 +198,7 @@ pub fn load_nodes_from_df<
                     // assumes we are loading our own graph, via the parquet loaders,
                     // so previous calls have already stored the node ids and types
                     if resolve_nodes {
-                        store_node_ids_and_type(&gid_str_cache, shard);
+                        store_node_ids_and_type(&gid_str_cache, &node_type_col_resolved, shard);
                     }
                     let mut writer = shard.writer();
 
@@ -158,6 +219,7 @@ pub fn load_nodes_from_df<
                         };
                     }
 
+                    node_segments_touched[segment_id].store(false, Ordering::Relaxed);
                     Ok::<_, GraphError>(())
                 })?;
 
@@ -170,6 +232,7 @@ pub fn load_nodes_from_df<
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn load_node_props_from_df<
     'a,
     G: StaticGraphViewOps + PropertyAdditionOps + AdditionOps + std::fmt::Debug,
@@ -187,6 +250,7 @@ pub fn load_node_props_from_df<
     if df_view.is_empty() {
         return Ok(());
     }
+    graph.flush().map_err(into_graph_err)?;
     let metadata_indices = metadata
         .iter()
         .map(|name| df_view.get_index(name))
@@ -308,7 +372,7 @@ pub fn load_node_props_from_df<
     Ok(())
 }
 
-type Resolved<'a> = (GidKey<'a>, (VID, usize));
+type Resolved<'a> = (GidRef<'a>, VID);
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn get_or_resolve_node_vids<
     'a: 'c,
@@ -322,7 +386,6 @@ fn get_or_resolve_node_vids<
     resolve_nodes: bool,
     df: &'b DFChunk,
     src_col: &'a NodeCol,
-    node_type_col: LayerCol<'a>,
 ) -> Result<(&'c [VID], Vec<Resolved<'a>>), GraphError> {
     let (src_vids, gid_str_cache) = if resolve_nodes {
         src_col_resolved.resize_with(df.len(), Default::default);
@@ -333,7 +396,6 @@ fn get_or_resolve_node_vids<
             graph,
             [src_col].as_ref(),
             [atomic_src_col].as_ref(),
-            node_type_col,
         )?;
         (
             src_col_resolved.as_slice(),
@@ -491,14 +553,13 @@ fn set_meta_for_pre_resolved_nodes_and_node_ids<
 #[inline(never)]
 fn store_node_ids_and_type<NS: NodeSegmentOps<Extension = Extension>>(
     gid_str_cache: &[Resolved<'_>],
+    node_type_ids: &[usize],
     locked_page: &mut LockedNodePage<'_, NS>,
 ) {
-    for (gid, (vid, node_type)) in gid_str_cache.iter() {
-        let gid = gid.gid;
-
-        if let Some(src_pos) = locked_page.resolve_pos(*vid) {
-            let mut writer = locked_page.writer();
-            writer.store_node_id_and_node_type(src_pos, STATIC_GRAPH_LAYER_ID, gid, *node_type);
+    let mut writer = locked_page.writer();
+    for ((gid, vid), &node_type_id) in gid_str_cache.iter().zip(node_type_ids) {
+        if let Some(src_pos) = writer.resolve_pos(*vid) {
+            writer.store_node_id_and_node_type(src_pos, STATIC_GRAPH_LAYER_ID, *gid, node_type_id);
         }
     }
 }

--- a/raphtory/src/io/arrow/df_loaders/nodes.rs
+++ b/raphtory/src/io/arrow/df_loaders/nodes.rs
@@ -21,10 +21,7 @@ use arrow::{array::AsArray, datatypes::UInt64Type};
 use itertools::izip;
 use raphtory_api::{
     atomic_extra::atomic_vid_from_mut_slice,
-    core::{
-        entities::properties::meta::STATIC_GRAPH_LAYER_ID,
-        storage::{timeindex::EventTime, FxDashMap},
-    },
+    core::{entities::properties::meta::STATIC_GRAPH_LAYER_ID, storage::timeindex::EventTime},
 };
 use raphtory_core::{entities::VID, storage::timeindex::AsTime};
 use raphtory_storage::mutation::addition_ops::{InternalAdditionOps, SessionAdditionOps};
@@ -311,6 +308,7 @@ pub fn load_node_props_from_df<
     Ok(())
 }
 
+type Resolved<'a> = (GidKey<'a>, (VID, usize));
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn get_or_resolve_node_vids<
     'a: 'c,
@@ -325,7 +323,7 @@ fn get_or_resolve_node_vids<
     df: &'b DFChunk,
     src_col: &'a NodeCol,
     node_type_col: LayerCol<'a>,
-) -> Result<(&'c [VID], FxDashMap<GidKey<'a>, (VID, usize)>), GraphError> {
+) -> Result<(&'c [VID], Vec<Resolved<'a>>), GraphError> {
     let (src_vids, gid_str_cache) = if resolve_nodes {
         src_col_resolved.resize_with(df.len(), Default::default);
 
@@ -337,14 +335,17 @@ fn get_or_resolve_node_vids<
             [atomic_src_col].as_ref(),
             node_type_col,
         )?;
-        (src_col_resolved.as_slice(), gid_str_cache)
+        (
+            src_col_resolved.as_slice(),
+            gid_str_cache.into_iter().collect(),
+        )
     } else {
         let srcs = df.chunk[src_index]
             .as_primitive_opt::<UInt64Type>()
             .ok_or_else(|| LoadError::InvalidNodeIdType(df.chunk[src_index].data_type().clone()))?
             .values()
             .as_ref();
-        (bytemuck::cast_slice(srcs), FxDashMap::default())
+        (bytemuck::cast_slice(srcs), vec![])
     };
     Ok((src_vids, gid_str_cache))
 }
@@ -489,16 +490,15 @@ fn set_meta_for_pre_resolved_nodes_and_node_ids<
 
 #[inline(never)]
 fn store_node_ids_and_type<NS: NodeSegmentOps<Extension = Extension>>(
-    gid_str_cache: &FxDashMap<GidKey<'_>, (VID, usize)>,
+    gid_str_cache: &[Resolved<'_>],
     locked_page: &mut LockedNodePage<'_, NS>,
 ) {
-    for entry in gid_str_cache.iter() {
-        let (vid, node_type) = entry.value();
-        let GidKey { gid, .. } = entry.key();
+    for (gid, (vid, node_type)) in gid_str_cache.iter() {
+        let gid = gid.gid;
 
         if let Some(src_pos) = locked_page.resolve_pos(*vid) {
             let mut writer = locked_page.writer();
-            writer.store_node_id_and_node_type(src_pos, STATIC_GRAPH_LAYER_ID, *gid, *node_type);
+            writer.store_node_id_and_node_type(src_pos, STATIC_GRAPH_LAYER_ID, gid, *node_type);
         }
     }
 }

--- a/raphtory/src/io/arrow/df_loaders/nodes.rs
+++ b/raphtory/src/io/arrow/df_loaders/nodes.rs
@@ -121,7 +121,7 @@ pub fn load_nodes_from_df<
                     df.chunk[idx]
                         .as_primitive_opt::<UInt64Type>()
                         .ok_or_else(|| {
-                            LoadError::InvalidLayerType(df.chunk[idx].data_type().clone())
+                            LoadError::InvalidNodeIdType(df.chunk[idx].data_type().clone())
                         })
                         .map(|array| array.values().as_ref())
                 })

--- a/raphtory/src/io/arrow/df_loaders/nodes.rs
+++ b/raphtory/src/io/arrow/df_loaders/nodes.rs
@@ -116,18 +116,7 @@ pub fn load_nodes_from_df<
                         .map_err(into_graph_err)
                 })?;
             let node_type_col = lift_node_type_col(node_type, node_type_index, &df)?;
-            let node_type_id_values = node_type_index
-                .map(|idx| {
-                    df.chunk[idx]
-                        .as_primitive_opt::<UInt64Type>()
-                        .ok_or_else(|| {
-                            LoadError::InvalidNodeIdType(df.chunk[idx].data_type().clone())
-                        })
-                        .map(|array| array.values().as_ref())
-                })
-                .transpose()?;
-            let node_type_col_resolved =
-                node_type_col.resolve_node_type(node_type_id_values, graph)?;
+            let node_type_col_resolved = node_type_col.resolve_node_type(graph)?;
 
             let time_col = df.time_col(time_index)?;
             let node_col = df.node_col(node_id_index)?;
@@ -141,6 +130,7 @@ pub fn load_nodes_from_df<
                 graph,
                 node_id_index,
                 &mut node_col_resolved,
+                &node_type_col_resolved,
                 resolve_nodes,
                 &df,
                 &node_col,
@@ -157,7 +147,7 @@ pub fn load_nodes_from_df<
                 .max_segment_len() as usize;
 
             if !gid_str_cache.is_empty() {
-                for (_, vid) in &gid_str_cache {
+                for (_, (vid, _)) in &gid_str_cache {
                     let (node_segment, _) = resolve_pos(vid.index(), max_node_segment_len as u32);
                     node_segments_touched[node_segment].store(true, Ordering::Relaxed);
                 }
@@ -198,7 +188,7 @@ pub fn load_nodes_from_df<
                     // assumes we are loading our own graph, via the parquet loaders,
                     // so previous calls have already stored the node ids and types
                     if resolve_nodes {
-                        store_node_ids_and_type(&gid_str_cache, &node_type_col_resolved, shard);
+                        store_node_ids_and_type(&gid_str_cache, shard);
                     }
                     let mut writer = shard.writer();
 
@@ -372,7 +362,7 @@ pub fn load_node_props_from_df<
     Ok(())
 }
 
-type Resolved<'a> = (GidRef<'a>, VID);
+type Resolved<'a> = (GidRef<'a>, (VID, usize));
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn get_or_resolve_node_vids<
     'a: 'c,
@@ -383,6 +373,7 @@ fn get_or_resolve_node_vids<
     graph: &G,
     src_index: usize,
     src_col_resolved: &'a mut Vec<VID>,
+    node_type_resolved: &'a [usize],
     resolve_nodes: bool,
     df: &'b DFChunk,
     src_col: &'a NodeCol,
@@ -395,6 +386,7 @@ fn get_or_resolve_node_vids<
         let gid_str_cache = resolve_nodes_and_type_with_cache::<G>(
             graph,
             [src_col].as_ref(),
+            [node_type_resolved].as_ref(),
             [atomic_src_col].as_ref(),
         )?;
         (
@@ -553,13 +545,12 @@ fn set_meta_for_pre_resolved_nodes_and_node_ids<
 #[inline(never)]
 fn store_node_ids_and_type<NS: NodeSegmentOps<Extension = Extension>>(
     gid_str_cache: &[Resolved<'_>],
-    node_type_ids: &[usize],
     locked_page: &mut LockedNodePage<'_, NS>,
 ) {
     let mut writer = locked_page.writer();
-    for ((gid, vid), &node_type_id) in gid_str_cache.iter().zip(node_type_ids) {
+    for (gid, (vid, node_type)) in gid_str_cache.iter() {
         if let Some(src_pos) = writer.resolve_pos(*vid) {
-            writer.store_node_id_and_node_type(src_pos, STATIC_GRAPH_LAYER_ID, *gid, node_type_id);
+            writer.store_node_id_and_node_type(src_pos, STATIC_GRAPH_LAYER_ID, *gid, *node_type);
         }
     }
 }

--- a/raphtory/src/io/arrow/layer_col.rs
+++ b/raphtory/src/io/arrow/layer_col.rs
@@ -9,6 +9,7 @@ use arrow::array::{Array, AsArray, LargeStringArray, StringArray, StringViewArra
 use iter_enum::{
     DoubleEndedIterator, ExactSizeIterator, IndexedParallelIterator, Iterator, ParallelIterator,
 };
+use raphtory_api::core::entities::properties::meta::DEFAULT_NODE_TYPE_ID;
 use rayon::prelude::*;
 
 #[derive(Copy, Clone, Debug)]
@@ -86,6 +87,60 @@ impl<'a> LayerCol<'a> {
                 } else {
                     None
                 }
+            }
+        }
+    }
+
+    pub fn resolve_node_type<'b>(
+        self,
+        node_type_id_col: Option<&'b [u64]>,
+        graph: &(impl AdditionOps + Send + Sync),
+    ) -> Result<Cow<'b, [usize]>, GraphError> {
+        match (self, node_type_id_col) {
+            (LayerCol::Name { name, len }, _) => {
+                let node_type_id = if let Some(name) = name {
+                    let nt = graph.node_meta().get_or_create_node_type_id(name);
+                    nt.inner()
+                } else {
+                    DEFAULT_NODE_TYPE_ID
+                };
+                Ok(Cow::Owned(vec![node_type_id; len]))
+            }
+            (col, None) => {
+                let mut res = vec![0usize; col.len()];
+                let node_type_mapper = graph.node_meta().node_type_meta();
+                let mut locked_node_type_mapper = node_type_mapper.write();
+                let mut last = None;
+                let mut last_id = DEFAULT_NODE_TYPE_ID;
+                for (row, name) in col.iter().enumerate() {
+                    let node_type_id = if let Some(name) = name {
+                        if last != Some(name) {
+                            locked_node_type_mapper.get_or_create_id(name).inner()
+                        } else {
+                            last_id
+                        }
+                    } else {
+                        DEFAULT_NODE_TYPE_ID
+                    };
+                    res[row] = node_type_id;
+                    last = name;
+                    last_id = node_type_id;
+                }
+                Ok(Cow::Owned(res))
+            }
+            (col, Some(node_type_ids)) => {
+                let node_type_mapper = graph.node_meta().node_type_meta();
+                let mut locked_node_type_mapper = node_type_mapper.write();
+                let mut last = None;
+                for (name, &id) in col.iter().zip(node_type_ids.iter()) {
+                    if name != last {
+                        if let Some(name) = name {
+                            locked_node_type_mapper.set_id(name, id as usize);
+                        };
+                    }
+                    last = name;
+                }
+                Ok(Cow::Borrowed(bytemuck::cast_slice(node_type_ids)))
             }
         }
     }

--- a/raphtory/src/io/arrow/layer_col.rs
+++ b/raphtory/src/io/arrow/layer_col.rs
@@ -93,11 +93,10 @@ impl<'a> LayerCol<'a> {
 
     pub fn resolve_node_type<'b>(
         self,
-        node_type_id_col: Option<&'b [u64]>,
         graph: &(impl AdditionOps + Send + Sync),
     ) -> Result<Cow<'b, [usize]>, GraphError> {
-        match (self, node_type_id_col) {
-            (LayerCol::Name { name, len }, _) => {
+        match self {
+            LayerCol::Name { name, len } => {
                 let node_type_id = if let Some(name) = name {
                     let nt = graph.node_meta().get_or_create_node_type_id(name);
                     nt.inner()
@@ -106,7 +105,7 @@ impl<'a> LayerCol<'a> {
                 };
                 Ok(Cow::Owned(vec![node_type_id; len]))
             }
-            (col, None) => {
+            col => {
                 let mut res = vec![0usize; col.len()];
                 let node_type_mapper = graph.node_meta().node_type_meta();
                 let mut locked_node_type_mapper = node_type_mapper.write();
@@ -127,20 +126,6 @@ impl<'a> LayerCol<'a> {
                     last_id = node_type_id;
                 }
                 Ok(Cow::Owned(res))
-            }
-            (col, Some(node_type_ids)) => {
-                let node_type_mapper = graph.node_meta().node_type_meta();
-                let mut locked_node_type_mapper = node_type_mapper.write();
-                let mut last = None;
-                for (name, &id) in col.iter().zip(node_type_ids.iter()) {
-                    if name != last {
-                        if let Some(name) = name {
-                            locked_node_type_mapper.set_id(name, id as usize);
-                        };
-                    }
-                    last = name;
-                }
-                Ok(Cow::Borrowed(bytemuck::cast_slice(node_type_ids)))
             }
         }
     }
@@ -250,9 +235,9 @@ pub(crate) fn lift_node_type_col<'a>(
         }),
         (None, Some(layer_index)) => {
             let col = &df.chunk[layer_index];
-            if let Some(col) = col.as_string_opt() {
+            if let Some(col) = col.as_string_opt::<i32>() {
                 Ok(LayerCol::Utf8 { col })
-            } else if let Some(col) = col.as_string_opt() {
+            } else if let Some(col) = col.as_string_opt::<i64>() {
                 Ok(LayerCol::LargeUtf8 { col })
             } else if let Some(col) = col.as_string_view_opt() {
                 Ok(LayerCol::Utf8View { col })

--- a/raphtory/src/io/parquet_loaders.rs
+++ b/raphtory/src/io/parquet_loaders.rs
@@ -381,7 +381,7 @@ pub(crate) fn process_parquet_file_to_df(
         .collect();
 
     let chunks = match batch_size {
-        None => chunks.with_batch_size(100_000),
+        None => chunks.with_batch_size(500_000),
         Some(batch_size) => chunks.with_batch_size(batch_size),
     };
 

--- a/raphtory/src/serialise/parquet/mod.rs
+++ b/raphtory/src/serialise/parquet/mod.rs
@@ -24,10 +24,7 @@ use crate::{
         GraphPaths,
     },
 };
-use arrow::{
-    datatypes::{DataType, Field, Schema, SchemaRef},
-    ipc::RecordBatch,
-};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow_json::{reader::Decoder, ReaderBuilder};
 use edges::{encode_edge_cprop, encode_edge_tprop};
 use itertools::Itertools;

--- a/raphtory/src/serialise/serialise.rs
+++ b/raphtory/src/serialise/serialise.rs
@@ -63,7 +63,7 @@ impl<T: ParquetEncoder + StaticGraphViewOps + AdditionOps> StableEncode for T {
         let folder: GraphFolder = path.into();
 
         if folder.write_as_zip_format {
-            let file = File::create_new(&folder.root())?;
+            let file = File::create_new(folder.root())?;
             self.encode_to_zip(ZipWriter::new(file))?;
         } else {
             let write_folder = folder.init_write()?;

--- a/raphtory/src/test_utils.rs
+++ b/raphtory/src/test_utils.rs
@@ -45,7 +45,7 @@ pub enum NameSortKey<'a> {
     Edge(&'a str, &'a str),
 }
 
-fn name_sort_key(value: &Value) -> Option<NameSortKey> {
+fn name_sort_key(value: &Value) -> Option<NameSortKey<'_>> {
     match value {
         Value::Object(inner) => inner
             .get("name")

--- a/raphtory/tests/df_loaders.rs
+++ b/raphtory/tests/df_loaders.rs
@@ -161,6 +161,37 @@ mod io_tests {
         }
     }
 
+    fn build_nodes_df(
+        chunk_size: usize,
+        nodes: &[(u64, i64, &str)],
+    ) -> DFView<impl Iterator<Item = Result<DFChunk, GraphError>>> {
+        let chunks = nodes.iter().chunks(chunk_size);
+        let mut node_id_col = UInt64Builder::new();
+        let mut time_col = Int64Builder::new();
+        let mut node_type_col = StringViewBuilder::new();
+        let chunks = chunks
+            .into_iter()
+            .map(|chunk| {
+                for (node_id, time, node_type) in chunk {
+                    node_id_col.append_value(*node_id);
+                    time_col.append_value(*time);
+                    node_type_col.append_value(node_type);
+                }
+                let chunk = vec![
+                    ArrayBuilder::finish(&mut node_id_col),
+                    ArrayBuilder::finish(&mut time_col),
+                    ArrayBuilder::finish(&mut node_type_col),
+                ];
+                Ok(DFChunk { chunk })
+            })
+            .collect_vec();
+        DFView {
+            names: vec!["id".to_owned(), "time".to_owned(), "node_type".to_owned()],
+            chunks: chunks.into_iter(),
+            num_rows: Some(nodes.len()),
+        }
+    }
+
     fn build_nodes_df_with_secondary_index(
         chunk_size: usize,
         nodes: &[(u64, i64, u64, &str, i64, &str)],
@@ -690,6 +721,52 @@ mod io_tests {
             Some(ArcStr::from("TypeC")),
         ];
         assert_eq!(act_node_types, exp_node_types);
+    }
+
+    #[test]
+    fn test_load_node_type_only() {
+        // (node_id, time, node_type)
+        let nodes: Vec<(u64, i64, &str)> = vec![
+            (1, 1, "P1"),
+            (2, 2, "P2"),
+            (3, 3, "P3"),
+            (4, 4, "P4"),
+            (5, 5, "P5"),
+            (6, 6, "P6"),
+        ];
+
+        // CHECK ALL NODE FUNCTIONS ON GRAPH FAIL WITH BOTH node_type AND node_type_col
+        let g = Graph::new();
+        load_nodes_from_df(
+            build_nodes_df(50, &nodes),
+            "time",
+            None,
+            "id",
+            &[],
+            &[],
+            None,
+            None,              // node_type (constant name)
+            Some("node_type"), // node_type_col (column name) — conflict!
+            &g,
+            true,
+        )
+        .unwrap();
+        let mut result = g
+            .nodes()
+            .into_iter()
+            .map(|node| (node.id(), node.node_type()))
+            .collect::<Vec<_>>();
+
+        result.sort();
+        let expected: Vec<(GID, Option<ArcStr>)> = vec![
+            (1u64.into(), Some(ArcStr::from("P1"))),
+            (2u64.into(), Some(ArcStr::from("P2"))),
+            (3u64.into(), Some(ArcStr::from("P3"))),
+            (4u64.into(), Some(ArcStr::from("P4"))),
+            (5u64.into(), Some(ArcStr::from("P5"))),
+            (6u64.into(), Some(ArcStr::from("P6"))),
+        ];
+        assert_eq!(result, expected);
     }
 }
 


### PR DESCRIPTION
Try and avoid including segments that do not have data in the bulk loader, move merge off the loading hot path, skips mutex slots in the resolver during bulk loader as we're holding locked dashmap segments