### PR TITLE
Add personalization to pagerank

### DIFF
--- a/examples/rust/src/bin/bench/main.rs
+++ b/examples/rust/src/bin/bench/main.rs
@@ -82,6 +82,6 @@ fn main() {
         g
     };
     info!("Data loaded\nPageRanking");
-    page_rank(&graph, None, Some(25), Some(8), None, true, None);
+    page_rank(&graph, None, Some(25), Some(8), None, true, None, None);
     info!("Done PR");
 }

--- a/examples/rust/src/bin/crypto/main.rs
+++ b/examples/rust/src/bin/crypto/main.rs
@@ -33,12 +33,12 @@ fn main() {
 
     info!("Pagerank");
     let now = Instant::now();
-    let _ = page_rank(&g, None, Some(20), None, None, true, None);
+    let _ = page_rank(&g, None, Some(20), None, None, true, None, None);
     info!("Time taken: {} secs", now.elapsed().as_secs());
 
     let now = Instant::now();
 
-    let _ = page_rank(&g, None, Some(20), None, None, true, None);
+    let _ = page_rank(&g, None, Some(20), None, None, true, None, None);
     info!("Time taken: {} secs", now.elapsed().as_secs());
 
     let now = Instant::now();
@@ -49,6 +49,7 @@ fn main() {
         None,
         None,
         true,
+        None,
         None,
     );
     info!("Time taken: {} secs", now.elapsed().as_secs());

--- a/examples/rust/src/bin/pokec/main.rs
+++ b/examples/rust/src/bin/pokec/main.rs
@@ -51,7 +51,16 @@ fn main() {
 
     let now = Instant::now();
 
-    page_rank(&g, None, Some(100), None, Some(0.00000001), true, None);
+    page_rank(
+        &g,
+        None,
+        Some(100),
+        None,
+        Some(0.00000001),
+        true,
+        None,
+        None,
+    );
 
     info!("PageRank took {} millis", now.elapsed().as_millis());
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.8.3"]
+requires = ["maturin>=1.8.1"]
 build-backend = "maturin"
 
 [project]

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -289,6 +289,7 @@ def pagerank(
     max_diff: Optional[float] = None,
     use_l2_norm: bool = True,
     damping_factor: float = 0.85,
+    personalization: Optional[dict[NodeInput, float]] = None,
 ) -> NodeStateF64:
     """
     Pagerank -- pagerank centrality value of the nodes in a graph
@@ -305,6 +306,9 @@ def pagerank(
             is less than the max diff value given.
         use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
         damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
+        personalization (Optional[dict[NodeInput, float]]): A dictionary mapping nodes to personalization values.
+            When provided, the random walk teleports to nodes proportionally to these values
+            instead of uniformly. Values are normalized to sum to 1. Defaults to None (uniform).
 
     Returns:
         NodeStateF64: Mapping of nodes to their pagerank value.

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -305,6 +305,7 @@ def pagerank(
     use_l2_norm: bool = True,
     damping_factor: float = 0.85,
     weight: Optional[str] = None,
+    personalization: Optional[str] = None,
 ) -> OutputNodeState:
     """
     Pagerank -- pagerank centrality value of the nodes in a graph
@@ -322,6 +323,9 @@ def pagerank(
         use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
         damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
         weight (Optional[str]): Edge property key to use as weight. If None, all edges have weight 1.0.
+        personalization (Optional[str]): Node property key to use as personalization weight.
+            When provided, the random walk teleports to nodes proportionally to these node property values
+            instead of uniformly. Values are normalized to sum to 1. Defaults to None (uniform).
 
     Returns:
         OutputNodeState: NodeState mapping nodes to their pagerank score.

--- a/python/tests/test_base_install/test_graphdb/test_algorithms.py
+++ b/python/tests/test_base_install/test_graphdb/test_algorithms.py
@@ -312,6 +312,21 @@ def test_page_rank():
     assert actual == expected
 
 
+def test_personalized_page_rank():
+    g = Graph()
+    edges = [(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)]
+    for src, dst in edges:
+        g.add_edge(0, src, dst, {})
+
+    actual = algorithms.pagerank(g, iter_count=1000, personalization={"1": 1.0, "2": 0.0, "3": 0.0, "4": 0.0})
+    for node, expected in [("1", 0.45223), ("2", 0.19220), ("3", 0.16337), ("4", 0.19220)]:
+        assert abs(actual[node] - expected) < 1e-5, f"node {node}: {actual[node]} != {expected}"
+
+    actual = algorithms.pagerank(g, iter_count=1000, max_diff=1e-10, use_l2_norm=False, personalization={"1": 0.5, "3": 0.5})
+    for node, expected in [("1", 0.41832), ("2", 0.17778), ("3", 0.22612), ("4", 0.17778)]:
+        assert abs(actual[node] - expected) < 1e-5, f"node {node}: {actual[node]} != {expected}"
+
+
 def test_temporal_reachability():
     g = gen_graph()
 

--- a/python/tests/test_base_install/test_graphdb/test_algorithms.py
+++ b/python/tests/test_base_install/test_graphdb/test_algorithms.py
@@ -369,9 +369,9 @@ def test_weighted_page_rank():
         ("3", 0.42311),
         ("4", 0.07837),
     ]:
-        assert abs(actual[node]["pagerank_score"] - expected) < 1e-5, (
-            f"node {node}: {actual[node]} != {expected}"
-        )
+        assert (
+            abs(actual[node]["pagerank_score"] - expected) < 1e-5
+        ), f"node {node}: {actual[node]} != {expected}"
 
 
 def test_weighted_page_rank_none_matches_unweighted():
@@ -389,6 +389,49 @@ def test_weighted_page_rank_none_matches_unweighted():
             abs(unweighted[node]["pagerank_score"] - weighted[node]["pagerank_score"])
             < 1e-5
         ), f"node {node} differs"
+
+
+def test_personalized_page_rank():
+    g = Graph()
+    edges = [(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)]
+    for node, personalization in [(1, 1.0), (2, 0.0), (3, 0.0), (4, 0.0)]:
+        g.add_node(0, node, {"personalization": personalization})
+    for src, dst in edges:
+        g.add_edge(0, src, dst, {})
+
+    actual = algorithms.pagerank(g, iter_count=1000, personalization="personalization")
+    for node, expected in [
+        ("1", 0.45223),
+        ("2", 0.19220),
+        ("3", 0.16337),
+        ("4", 0.19220),
+    ]:
+        assert (
+            abs(actual[node]['pagerank_score'] - expected) < 1e-5
+        ), f"node {node}: {actual[node]} != {expected}"
+
+    g = Graph()
+    g.add_node(0, 1, {"personalization": 0.5})
+    g.add_node(0, 3, {"personalization": 0.5})
+    for src, dst in edges:
+        g.add_edge(0, src, dst, {})
+
+    actual = algorithms.pagerank(
+        g,
+        iter_count=1000,
+        max_diff=1e-10,
+        use_l2_norm=False,
+        personalization="personalization",
+    )
+    for node, expected in [
+        ("1", 0.41832),
+        ("2", 0.17778),
+        ("3", 0.22612),
+        ("4", 0.17778),
+    ]:
+        assert (
+            abs(actual[node]['pagerank_score'] - expected) < 1e-5
+        ), f"node {node}: {actual[node]} != {expected}"
 
 
 def test_temporal_reachability():

--- a/raphtory-benchmark/benches/algobench.rs
+++ b/raphtory-benchmark/benches/algobench.rs
@@ -87,7 +87,7 @@ pub fn graphgen_large_pagerank(c: &mut Criterion) {
         &graph,
         |b, graph| {
             b.iter(|| {
-                let result = unweighted_page_rank(graph, Some(100), None, None, true, None);
+                let result = unweighted_page_rank(graph, Some(100), None, None, true, None, None);
                 black_box(result);
             });
         },

--- a/raphtory-benchmark/benches/algobench.rs
+++ b/raphtory-benchmark/benches/algobench.rs
@@ -88,7 +88,7 @@ pub fn graphgen_large_pagerank(c: &mut Criterion) {
         &graph,
         |b, graph| {
             b.iter(|| {
-                let result = page_rank(graph, None, Some(100), None, None, true, None);
+                let result = page_rank(graph, None, Some(100), None, None, true, None, None);
                 black_box(result);
             });
         },

--- a/raphtory-benchmark/bin/main.rs
+++ b/raphtory-benchmark/bin/main.rs
@@ -200,7 +200,7 @@ fn main() {
 
     // page rank with time
     now = Instant::now();
-    let _page_rank = page_rank(&g, None, Some(1000), None, None, true, None);
+    let _page_rank = page_rank(&g, None, Some(1000), None, None, true, None, None);
     info!("Page rank: {} seconds", now.elapsed().as_secs_f64());
 
     // connected community_detection with time

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -5614,4 +5614,3 @@ schema {
 	query: QueryRoot
 	mutation: MutRoot
 }
-

--- a/raphtory-graphql/src/model/plugins/algorithms.rs
+++ b/raphtory-graphql/src/model/plugins/algorithms.rs
@@ -103,6 +103,7 @@ fn apply_pagerank<'b>(
         tol,
         true,
         damping_factor,
+        None,
     );
     let result = binding
         .into_iter()

--- a/raphtory-graphql/src/model/plugins/algorithms.rs
+++ b/raphtory-graphql/src/model/plugins/algorithms.rs
@@ -83,6 +83,7 @@ fn apply_pagerank<'b>(
         tol,
         true,
         damping_factor,
+        None,
     );
     let result = binding
         .into_iter()

--- a/raphtory-tests/tests/db_tests.rs
+++ b/raphtory-tests/tests/db_tests.rs
@@ -2933,7 +2933,7 @@ fn test_node_state_merge() {
 
     let sg = graph.subgraph(1..200);
     let degs = degree_centrality(&graph);
-    let pr = page_rank(&sg, None, None, None, None, false, None);
+    let pr = page_rank(&sg, None, None, None, None, false, None, None);
 
     let m1 = pr.state.merge(
         &degs.state,

--- a/raphtory/src/algorithms/centrality/pagerank.rs
+++ b/raphtory/src/algorithms/centrality/pagerank.rs
@@ -14,6 +14,56 @@ use crate::{
     prelude::GraphViewOps,
 };
 use num_traits::abs;
+use raphtory_api::core::entities::VID;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+trait Teleport: Clone + Send + Sync + 'static {
+    fn teleport_value(&self, vid_index: usize, damp: f64) -> f64;
+    fn sink_contribution(&self, prev_score: f64) -> f64;
+    fn distribute_sink(&self, total_sink: f64, vid_index: usize, damp: f64) -> f64;
+}
+
+#[derive(Clone)]
+struct Uniform {
+    teleport_prob: f64,
+    factor: f64,
+}
+
+impl Teleport for Uniform {
+    #[inline]
+    fn teleport_value(&self, _vid_index: usize, _damp: f64) -> f64 {
+        self.teleport_prob
+    }
+    #[inline]
+    fn sink_contribution(&self, prev_score: f64) -> f64 {
+        self.factor * prev_score
+    }
+    #[inline]
+    fn distribute_sink(&self, total_sink: f64, _vid_index: usize, _damp: f64) -> f64 {
+        total_sink
+    }
+}
+
+#[derive(Clone)]
+struct Personalized {
+    weights: Arc<Vec<f64>>,
+}
+
+impl Teleport for Personalized {
+    #[inline]
+    fn teleport_value(&self, vid_index: usize, damp: f64) -> f64 {
+        (1.0 - damp) * self.weights[vid_index]
+    }
+    #[inline]
+    fn sink_contribution(&self, prev_score: f64) -> f64 {
+        prev_score
+    }
+    #[inline]
+    fn distribute_sink(&self, total_sink: f64, vid_index: usize, damp: f64) -> f64 {
+        damp * total_sink * self.weights[vid_index]
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 struct PageRankState {
@@ -45,6 +95,9 @@ impl PageRankState {
 /// - `tol`: The tolerance value for convergence
 /// - `use_l2_norm`: Whether to use L2 norm for convergence
 /// - `damping_factor`: Probability of likelihood the spread will continue
+/// - `personalization`: Optional map from node VID to personalization weight.
+///     When provided, the random walk teleports proportionally to these weights
+///     instead of uniformly. Values are normalized to sum to 1.
 ///
 /// # Returns
 ///
@@ -57,16 +110,58 @@ pub fn unweighted_page_rank<G: StaticGraphViewOps>(
     tol: Option<f64>,
     use_l2_norm: bool,
     damping_factor: Option<f64>,
+    personalization: Option<HashMap<VID, f64>>,
+) -> NodeState<'static, f64, G> {
+    let n = g.count_nodes();
+    let damp = damping_factor.unwrap_or(0.85);
+
+    match personalization {
+        Some(p) => {
+            let total: f64 = p.values().sum();
+            let mut weights = vec![0.0f64; n];
+            for (&vid, &value) in &p {
+                weights[vid.index()] = value / total;
+            }
+            run_pagerank(
+                g,
+                iter_count,
+                threads,
+                tol,
+                use_l2_norm,
+                damp,
+                Personalized { weights: Arc::new(weights) },
+            )
+        }
+        None => run_pagerank(
+            g,
+            iter_count,
+            threads,
+            tol,
+            use_l2_norm,
+            damp,
+            Uniform {
+                teleport_prob: (1f64 - damp) / n as f64,
+                factor: damp / n as f64,
+            },
+        ),
+    }
+}
+
+fn run_pagerank<G: StaticGraphViewOps, T: Teleport>(
+    g: &G,
+    iter_count: Option<usize>,
+    threads: Option<usize>,
+    tol: Option<f64>,
+    use_l2_norm: bool,
+    damp: f64,
+    teleport: T,
 ) -> NodeState<'static, f64, G> {
     let n = g.count_nodes();
 
     let mut ctx: Context<G, ComputeStateVec> = g.into();
 
     let tol: f64 = tol.unwrap_or(0.000001f64);
-    let damp = damping_factor.unwrap_or(0.85);
     let iter_count = iter_count.unwrap_or(20);
-    let teleport_prob = (1f64 - damp) / n as f64;
-    let factor = damp / n as f64;
 
     let max_diff = accumulators::sum::<f64>(2);
 
@@ -83,35 +178,42 @@ pub fn unweighted_page_rank<G: StaticGraphViewOps>(
         Step::Continue
     });
 
-    let step2: ATask<G, ComputeStateVec, PageRankState, _> = ATask::new(move |s| {
-        // reset score
-        {
-            let state: &mut PageRankState = s.get_mut();
-            state.reset();
+    let step2: ATask<G, ComputeStateVec, PageRankState, _> = ATask::new({
+        let teleport = teleport.clone();
+        move |s| {
+            {
+                let state: &mut PageRankState = s.get_mut();
+                state.reset();
+            }
+
+            for t in s.in_neighbours() {
+                let prev = t.prev();
+
+                s.get_mut().score += prev.score / prev.out_degree as f64;
+            }
+
+            s.get_mut().score *= damp;
+
+            s.get_mut().score += teleport.teleport_value(s.node.index(), damp);
+            Step::Continue
         }
-
-        for t in s.in_neighbours() {
-            let prev = t.prev();
-
-            s.get_mut().score += prev.score / prev.out_degree as f64;
-        }
-
-        s.get_mut().score *= damp;
-
-        s.get_mut().score += teleport_prob;
-        Step::Continue
     });
 
-    let step3 = ATask::new(move |s| {
-        let state: &mut PageRankState = s.get_mut();
+    let step3 = ATask::new({
+        let teleport = teleport.clone();
+        move |s| {
+            let state: &mut PageRankState = s.get_mut();
 
-        if state.out_degree == 0 {
-            let curr = s.prev().score;
+            if state.out_degree == 0 {
+                let curr = s.prev().score;
 
-            let ts_contrib = factor * curr;
-            s.global_update(&total_sink_contribution, ts_contrib);
+                s.global_update(
+                    &total_sink_contribution,
+                    teleport.sink_contribution(curr),
+                );
+            }
+            Step::Continue
         }
-        Step::Continue
     });
 
     let step4 = ATask::new(move |s| {
@@ -120,8 +222,10 @@ pub fn unweighted_page_rank<G: StaticGraphViewOps>(
             .read_global_state(&total_sink_contribution)
             .unwrap_or_default();
         // update local score with total sink contribution
+        let vid_index = s.node.index();
         let state: &mut PageRankState = s.get_mut();
-        state.score += total_sink_contribution;
+        state.score +=
+            teleport.distribute_sink(total_sink_contribution, vid_index, damp);
 
         // update global max diff
 

--- a/raphtory/src/algorithms/centrality/pagerank.rs
+++ b/raphtory/src/algorithms/centrality/pagerank.rs
@@ -7,6 +7,7 @@ use crate::{
         },
         task::{
             context::Context,
+            node::eval_node::EvalNodeView,
             task::{ATask, Job, Step},
             task_runner::TaskRunner,
         },
@@ -32,10 +33,6 @@ impl PageRankState {
             weighted_out_degree: 0f64,
         }
     }
-
-    fn reset(&mut self) {
-        self.score = 0f64;
-    }
 }
 
 /// PageRank Algorithm:
@@ -50,6 +47,9 @@ impl PageRankState {
 /// - `tol`: The tolerance value for convergence
 /// - `use_l2_norm`: Whether to use L2 norm for convergence
 /// - `damping_factor`: Probability of likelihood the spread will continue
+/// - `personalization`: Optional node property key to use as personalization weight.
+///     When provided, the random walk teleports proportionally to these node property values
+///     instead of uniformly. Values are normalized to sum to 1.
 ///
 /// # Returns
 ///
@@ -63,138 +63,207 @@ pub fn page_rank<G: StaticGraphViewOps>(
     tol: Option<f64>,
     use_l2_norm: bool,
     damping_factor: Option<f64>,
+    personalization: Option<&str>,
 ) -> TypedNodeState<'static, PageRankState, G> {
-    let n = g.count_nodes();
-
-    let mut ctx: Context<G, ComputeStateVec> = g.into();
-
-    let tol: f64 = tol.unwrap_or(0.000001f64);
     let damp = damping_factor.unwrap_or(0.85);
-    let iter_count = iter_count.unwrap_or(20);
-    let teleport_prob = (1f64 - damp) / n as f64;
-    let factor = damp / n as f64;
-
-    let max_diff = accumulators::sum::<f64>(2);
-
-    let total_sink_contribution = accumulators::sum::<f64>(4);
-
-    ctx.global_agg_reset(max_diff);
-
-    ctx.global_agg_reset(total_sink_contribution);
-
-    let weight_id = weight.and_then(|key| g.edge_meta().get_prop_id(key, false));
-
-    let step1 = ATask::new({
-        move |s| {
-            let weighted_out_degree = s.out_edges().iter().fold(0.0f64, |acc, edge| {
-                weight_id
-                    .and_then(|id| edge.properties().get_by_id(id))
-                    .and_then(|p| p.as_f64())
-                    .unwrap_or(1.0)
-                    + acc
-            });
-            let state: &mut PageRankState = s.get_mut();
-            state.weighted_out_degree = weighted_out_degree;
-            Step::Continue
+    let personalization_id = personalization.and_then(|key| g.node_meta().get_prop_id(key, false));
+    let n = g.count_nodes();
+    
+        let mut ctx: Context<G, ComputeStateVec> = g.into();
+    
+        let tol: f64 = tol.unwrap_or(0.000001f64);
+        let iter_count = iter_count.unwrap_or(20);
+    
+        let max_diff = accumulators::sum::<f64>(2);
+        let total_sink_contribution = accumulators::sum::<f64>(4);
+        let personalization_total = accumulators::sum::<f64>(5);
+    
+        ctx.global_agg_reset(max_diff);
+        ctx.global_agg_reset(total_sink_contribution);
+        if personalization_id.is_some() {
+            ctx.global_agg(personalization_total);
         }
-    });
-
-    let step2: ATask<G, ComputeStateVec, PageRankState, _> = ATask::new(move |s| {
-        // reset score
-        {
-            let state: &mut PageRankState = s.get_mut();
-            state.reset();
-        }
-
-        for edge in s.in_edges() {
-            let w = weight_id
-                .and_then(|id| edge.properties().get_by_id(id))
-                .and_then(|p| p.as_f64())
-                .unwrap_or(1.0);
-            let nbr = edge.nbr();
-            let prev = nbr.prev();
-
-            if prev.weighted_out_degree > 0.0 {
-                s.get_mut().score += prev.score * w / prev.weighted_out_degree;
+    
+        let uniform_teleport_prob = (1f64 - damp) / n as f64;
+        let uniform_sink_factor = damp / n as f64;
+    
+        let weight_id = weight.and_then(|key| g.edge_meta().get_prop_id(key, false));
+    
+        let personalization_total_task = personalization_id.map(|personalization_id| {
+            let task: ATask<G, ComputeStateVec, PageRankState, _> =
+                ATask::new(move |s: &mut EvalNodeView<_, PageRankState>| {
+                    let value = s
+                        .properties()
+                        .get_by_id(personalization_id)
+                        .and_then(|p| p.as_f64())
+                        .unwrap_or(0.0);
+                    s.global_update(&personalization_total, value);
+                    Step::Continue
+                });
+            task
+        });
+    
+        let step1: ATask<G, ComputeStateVec, PageRankState, _> = ATask::new({
+            move |s: &mut EvalNodeView<_, PageRankState>| {
+                let weighted_out_degree = s.out_edges().iter().fold(0.0f64, |acc, edge| {
+                    weight_id
+                        .and_then(|id| edge.properties().get_by_id(id))
+                        .and_then(|p| p.as_f64())
+                        .unwrap_or(1.0)
+                        + acc
+                });
+                let state: &mut PageRankState = s.get_mut();
+                state.weighted_out_degree = weighted_out_degree;
+                Step::Continue
             }
+        });
+    
+        let step2: ATask<G, ComputeStateVec, PageRankState, _> =
+            ATask::new(move |s: &mut EvalNodeView<_, PageRankState>| {
+                let mut score = 0.0f64;
+    
+                for edge in s.in_edges() {
+                    let w = weight_id
+                        .and_then(|id| edge.properties().get_by_id(id))
+                        .and_then(|p| p.as_f64())
+                        .unwrap_or(1.0);
+                    let nbr = edge.nbr();
+                    let prev: &PageRankState = nbr.prev();
+    
+                    if prev.weighted_out_degree > 0.0 {
+                        score += prev.score * w / prev.weighted_out_degree;
+                    }
+                }
+    
+                score *= damp;
+                score += match personalization_id {
+                    Some(personalization_id) => {
+                        // NOTE: Obviously `unwrap`/`context` is tempting fate,
+                        // but this does seem both unrecoverable and very unlikely.
+                        let total = s
+                            .read_global_state(&personalization_total)
+                            .expect("Computing personalized pagerank, but total personalization missing");
+                        if total.abs() > f64::EPSILON {
+                            let value = s
+                                .properties()
+                                .get_by_id(personalization_id)
+                                .and_then(|p| p.as_f64())
+                                .unwrap_or(0.0);
+                            (1.0 - damp) * value / total
+                        } else {
+                            uniform_teleport_prob
+                        }
+                    }
+                    None => uniform_teleport_prob,
+                };
+    
+                s.get_mut().score = score;
+                Step::Continue
+            });
+    
+        let step3: ATask<G, ComputeStateVec, PageRankState, _> =
+            ATask::new(move |s: &mut EvalNodeView<_, PageRankState>| {
+                let state: &PageRankState = s.get();
+    
+                if state.weighted_out_degree.abs() < f64::EPSILON {
+                    let curr = s.prev().score;
+                    let sink_contribution = match personalization_id {
+                        Some(_) => {
+                            let total = s
+                                .read_global_state(&personalization_total)
+                                .expect("Computing personalized pagerank, but total personalization missing");
+                            if total.abs() > f64::EPSILON {
+                                curr
+                            } else {
+                                uniform_sink_factor * curr
+                            }
+                        }
+                        None => uniform_sink_factor * curr,
+                    };
+    
+                    s.global_update(&total_sink_contribution, sink_contribution);
+                }
+                Step::Continue
+            });
+
+        let step4: ATask<G, ComputeStateVec, PageRankState, _> =
+            ATask::new(move |s: &mut EvalNodeView<_, PageRankState>| {
+                let total_sink_contribution = s
+                    .read_global_state(&total_sink_contribution)
+                    .unwrap_or_default();
+                let sink_addition = match personalization_id {
+                    Some(personalization_id) => {
+                        let personalization_total = s
+                            .read_global_state(&personalization_total)
+                            .expect("Computing personalized pagerank, but total personalization missing");
+                        if personalization_total.abs() > 0.0 {
+                            let value = s
+                                .properties()
+                                .get_by_id(personalization_id)
+                                .and_then(|p| p.as_f64())
+                                .unwrap_or(0.0);
+                            damp * total_sink_contribution * value / personalization_total
+                        } else {
+                            total_sink_contribution
+                        }
+                    }
+                    None => total_sink_contribution,
+                };
+    
+                let prev = s.prev().score;
+                let state: &mut PageRankState = s.get_mut();
+                state.score += sink_addition;
+                let curr = state.score;
+    
+                let md = if use_l2_norm {
+                    f64::powi(abs(prev - curr), 2)
+                } else {
+                    abs(prev - curr)
+                };
+    
+                s.global_update(&max_diff, md);
+                Step::Continue
+            });
+    
+        let step5 = Job::Check(Box::new(move |state| {
+            let max_diff_val = state.read(&max_diff);
+            let cont = if use_l2_norm {
+                let sum_d = f64::sqrt(max_diff_val);
+                (sum_d) > tol * n as f64
+            } else {
+                (max_diff_val) > tol * n as f64
+            };
+            if cont {
+                Step::Continue
+            } else {
+                Step::Done
+            }
+        }));
+    
+        let mut runner: TaskRunner<G, _> = TaskRunner::new(ctx);
+    
+        let num_nodes = g.count_nodes();
+        let mut init_tasks = Vec::new();
+        if let Some(personalization_total_task) = personalization_total_task {
+            init_tasks.push(Job::new(personalization_total_task));
         }
-
-        s.get_mut().score *= damp;
-
-        s.get_mut().score += teleport_prob;
-        Step::Continue
-    });
-
-    let step3 = ATask::new(move |s| {
-        let state: &mut PageRankState = s.get_mut();
-
-        if state.weighted_out_degree.abs() < f64::EPSILON {
-            let curr = s.prev().score;
-
-            let ts_contrib = factor * curr;
-            s.global_update(&total_sink_contribution, ts_contrib);
-        }
-        Step::Continue
-    });
-
-    let step4 = ATask::new(move |s| {
-        //read total sink contribution
-        let total_sink_contribution = s
-            .read_global_state(&total_sink_contribution)
-            .unwrap_or_default();
-        // update local score with total sink contribution
-        let state: &mut PageRankState = s.get_mut();
-        state.score += total_sink_contribution;
-
-        // update global max diff
-
-        let curr = state.score;
-        let prev = s.prev().score;
-
-        let md = if use_l2_norm {
-            f64::powi(abs(prev - curr), 2)
-        } else {
-            abs(prev - curr)
-        };
-
-        s.global_update(&max_diff, md);
-        Step::Continue
-    });
-
-    let step5 = Job::Check(Box::new(move |state| {
-        let max_diff_val = state.read(&max_diff);
-        let cont = if use_l2_norm {
-            let sum_d = f64::sqrt(max_diff_val);
-            (sum_d) > tol * n as f64
-        } else {
-            (max_diff_val) > tol * n as f64
-        };
-        if cont {
-            Step::Continue
-        } else {
-            Step::Done
-        }
-    }));
-
-    let mut runner: TaskRunner<G, _> = TaskRunner::new(ctx);
-
-    let num_nodes = g.count_nodes();
-
-    runner.run(
-        vec![Job::new(step1)],
-        vec![Job::new(step2), Job::new(step3), Job::new(step4), step5],
-        Some(vec![PageRankState::new(num_nodes); num_nodes]),
-        |_, _, _, local, index| {
-            TypedNodeState::new(GenericNodeState::new_from_eval_with_index(
-                g.clone(),
-                local,
-                index,
-                None,
-            ))
-        },
-        threads,
-        iter_count,
-        None,
-        None,
-    )
+        init_tasks.push(Job::new(step1));
+    
+        runner.run(
+            init_tasks,
+            vec![Job::new(step2), Job::new(step3), Job::new(step4), step5],
+            Some(vec![PageRankState::new(num_nodes); num_nodes]),
+            |_, _, _, local, index| {
+                TypedNodeState::new(GenericNodeState::new_from_eval_with_index(
+                    g.clone(),
+                    local,
+                    index,
+                    None,
+                ))
+            },
+            threads,
+            iter_count,
+            None,
+            None,
+        )
 }

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -70,11 +70,12 @@ use crate::{
         utils::PyNodeRef,
     },
 };
+use crate::prelude::GraphViewOps;
 use pyo3::{prelude::*, types::PyList};
 use rand::{prelude::StdRng, SeedableRng};
 use raphtory_api::core::{entities::LayerIds, storage::timeindex::EventTime, Direction};
 use raphtory_storage::core_ops::CoreGraphOps;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Helper function to parse single-vertex or multi-vertex parameters to a Vec of vertices
 fn process_node_param(param: &Bound<PyAny>) -> PyResult<Vec<PyNodeRef>> {
@@ -268,18 +269,29 @@ pub fn out_component(
 ///         is less than the max diff value given.
 ///     use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
 ///     damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
+///     personalization (Optional[dict[Node, float]]): A dictionary mapping nodes to personalization values.
+///         When provided, the random walk teleports to nodes proportionally to these values
+///         instead of uniformly. Values are normalized to sum to 1. Defaults to None (uniform).
 ///
 /// Returns:
 ///     NodeStateF64: Mapping of nodes to their pagerank value.
 #[pyfunction]
-#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85))]
+#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85, personalization=None))]
 pub fn pagerank(
     graph: &PyGraphView,
     iter_count: usize,
     max_diff: Option<f64>,
     use_l2_norm: bool,
     damping_factor: Option<f64>,
+    personalization: Option<HashMap<PyNodeRef, f64>>,
 ) -> NodeState<'static, f64, DynamicGraph> {
+    let personalization = personalization.map(|p| {
+        p.into_iter()
+            .filter_map(|(node_ref, value)| {
+                graph.graph.node(node_ref).map(|n| (n.node, value))
+            })
+            .collect()
+    });
     unweighted_page_rank(
         &graph.graph,
         Some(iter_count),
@@ -287,6 +299,7 @@ pub fn pagerank(
         max_diff,
         use_l2_norm,
         damping_factor,
+        personalization,
     )
 }
 

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -64,7 +64,7 @@ use crate::{
         graph::nodes::Nodes,
     },
     errors::GraphError,
-    prelude::Graph,
+    prelude::{Graph, GraphViewOps},
     python::{
         filter::filter_expr::PyFilterExpr,
         graph::{node::PyNode, views::graph_view::PyGraphView},
@@ -75,6 +75,7 @@ use pyo3::{prelude::*, types::PyList};
 use rand::{prelude::StdRng, SeedableRng};
 use raphtory_api::core::{entities::LayerIds, storage::timeindex::EventTime, Direction};
 use raphtory_storage::core_ops::CoreGraphOps;
+use std::collections::{HashMap, HashSet};
 
 /// Helper function to parse single-vertex or multi-vertex parameters to a Vec of vertices
 fn process_node_param(param: &Bound<PyAny>) -> PyResult<Vec<PyNodeRef>> {
@@ -257,11 +258,14 @@ pub fn out_component(
 ///     use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
 ///     damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
 ///     weight (Optional[str]): Edge property key to use as weight. If None, all edges have weight 1.0.
+///     personalization (Optional[str]): Node property key to use as personalization weight.
+///         When provided, the random walk teleports to nodes proportionally to these node property values
+///         instead of uniformly. Values are normalized to sum to 1. Defaults to None (uniform).
 ///
 /// Returns:
 ///     OutputNodeState: NodeState mapping nodes to their pagerank score.
 #[pyfunction]
-#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85, weight=None))]
+#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85, weight=None, personalization=None))]
 pub fn pagerank(
     graph: &PyGraphView,
     iter_count: usize,
@@ -269,6 +273,7 @@ pub fn pagerank(
     use_l2_norm: bool,
     damping_factor: Option<f64>,
     weight: Option<&str>,
+    personalization: Option<&str>,
 ) -> OutputTypedNodeState<'static, DynamicGraph> {
     page_rank(
         &graph.graph,
@@ -278,6 +283,7 @@ pub fn pagerank(
         max_diff,
         use_l2_norm,
         damping_factor,
+        personalization,
     )
     .to_output_nodestate()
 }

--- a/raphtory/tests/algo_tests/centrality.rs
+++ b/raphtory/tests/algo_tests/centrality.rs
@@ -144,7 +144,7 @@ fn test_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(1), None, true, None);
+        let results = unweighted_page_rank(graph, Some(1000), Some(1), None, true, None, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.38694), 5);
         assert_eq_f64(results.get_by_node("2"), Some(&0.20195), 5);
@@ -188,7 +188,7 @@ fn motif_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None);
+        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None, None);
 
         assert_eq_f64(results.get_by_node("10"), Some(&0.072082), 5);
         assert_eq_f64(results.get_by_node("8"), Some(&0.136473), 5);
@@ -215,7 +215,7 @@ fn two_nodes_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, false, None);
+        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, false, None, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.5), 3);
         assert_eq_f64(results.get_by_node("2"), Some(&0.5), 3);
@@ -233,7 +233,7 @@ fn three_nodes_page_rank_one_dangling() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(10), Some(4), None, false, None);
+        let results = unweighted_page_rank(graph, Some(10), Some(4), None, false, None, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.303), 3);
         assert_eq_f64(results.get_by_node("2"), Some(&0.393), 3);
@@ -270,7 +270,7 @@ fn dangling_page_rank() {
         graph.add_edge(t, src, dst, NO_PROPS, None).unwrap();
     }
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None);
+        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.055), 3);
         assert_eq_f64(results.get_by_node("2"), Some(&0.079), 3);
@@ -283,6 +283,70 @@ fn dangling_page_rank() {
         assert_eq_f64(results.get_by_node("9"), Some(&0.110), 3);
         assert_eq_f64(results.get_by_node("10"), Some(&0.117), 3);
         assert_eq_f64(results.get_by_node("11"), Some(&0.122), 3);
+    });
+}
+
+#[test]
+fn test_personalized_page_rank() {
+    let graph = Graph::new();
+    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
+    for (src, dst) in edges {
+        graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
+    }
+
+    test_storage!(&graph, |graph| {
+        let mut personalization = HashMap::new();
+        personalization.insert(graph.node("1").unwrap().node, 1.0);
+        personalization.insert(graph.node("2").unwrap().node, 0.0);
+        personalization.insert(graph.node("3").unwrap().node, 0.0);
+        personalization.insert(graph.node("4").unwrap().node, 0.0);
+
+        let results = unweighted_page_rank(
+            graph,
+            Some(1000),
+            Some(1),
+            None,
+            true,
+            None,
+            Some(personalization),
+        );
+
+        // nx.pagerank(G, alpha=0.85, personalization={1:1.0, 2:0.0, 3:0.0, 4:0.0})
+        assert_eq_f64(results.get_by_node("1"), Some(&0.45223), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.19220), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.16337), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.19220), 5);
+    });
+}
+
+#[test]
+fn test_personalized_page_rank_partial() {
+    let graph = Graph::new();
+    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
+    for (src, dst) in edges {
+        graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
+    }
+
+    test_storage!(&graph, |graph| {
+        let mut personalization = HashMap::new();
+        personalization.insert(graph.node("1").unwrap().node, 0.5);
+        personalization.insert(graph.node("3").unwrap().node, 0.5);
+
+        let results = unweighted_page_rank(
+            graph,
+            Some(1000),
+            Some(1),
+            Some(1e-10),
+            false,
+            None,
+            Some(personalization),
+        );
+
+        // nx.pagerank(G, alpha=0.85, personalization={1:0.5, 3:0.5})
+        assert_eq_f64(results.get_by_node("1"), Some(&0.41832), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.17778), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.22612), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.17778), 5);
     });
 }
 

--- a/raphtory/tests/algo_tests/centrality.rs
+++ b/raphtory/tests/algo_tests/centrality.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
+use std::borrow::Borrow;
 
-use crate::algo_tests::assert_eq_hashmaps_approx;
 use itertools::Itertools;
 use raphtory::{
     algorithms::centrality::{
@@ -8,8 +7,8 @@ use raphtory::{
         pagerank::page_rank,
     },
     prelude::*,
+    test_storage,
 };
-use raphtory_tests::test_storage;
 
 #[test]
 fn test_betweenness_centrality() {
@@ -41,8 +40,7 @@ fn test_betweenness_centrality() {
         expected.insert("5".to_string(), 0.0);
         expected.insert("6".to_string(), 0.0);
 
-        let res = betweenness_centrality(graph, None, false)
-            .to_hashmap(|value| value.betweenness_centrality);
+        let res = betweenness_centrality(graph, None, false);
         assert_eq!(res, expected);
 
         let mut expected: HashMap<String, f64> = HashMap::new();
@@ -52,8 +50,7 @@ fn test_betweenness_centrality() {
         expected.insert("4".to_string(), 0.05);
         expected.insert("5".to_string(), 0.0);
         expected.insert("6".to_string(), 0.0);
-        let res = betweenness_centrality(graph, None, true)
-            .to_hashmap(|value| value.betweenness_centrality);
+        let res = betweenness_centrality(graph, None, true);
         assert_eq!(res, expected);
     });
 }
@@ -72,7 +69,7 @@ fn test_degree_centrality() {
         expected.insert("3".to_string(), 2.0 / 3.0);
         expected.insert("4".to_string(), 2.0 / 3.0);
 
-        let res = degree_centrality(graph).to_hashmap(|value| value.score);
+        let res = degree_centrality(graph);
         assert_eq!(res, expected);
     });
 }
@@ -119,18 +116,18 @@ fn test_hits() {
         for (node, value) in results.iter() {
             let expected_value = expected.get(&node.name()).unwrap();
             assert!(
-                (value.hub_score - expected_value.0).abs() < 1e-6,
+                (value.0 - expected_value.0).abs() < 1e-6,
                 "mismatched hub score for node {}, expected {}, actual {}",
                 node.name(),
                 expected_value.0,
-                value.hub_score
+                value.0
             );
             assert!(
-                (value.auth_score - expected_value.1).abs() < 1e-6,
+                (value.1 - expected_value.1).abs() < 1e-6,
                 "mismatched authority score for node {}, expected {}, actual {}",
                 node.name(),
                 expected_value.1,
-                value.auth_score
+                value.1
             );
         }
     })
@@ -147,15 +144,13 @@ fn test_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let expected: HashMap<String, f64> = HashMap::from([
-            ("1".to_string(), 0.38694),
-            ("2".to_string(), 0.20195),
-            ("3".to_string(), 0.20916),
-            ("4".to_string(), 0.20195),
-        ]);
         let results = page_rank(graph, None, Some(1000), Some(1), None, true, None, None)
-            .to_hashmap(|value| value.score);
-        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
+            .map(|pr| pr.score);
+
+        assert_eq_f64(results.get_by_node("1"), Some(&0.38694), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.20195), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.20195), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.20916), 5);
     });
 }
 
@@ -194,23 +189,20 @@ fn motif_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let expected: HashMap<String, f64> = HashMap::from([
-            ("10".to_string(), 0.072082),
-            ("8".to_string(), 0.136473),
-            ("3".to_string(), 0.15484),
-            ("6".to_string(), 0.07208),
-            ("11".to_string(), 0.06186),
-            ("2".to_string(), 0.03557),
-            ("1".to_string(), 0.11284),
-            ("4".to_string(), 0.07944),
-            ("7".to_string(), 0.01638),
-            ("9".to_string(), 0.06186),
-            ("5".to_string(), 0.19658),
-        ]);
         let results = page_rank(graph, None, Some(1000), Some(4), None, true, None, None)
-            .to_hashmap(|value| value.score);
+            .map(|pr| pr.score);
 
-        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
+        assert_eq_f64(results.get_by_node("10"), Some(&0.072082), 5);
+        assert_eq_f64(results.get_by_node("8"), Some(&0.136473), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.15484), 5);
+        assert_eq_f64(results.get_by_node("6"), Some(&0.07208), 5);
+        assert_eq_f64(results.get_by_node("11"), Some(&0.06186), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.03557), 5);
+        assert_eq_f64(results.get_by_node("1"), Some(&0.11284), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.07944), 5);
+        assert_eq_f64(results.get_by_node("7"), Some(&0.01638), 5);
+        assert_eq_f64(results.get_by_node("9"), Some(&0.06186), 5);
+        assert_eq_f64(results.get_by_node("5"), Some(&0.19658), 5);
     });
 }
 
@@ -225,12 +217,11 @@ fn two_nodes_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let expected: HashMap<String, f64> =
-            HashMap::from([("1".to_string(), 0.5), ("2".to_string(), 0.5)]);
         let results = page_rank(graph, None, Some(1000), Some(4), None, false, None, None)
-            .to_hashmap(|value| value.score);
+            .map(|pr| pr.score);
 
-        assert_eq_hashmaps_approx(&results, &expected, 1e-3);
+        assert_eq_f64(results.get_by_node("1"), Some(&0.5), 3);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.5), 3);
     });
 }
 
@@ -245,15 +236,12 @@ fn three_nodes_page_rank_one_dangling() {
     }
 
     test_storage!(&graph, |graph| {
-        let expected: HashMap<String, f64> = HashMap::from([
-            ("1".to_string(), 0.303),
-            ("2".to_string(), 0.393),
-            ("3".to_string(), 0.303),
-        ]);
         let results = page_rank(graph, None, Some(10), Some(4), None, false, None, None)
-            .to_hashmap(|value| value.score);
+            .map(|pr| pr.score);
 
-        assert_eq_hashmaps_approx(&results, &expected, 1e-3);
+        assert_eq_f64(results.get_by_node("1"), Some(&0.303), 3);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.393), 3);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.303), 3);
     });
 }
 
@@ -286,171 +274,108 @@ fn dangling_page_rank() {
         graph.add_edge(t, src, dst, NO_PROPS, None).unwrap();
     }
     test_storage!(&graph, |graph| {
-        let expected: HashMap<String, f64> = HashMap::from([
-            ("1".to_string(), 0.055),
-            ("2".to_string(), 0.079),
-            ("3".to_string(), 0.113),
-            ("4".to_string(), 0.055),
-            ("5".to_string(), 0.070),
-            ("6".to_string(), 0.083),
-            ("7".to_string(), 0.093),
-            ("8".to_string(), 0.102),
-            ("9".to_string(), 0.110),
-            ("10".to_string(), 0.117),
-            ("11".to_string(), 0.122),
-        ]);
         let results = page_rank(graph, None, Some(1000), Some(4), None, true, None, None)
-            .to_hashmap(|value| value.score);
+            .map(|pr| pr.score);
 
-        assert_eq_hashmaps_approx(&results, &expected, 1e-3);
-    });
-}
-#[test]
-fn page_rank_non_uniform_weights() {
-    let graph = Graph::new();
-    graph
-        .add_edge(0, 1, 2, [("weight", Prop::F64(0.37))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 1, 3, [("weight", Prop::F64(4.2))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 2, 1, [("weight", Prop::F64(0.9))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 2, 4, [("weight", Prop::F64(1.7))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 3, 1, [("weight", Prop::F64(2.6))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 3, 2, [("weight", Prop::F64(0.05))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 4, 3, [("weight", Prop::F64(3.3))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 4, 1, [("weight", Prop::F64(0.8))], None)
-        .unwrap();
-
-    test_storage!(&graph, |graph| {
-        let expected: HashMap<String, f64> = HashMap::from([
-            ("1".to_string(), 0.42499),
-            ("2".to_string(), 0.07353),
-            ("3".to_string(), 0.42311),
-            ("4".to_string(), 0.07837),
-        ]);
-        let results = page_rank(
-            graph,
-            Some("weight"),
-            Some(1000),
-            Some(1),
-            Some(1e-10),
-            true,
-            None,
-            None,
-        )
-        .to_hashmap(|value| value.score);
-
-        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
+        assert_eq_f64(results.get_by_node("1"), Some(&0.055), 3);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.079), 3);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.113), 3);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.055), 3);
+        assert_eq_f64(results.get_by_node("5"), Some(&0.070), 3);
+        assert_eq_f64(results.get_by_node("6"), Some(&0.083), 3);
+        assert_eq_f64(results.get_by_node("7"), Some(&0.093), 3);
+        assert_eq_f64(results.get_by_node("8"), Some(&0.102), 3);
+        assert_eq_f64(results.get_by_node("9"), Some(&0.110), 3);
+        assert_eq_f64(results.get_by_node("10"), Some(&0.117), 3);
+        assert_eq_f64(results.get_by_node("11"), Some(&0.122), 3);
     });
 }
 
 #[test]
-fn page_rank_dangling_weighted() {
-    let graph = Graph::new();
-    graph
-        .add_edge(0, 1, 2, [("weight", Prop::F64(0.12))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 1, 3, [("weight", Prop::F64(7.1))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 2, 4, [("weight", Prop::F64(0.004))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 3, 1, [("weight", Prop::F64(1.9))], None)
-        .unwrap();
-    graph
-        .add_edge(0, 3, 5, [("weight", Prop::F64(0.63))], None)
-        .unwrap();
-
-    test_storage!(&graph, |graph| {
-        let expected: HashMap<String, f64> = HashMap::from([
-            ("1".to_string(), 0.28736),
-            ("2".to_string(), 0.08587),
-            ("3".to_string(), 0.32201),
-            ("4".to_string(), 0.15480),
-            ("5".to_string(), 0.14997),
-        ]);
-        let results = page_rank(
-            graph,
-            Some("weight"),
-            Some(1000),
-            Some(1),
-            Some(1e-10),
-            true,
-            None,
-            None,
-        )
-        .to_hashmap(|value| value.score);
-
-        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
-    });
-}
-
-#[test]
-fn page_rank_uniform_weights_match_unweighted() {
+fn test_personalized_page_rank() {
     let graph = Graph::new();
     let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
-    for (src, dst) in edges {
+    for node in [(1, 1.0), (2, 0.0), (3, 0.0), (4, 0.0)] {
         graph
-            .add_edge(0, src, dst, [("weight", Prop::F64(1.0))], None)
+            .add_node(0, node.0, [("personalization", node.1)], None, None)
             .unwrap();
     }
-
-    test_storage!(&graph, |graph| {
-        let expected = page_rank(graph, None, Some(1000), Some(1), None, true, None, None)
-            .to_hashmap(|value| value.score);
-        let results = page_rank(
-            graph,
-            Some("weight"),
-            Some(1000),
-            Some(1),
-            None,
-            true,
-            None,
-            None,
-        )
-        .to_hashmap(|value| value.score);
-
-        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
-    });
-}
-
-#[test]
-fn page_rank_missing_property_defaults_to_unweighted() {
-    let graph = Graph::new();
-    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
     for (src, dst) in edges {
         graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
     }
 
     test_storage!(&graph, |graph| {
-        let expected = page_rank(graph, None, Some(1000), Some(1), None, true, None, None)
-            .to_hashmap(|value| value.score);
         let results = page_rank(
             graph,
-            Some("weight"),
+            None,
             Some(1000),
             Some(1),
             None,
             true,
             None,
-            None,
+            Some("personalization"),
         )
-        .to_hashmap(|value| value.score);
+        .map(|pr| pr.score);
 
-        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
+        // nx.pagerank(G, alpha=0.85, personalization={1:1.0, 2:0.0, 3:0.0, 4:0.0})
+        assert_eq_f64(results.get_by_node("1"), Some(&0.45223), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.19220), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.16337), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.19220), 5);
     });
+}
+
+#[test]
+fn test_personalized_page_rank_partial() {
+    let graph = Graph::new();
+    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
+    graph
+        .add_node(0, 1, [("personalization", 0.5)], None, None)
+        .unwrap();
+    graph
+        .add_node(0, 3, [("personalization", 0.5)], None, None)
+        .unwrap();
+    for (src, dst) in edges {
+        graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
+    }
+
+    test_storage!(&graph, |graph| {
+        let results = page_rank(
+            graph,
+            None,
+            Some(1000),
+            Some(1),
+            Some(1e-10),
+            false,
+            None,
+            Some("personalization"),
+        )
+        .map(|pr| pr.score);
+
+        // nx.pagerank(G, alpha=0.85, personalization={1:0.5, 3:0.5})
+        assert_eq_f64(results.get_by_node("1"), Some(&0.41832), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.17778), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.22612), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.17778), 5);
+    });
+}
+
+pub fn assert_eq_f64<T: Borrow<f64> + PartialEq + std::fmt::Debug>(
+    a: Option<T>,
+    b: Option<T>,
+    decimals: u8,
+) {
+    if a.is_none() || b.is_none() {
+        assert_eq!(a, b);
+    } else {
+        let factor = 10.0_f64.powi(decimals as i32);
+        match (a, b) {
+            (Some(a), Some(b)) => {
+                let left = (a.borrow() * factor).round();
+                let right = (b.borrow() * factor).round();
+                assert_eq!(left, right,);
+            }
+            _ => unreachable!(),
+        }
+    }
 }


### PR DESCRIPTION
Two tests with expected values computed via NetworkX:
- test_personalized_page_rank: all teleport weight on node 1
- test_personalized_page_rank_partial: weight split between nodes 1 and 3

### What changes were proposed in this pull request?

Add a personalization parameter to `unweighted_page_rank`

If `personalization` is None, then we dispatch via trait to the exact same calculations as the previous, uniform variant to avoid rounding errors from non-commutative f64 arithmetic. 

### Why are the changes needed?

To compute personalized page rank (e.g., in fraud-detection situations)

### Does this PR introduce any user-facing change? If yes is this documented?

Yes, it adds the `personalization` parameter to `unweighted_pagerank`. This is added to docstrings in both `python` and `algorithms/centrality`

### How was this patch tested?

The unit tests added were validated by computing the same values using networkx.

### Are there any further changes required?

I am quite happy to also add a weighted variant
