### PR TITLE
Fix deep_clone on DictMapper not cloning the underlying map

### DIFF
--- a/raphtory-api/src/core/storage/dict_mapper.rs
+++ b/raphtory-api/src/core/storage/dict_mapper.rs
@@ -330,6 +330,93 @@ impl DictMapper {
     }
 }
 
+#[derive(Debug)]
+pub struct AllKeys<T> {
+    pub(crate) guard: ArcRwLockReadGuard<Vec<T>>,
+}
+
+impl<T> Deref for AllKeys<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.guard.deref().deref()
+    }
+}
+
+impl<T: Clone> IntoIterator for AllKeys<T> {
+    type Item = T;
+    type IntoIter = LockedIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let guard = self.guard;
+        let len = guard.len();
+        let pos = 0;
+        LockedIter { guard, pos, len }
+    }
+}
+
+pub struct PublicKeys<T> {
+    guard: ArcRwLockReadGuard<Vec<T>>,
+    num_private_fields: usize,
+}
+
+impl<T> PublicKeys<T> {
+    fn items(&self) -> &[T] {
+        &self.guard[self.num_private_fields..]
+    }
+    pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
+        self.items().iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.items().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items().is_empty()
+    }
+}
+
+impl<T: Clone> IntoIterator for PublicKeys<T> {
+    type Item = T;
+    type IntoIter = LockedIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let guard = self.guard;
+        let len = guard.len();
+        let pos = self.num_private_fields;
+        LockedIter { guard, pos, len }
+    }
+}
+
+pub struct LockedIter<T> {
+    guard: ArcRwLockReadGuard<Vec<T>>,
+    pos: usize,
+    len: usize,
+}
+
+impl<T: Clone> Iterator for LockedIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos < self.len {
+            let next_val = Some(self.guard[self.pos].clone());
+            self.pos += 1;
+            next_val
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len - self.pos;
+        (len, Some(len))
+    }
+}
+
+impl<T: Clone> ExactSizeIterator for LockedIter<T> {}
+
 #[cfg(test)]
 mod test {
     use crate::core::storage::dict_mapper::DictMapper;
@@ -462,90 +549,3 @@ mod test {
         assert_eq!(actual, vec![0, 1, 2, 3, 4]);
     }
 }
-
-#[derive(Debug)]
-pub struct AllKeys<T> {
-    pub(crate) guard: ArcRwLockReadGuard<Vec<T>>,
-}
-
-impl<T> Deref for AllKeys<T> {
-    type Target = [T];
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.guard.deref().deref()
-    }
-}
-
-impl<T: Clone> IntoIterator for AllKeys<T> {
-    type Item = T;
-    type IntoIter = LockedIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        let guard = self.guard;
-        let len = guard.len();
-        let pos = 0;
-        LockedIter { guard, pos, len }
-    }
-}
-
-pub struct PublicKeys<T> {
-    guard: ArcRwLockReadGuard<Vec<T>>,
-    num_private_fields: usize,
-}
-
-impl<T> PublicKeys<T> {
-    fn items(&self) -> &[T] {
-        &self.guard[self.num_private_fields..]
-    }
-    pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
-        self.items().iter()
-    }
-
-    pub fn len(&self) -> usize {
-        self.items().len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.items().is_empty()
-    }
-}
-
-impl<T: Clone> IntoIterator for PublicKeys<T> {
-    type Item = T;
-    type IntoIter = LockedIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        let guard = self.guard;
-        let len = guard.len();
-        let pos = self.num_private_fields;
-        LockedIter { guard, pos, len }
-    }
-}
-
-pub struct LockedIter<T> {
-    guard: ArcRwLockReadGuard<Vec<T>>,
-    pos: usize,
-    len: usize,
-}
-
-impl<T: Clone> Iterator for LockedIter<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.pos < self.len {
-            let next_val = Some(self.guard[self.pos].clone());
-            self.pos += 1;
-            next_val
-        } else {
-            None
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len - self.pos;
-        (len, Some(len))
-    }
-}
-
-impl<T: Clone> ExactSizeIterator for LockedIter<T> {}

--- a/raphtory-api/src/core/storage/dict_mapper.rs
+++ b/raphtory-api/src/core/storage/dict_mapper.rs
@@ -209,10 +209,11 @@ impl DictMapper {
     }
 
     pub fn deep_clone(&self) -> Self {
+        let map = self.map.read_recursive().clone();
         let reverse_map = self.read_lock_reverse_map().clone();
 
         Self {
-            map: self.map.clone(),
+            map: Arc::new(RwLock::new(map)),
             reverse_map: Arc::new(RwLock::new(reverse_map)),
             num_private_fields: self.num_private_fields,
         }

--- a/raphtory-api/src/core/storage/dict_mapper.rs
+++ b/raphtory-api/src/core/storage/dict_mapper.rs
@@ -336,7 +336,7 @@ mod test {
     use proptest::prelude::*;
     use rand::seq::SliceRandom;
     use rayon::prelude::*;
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc};
 
     #[test]
     fn test_dict_mapper() {
@@ -346,6 +346,59 @@ mod test {
         assert_eq!(mapper.get_or_create_id("test2").inner(), 1);
         assert_eq!(mapper.get_or_create_id("test2").inner(), 1);
         assert_eq!(mapper.get_or_create_id("test").inner(), 0);
+    }
+
+    #[test]
+    fn test_dict_mapper_deep_clone() {
+        let mapper = DictMapper::new_with_private_fields(["_private"]);
+        let alpha_id = mapper.get_or_create_id("alpha").inner();
+        let beta_id = mapper.get_or_create_id("beta").inner();
+
+        let cloned = mapper.deep_clone();
+
+        assert_eq!(cloned.num_private_fields(), mapper.num_private_fields());
+        assert_eq!(cloned.get_id("alpha"), Some(alpha_id));
+        assert_eq!(cloned.get_id("beta"), Some(beta_id));
+        assert_eq!(cloned.get_name(alpha_id).as_ref(), "alpha");
+        assert_eq!(cloned.get_name(beta_id).as_ref(), "beta");
+        assert_eq!(cloned.num_fields(), mapper.num_fields());
+        assert_eq!(
+            cloned.all_keys().into_iter().collect::<Vec<_>>(),
+            mapper.all_keys().into_iter().collect::<Vec<_>>()
+        );
+
+        assert!(
+            !Arc::ptr_eq(&mapper.map, &cloned.map),
+            "deep_clone() must allocate a distinct map lock"
+        );
+        assert!(
+            !Arc::ptr_eq(&mapper.reverse_map, &cloned.reverse_map),
+            "deep_clone() must allocate a distinct reverse-map lock"
+        );
+
+        let _mapper_map_guard = mapper.map.write();
+        assert!(
+            cloned.map.try_write().is_some(),
+            "deep_clone() reused the original map lock; a second lock would block and could deadlock"
+        );
+        drop(_mapper_map_guard);
+
+        let _mapper_reverse_guard = mapper.reverse_map.write();
+        assert!(
+            cloned.reverse_map.try_write().is_some(),
+            "deep_clone() reused the original reverse-map lock; a second lock would block and could deadlock"
+        );
+        drop(_mapper_reverse_guard);
+
+        let gamma_id = cloned.get_or_create_id("gamma").inner();
+        assert_eq!(gamma_id, 3);
+        assert!(cloned.contains("gamma"));
+        assert!(!mapper.contains("gamma"));
+
+        let delta_id = mapper.get_or_create_id("delta").inner();
+        assert_eq!(delta_id, 3);
+        assert!(mapper.contains("delta"));
+        assert!(!cloned.contains("delta"));
     }
 
     #[test]

--- a/raphtory-api/src/core/storage/dict_mapper.rs
+++ b/raphtory-api/src/core/storage/dict_mapper.rs
@@ -454,29 +454,6 @@ mod test {
             mapper.all_keys().into_iter().collect::<Vec<_>>()
         );
 
-        assert!(
-            !Arc::ptr_eq(&mapper.map, &cloned.map),
-            "deep_clone() must allocate a distinct map lock"
-        );
-        assert!(
-            !Arc::ptr_eq(&mapper.reverse_map, &cloned.reverse_map),
-            "deep_clone() must allocate a distinct reverse-map lock"
-        );
-
-        let _mapper_map_guard = mapper.map.write();
-        assert!(
-            cloned.map.try_write().is_some(),
-            "deep_clone() reused the original map lock; a second lock would block and could deadlock"
-        );
-        drop(_mapper_map_guard);
-
-        let _mapper_reverse_guard = mapper.reverse_map.write();
-        assert!(
-            cloned.reverse_map.try_write().is_some(),
-            "deep_clone() reused the original reverse-map lock; a second lock would block and could deadlock"
-        );
-        drop(_mapper_reverse_guard);
-
         let gamma_id = cloned.get_or_create_id("gamma").inner();
         assert_eq!(gamma_id, 3);
         assert!(cloned.contains("gamma"));


### PR DESCRIPTION
Previously, deep_clone on DictMapper would only clone the Arc holding the map, not the map itself. This led to problems involving correctness and deadlocks.


