### PR TITLE
Fix deadlock in resolving nodes in add_edge

### DIFF
--- a/raphtory-storage/src/mutation/addition_ops_ext.rs
+++ b/raphtory-storage/src/mutation/addition_ops_ext.rs
@@ -392,14 +392,17 @@ impl InternalAdditionOps for TemporalGraph {
                     std::cmp::Ordering::Greater => {
                         // resolve the smaller id first to avoid deadlocks when adding the same edge in both directions
                         let dst_init = self.logical_to_physical.get_or_init(dst_gid)?;
-                        (self.logical_to_physical.get_or_init(src_gid)?, Some(dst_init))
+                        (
+                            self.logical_to_physical.get_or_init(src_gid)?,
+                            Some(dst_init),
+                        )
                     }
                 }
             }
         };
 
         let dst_init = dst_init.filter(|dst_init| dst_init != &src_init);
-        
+
         let (mut node_writers, src_id, dst_id) = match (src_init, dst_init) {
             (src_init, None) => {
                 // self-loop

--- a/raphtory-storage/src/mutation/addition_ops_ext.rs
+++ b/raphtory-storage/src/mutation/addition_ops_ext.rs
@@ -367,21 +367,39 @@ impl InternalAdditionOps for TemporalGraph {
         e_id: Option<EID>,
     ) -> Result<Self::AtomicAddEdge<'_>, Self::Error> {
         let nodes = self.storage().nodes();
-        let src_init = match src {
-            NodeRef::Internal(vid) => MaybeInit::VID(vid),
-            NodeRef::External(gid) => self.logical_to_physical.get_or_init(gid)?,
+
+        let (src_init, dst_init) = match (src, dst) {
+            (NodeRef::Internal(src_id), NodeRef::Internal(dst_id)) => {
+                (MaybeInit::VID(src_id), Some(MaybeInit::VID(dst_id)))
+            }
+            (NodeRef::Internal(src_id), NodeRef::External(dst_gid)) => (
+                MaybeInit::VID(src_id),
+                Some(self.logical_to_physical.get_or_init(dst_gid)?),
+            ),
+            (NodeRef::External(src_gid), NodeRef::Internal(dst_id)) => (
+                self.logical_to_physical.get_or_init(src_gid)?,
+                Some(MaybeInit::VID(dst_id)),
+            ),
+            (NodeRef::External(src_gid), NodeRef::External(dst_gid)) => {
+                match src_gid.cmp(&dst_gid) {
+                    std::cmp::Ordering::Less => (
+                        self.logical_to_physical.get_or_init(src_gid)?,
+                        Some(self.logical_to_physical.get_or_init(dst_gid)?),
+                    ),
+                    std::cmp::Ordering::Equal => {
+                        (self.logical_to_physical.get_or_init(src_gid)?, None)
+                    }
+                    std::cmp::Ordering::Greater => {
+                        // resolve the smaller id first to avoid deadlocks when adding the same edge in both directions
+                        let dst_init = self.logical_to_physical.get_or_init(dst_gid)?;
+                        (self.logical_to_physical.get_or_init(src_gid)?, Some(dst_init))
+                    }
+                }
+            }
         };
 
-        let dst_init = if src == dst {
-            None
-        } else {
-            match dst {
-                NodeRef::Internal(vid) => Some(MaybeInit::VID(vid)),
-                NodeRef::External(gid) => Some(self.logical_to_physical.get_or_init(gid)?),
-            }
-        }
-        .filter(|dst_init| dst_init != &src_init);
-
+        let dst_init = dst_init.filter(|dst_init| dst_init != &src_init);
+        
         let (mut node_writers, src_id, dst_id) = match (src_init, dst_init) {
             (src_init, None) => {
                 // self-loop

--- a/raphtory/tests/db_tests.rs
+++ b/raphtory/tests/db_tests.rs
@@ -156,6 +156,25 @@ fn test_multithreaded_add_edge() {
 }
 
 #[test]
+fn test_multithreaded_add_edge_both_directions() {
+    proptest!(|(edges: Vec<(u64, u64)>)| {
+        let g = Graph::new();
+        let mut self_loop_count = 0;
+        for (src, dst) in edges.iter() {
+            if src == dst {
+                self_loop_count += 1;
+            }
+            // try to maximise the chance that both directions of the edge are added in parallel
+            join(|| {
+                g.add_edge(0, *src, *dst, NO_PROPS, None).unwrap();
+            }, || {g.add_edge(0, *dst, *src, NO_PROPS, None).unwrap();});
+        }
+
+        prop_assert!(edges.iter().all(|(i, j)| g.has_edge(*i, *j) && g.has_edge(*j, *i)) && g.count_temporal_edges() == 2*edges.len()-self_loop_count);
+    });
+}
+
+#[test]
 fn add_node_grows_graph_len() {
     proptest!(|(vs: Vec<(i64, u64)>)| {
         let g = Graph::new();


### PR DESCRIPTION
### What changes were proposed in this pull request?

make sure to resolve nodes in fixed order to avoid deadlocking the resolution 

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


