### PR TITLE
Add optional weight to pagerank

### DIFF
--- a/examples/rust/src/bin/bench/main.rs
+++ b/examples/rust/src/bin/bench/main.rs
@@ -1,5 +1,5 @@
 use raphtory::{
-    algorithms::centrality::pagerank::unweighted_page_rank, io::csv_loader::CsvLoader,
+    algorithms::centrality::pagerank::page_rank, io::csv_loader::CsvLoader,
     logging::global_info_logger, prelude::*,
 };
 use serde::Deserialize;
@@ -82,6 +82,6 @@ fn main() {
         g
     };
     info!("Data loaded\nPageRanking");
-    unweighted_page_rank(&graph, Some(25), Some(8), None, true, None);
+    page_rank(&graph, None, Some(25), Some(8), None, true, None);
     info!("Done PR");
 }

--- a/examples/rust/src/bin/crypto/main.rs
+++ b/examples/rust/src/bin/crypto/main.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use raphtory::{
     algorithms::{
-        centrality::pagerank::unweighted_page_rank,
+        centrality::pagerank::page_rank,
         pathing::temporal_reachability::temporally_reachable_nodes,
     },
     db::api::view::*,
@@ -33,16 +33,24 @@ fn main() {
 
     info!("Pagerank");
     let now = Instant::now();
-    let _ = unweighted_page_rank(&g, Some(20), None, None, true, None);
+    let _ = page_rank(&g, None, Some(20), None, None, true, None);
     info!("Time taken: {} secs", now.elapsed().as_secs());
 
     let now = Instant::now();
 
-    let _ = unweighted_page_rank(&g, Some(20), None, None, true, None);
+    let _ = page_rank(&g, None, Some(20), None, None, true, None);
     info!("Time taken: {} secs", now.elapsed().as_secs());
 
     let now = Instant::now();
-    let _ = unweighted_page_rank(&g.layers("USDT").unwrap(), Some(20), None, None, true, None);
+    let _ = page_rank(
+        &g.layers("USDT").unwrap(),
+        None,
+        Some(20),
+        None,
+        None,
+        true,
+        None,
+    );
     info!("Time taken: {} secs", now.elapsed().as_secs());
 
     info!("Generic taint");

--- a/examples/rust/src/bin/pokec/main.rs
+++ b/examples/rust/src/bin/pokec/main.rs
@@ -1,6 +1,6 @@
 use raphtory::{
     algorithms::{
-        centrality::pagerank::unweighted_page_rank, components::weakly_connected_components,
+        centrality::pagerank::page_rank, components::weakly_connected_components,
     },
     db::{api::mutation::AdditionOps, graph::graph::Graph},
     io::csv_loader::CsvLoader,
@@ -51,7 +51,7 @@ fn main() {
 
     let now = Instant::now();
 
-    unweighted_page_rank(&g, Some(100), None, Some(0.00000001), true, None);
+    page_rank(&g, None, Some(100), None, Some(0.00000001), true, None);
 
     info!("PageRank took {} millis", now.elapsed().as_millis());
 

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -289,6 +289,7 @@ def pagerank(
     max_diff: Optional[float] = None,
     use_l2_norm: bool = True,
     damping_factor: float = 0.85,
+    weight: Optional[str] = None,
 ) -> NodeStateF64:
     """
     Pagerank -- pagerank centrality value of the nodes in a graph
@@ -305,6 +306,7 @@ def pagerank(
             is less than the max diff value given.
         use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
         damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
+        weight (Optional[str]): Edge property key to use as weight. If None, all edges have weight 1.0.
 
     Returns:
         NodeStateF64: Mapping of nodes to their pagerank value.

--- a/python/python/raphtory/algorithms/__init__.pyi
+++ b/python/python/raphtory/algorithms/__init__.pyi
@@ -304,6 +304,7 @@ def pagerank(
     max_diff: Optional[float] = None,
     use_l2_norm: bool = True,
     damping_factor: float = 0.85,
+    weight: Optional[str] = None,
 ) -> OutputNodeState:
     """
     Pagerank -- pagerank centrality value of the nodes in a graph
@@ -320,6 +321,7 @@ def pagerank(
             is less than the max diff value given.
         use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
         damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
+        weight (Optional[str]): Edge property key to use as weight. If None, all edges have weight 1.0.
 
     Returns:
         OutputNodeState: NodeState mapping nodes to their pagerank score.

--- a/python/tests/test_base_install/test_graphdb/test_algorithms.py
+++ b/python/tests/test_base_install/test_graphdb/test_algorithms.py
@@ -312,6 +312,36 @@ def test_page_rank():
     assert actual == expected
 
 
+def test_weighted_page_rank():
+    g = Graph()
+    g.add_edge(0, 1, 2, {"weight": 0.37})
+    g.add_edge(0, 1, 3, {"weight": 4.2})
+    g.add_edge(0, 2, 1, {"weight": 0.9})
+    g.add_edge(0, 2, 4, {"weight": 1.7})
+    g.add_edge(0, 3, 1, {"weight": 2.6})
+    g.add_edge(0, 3, 2, {"weight": 0.05})
+    g.add_edge(0, 4, 3, {"weight": 3.3})
+    g.add_edge(0, 4, 1, {"weight": 0.8})
+
+    actual = algorithms.pagerank(g, iter_count=1000, max_diff=1e-10, weight="weight")
+    for node, expected in [("1", 0.42499), ("2", 0.07353), ("3", 0.42311), ("4", 0.07837)]:
+        assert abs(actual[node] - expected) < 1e-5, f"node {node}: {actual[node]} != {expected}"
+
+
+def test_weighted_page_rank_none_matches_unweighted():
+    g = Graph()
+    g.add_edge(0, 1, 2, {"weight": 1.0})
+    g.add_edge(0, 1, 4, {"weight": 1.0})
+    g.add_edge(0, 2, 3, {"weight": 1.0})
+    g.add_edge(0, 3, 1, {"weight": 1.0})
+    g.add_edge(0, 4, 1, {"weight": 1.0})
+
+    unweighted = algorithms.pagerank(g, iter_count=1000)
+    weighted = algorithms.pagerank(g, iter_count=1000, weight="weight")
+    for node in ["1", "2", "3", "4"]:
+        assert abs(unweighted[node] - weighted[node]) < 1e-5, f"node {node} differs"
+
+
 def test_temporal_reachability():
     g = gen_graph()
 

--- a/python/tests/test_base_install/test_graphdb/test_algorithms.py
+++ b/python/tests/test_base_install/test_graphdb/test_algorithms.py
@@ -351,6 +351,46 @@ def test_page_rank():
     assert result == expected
 
 
+def test_weighted_page_rank():
+    g = Graph()
+    g.add_edge(0, 1, 2, {"weight": 0.37})
+    g.add_edge(0, 1, 3, {"weight": 4.2})
+    g.add_edge(0, 2, 1, {"weight": 0.9})
+    g.add_edge(0, 2, 4, {"weight": 1.7})
+    g.add_edge(0, 3, 1, {"weight": 2.6})
+    g.add_edge(0, 3, 2, {"weight": 0.05})
+    g.add_edge(0, 4, 3, {"weight": 3.3})
+    g.add_edge(0, 4, 1, {"weight": 0.8})
+
+    actual = algorithms.pagerank(g, iter_count=1000, max_diff=1e-10, weight="weight")
+    for node, expected in [
+        ("1", 0.42499),
+        ("2", 0.07353),
+        ("3", 0.42311),
+        ("4", 0.07837),
+    ]:
+        assert abs(actual[node]["pagerank_score"] - expected) < 1e-5, (
+            f"node {node}: {actual[node]} != {expected}"
+        )
+
+
+def test_weighted_page_rank_none_matches_unweighted():
+    g = Graph()
+    g.add_edge(0, 1, 2, {"weight": 1.0})
+    g.add_edge(0, 1, 4, {"weight": 1.0})
+    g.add_edge(0, 2, 3, {"weight": 1.0})
+    g.add_edge(0, 3, 1, {"weight": 1.0})
+    g.add_edge(0, 4, 1, {"weight": 1.0})
+
+    unweighted = algorithms.pagerank(g, iter_count=1000)
+    weighted = algorithms.pagerank(g, iter_count=1000, weight="weight")
+    for node in ["1", "2", "3", "4"]:
+        assert (
+            abs(unweighted[node]["pagerank_score"] - weighted[node]["pagerank_score"])
+            < 1e-5
+        ), f"node {node} differs"
+
+
 def test_temporal_reachability():
     g = gen_graph()
 

--- a/raphtory-benchmark/benches/algobench.rs
+++ b/raphtory-benchmark/benches/algobench.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
 use raphtory::{
     algorithms::{
-        centrality::pagerank::unweighted_page_rank,
+        centrality::pagerank::page_rank,
         components::weakly_connected_components,
         metrics::clustering_coefficient::{
             global_clustering_coefficient::global_clustering_coefficient,
@@ -87,7 +87,7 @@ pub fn graphgen_large_pagerank(c: &mut Criterion) {
         &graph,
         |b, graph| {
             b.iter(|| {
-                let result = unweighted_page_rank(graph, Some(100), None, None, true, None);
+                let result = page_rank(graph, None, Some(100), None, None, true, None);
                 black_box(result);
             });
         },

--- a/raphtory-benchmark/benches/algobench.rs
+++ b/raphtory-benchmark/benches/algobench.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
 use raphtory::{
     algorithms::{
-        centrality::pagerank::unweighted_page_rank,
+        centrality::pagerank::page_rank,
         components::weakly_connected_components,
         metrics::clustering_coefficient::{
             global_clustering_coefficient::global_clustering_coefficient,
@@ -88,7 +88,7 @@ pub fn graphgen_large_pagerank(c: &mut Criterion) {
         &graph,
         |b, graph| {
             b.iter(|| {
-                let result = unweighted_page_rank(graph, Some(100), None, None, true, None);
+                let result = page_rank(graph, None, Some(100), None, None, true, None);
                 black_box(result);
             });
         },

--- a/raphtory-benchmark/bin/main.rs
+++ b/raphtory-benchmark/bin/main.rs
@@ -3,7 +3,7 @@ use csv::StringRecord;
 use flate2::read::GzDecoder;
 use raphtory::{
     algorithms::{
-        centrality::pagerank::unweighted_page_rank, components::weakly_connected_components,
+        centrality::pagerank::page_rank, components::weakly_connected_components,
     },
     graph_loader::fetch_file,
     io::csv_loader::CsvLoader,
@@ -200,7 +200,7 @@ fn main() {
 
     // page rank with time
     now = Instant::now();
-    let _page_rank = unweighted_page_rank(&g, Some(1000), None, None, true, None);
+    let _page_rank = page_rank(&g, None, Some(1000), None, None, true, None);
     info!("Page rank: {} seconds", now.elapsed().as_secs_f64());
 
     // connected community_detection with time

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -1184,7 +1184,7 @@ type Graph {
 }
 
 type GraphAlgorithmPlugin {
-	pagerank(iterCount: Int!, threads: Int, tol: Float): [PagerankOutput!]!
+	pagerank(iterCount: Int!, threads: Int, tol: Float, weight: String): [PagerankOutput!]!
 	shortest_path(source: String!, targets: [String!]!, direction: String): [ShortestPathOutput!]!
 }
 

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -1844,7 +1844,7 @@ type Graph {
 }
 
 type GraphAlgorithmPlugin {
-	pagerank(iterCount: Int!, threads: Int, tol: Float): [PagerankOutput!]!
+	pagerank(iterCount: Int!, threads: Int, tol: Float, weight: String): [PagerankOutput!]!
 	shortest_path(source: String!, targets: [String!]!, direction: String): [ShortestPathOutput!]!
 }
 

--- a/raphtory-graphql/src/model/plugins/algorithms.rs
+++ b/raphtory-graphql/src/model/plugins/algorithms.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use raphtory::{
     algorithms::{
-        centrality::pagerank::unweighted_page_rank,
+        centrality::pagerank::page_rank,
         pathing::dijkstra::dijkstra_single_source_shortest_paths,
     },
     prelude::NodeViewOps,
@@ -70,6 +70,7 @@ impl<'a> Operation<'a, GraphAlgorithmPlugin> for Pagerank {
             ("iterCount", TypeRef::named_nn(TypeRef::INT)), // _nn stands for not null
             ("threads", TypeRef::named(TypeRef::INT)),      // this one though might be null
             ("tol", TypeRef::named(TypeRef::FLOAT)),
+            ("weight", TypeRef::named(TypeRef::STRING)),
         ]
     }
 
@@ -96,8 +97,10 @@ fn apply_pagerank<'b>(
         .get("damping_factor")
         .map(|v| v.f64())
         .transpose()?;
-    let binding = unweighted_page_rank(
+    let weight = ctx.args.get("weight").map(|v| v.string()).transpose()?;
+    let binding = page_rank(
         &entry_point.graph,
+        weight.as_deref(),
         Some(iter_count),
         threads,
         tol,

--- a/raphtory-graphql/src/model/plugins/algorithms.rs
+++ b/raphtory-graphql/src/model/plugins/algorithms.rs
@@ -8,7 +8,7 @@ use futures_util::future::BoxFuture;
 use itertools::Itertools;
 use raphtory::{
     algorithms::{
-        centrality::pagerank::{unweighted_page_rank, PageRankState},
+        centrality::pagerank::{page_rank, PageRankState},
         pathing::dijkstra::dijkstra_single_source_shortest_paths,
     },
     prelude::{GraphViewOps, NodeViewOps},
@@ -47,6 +47,7 @@ impl<'a> Operation<'a, GraphAlgorithmPlugin> for Pagerank {
             ("iterCount", TypeRef::named_nn(TypeRef::INT)), // _nn stands for not null
             ("threads", TypeRef::named(TypeRef::INT)),      // this one though might be null
             ("tol", TypeRef::named(TypeRef::FLOAT)),
+            ("weight", TypeRef::named(TypeRef::STRING)),
         ]
     }
 
@@ -73,8 +74,10 @@ fn apply_pagerank<'b>(
         .get("damping_factor")
         .map(|v| v.f64())
         .transpose()?;
-    let binding = unweighted_page_rank(
+    let weight = ctx.args.get("weight").map(|v| v.string()).transpose()?;
+    let binding = page_rank(
         &entry_point.graph,
+        weight.as_deref(),
         Some(iter_count),
         threads,
         tol,

--- a/raphtory-tests/tests/algo_tests/centrality.rs
+++ b/raphtory-tests/tests/algo_tests/centrality.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use raphtory::{
     algorithms::centrality::{
         betweenness::betweenness_centrality, degree_centrality::degree_centrality, hits::hits,
-        pagerank::unweighted_page_rank,
+        pagerank::page_rank,
     },
     prelude::*,
 };
@@ -153,7 +153,7 @@ fn test_page_rank() {
             ("3".to_string(), 0.20916),
             ("4".to_string(), 0.20195),
         ]);
-        let results = unweighted_page_rank(graph, Some(1000), Some(1), None, true, None)
+        let results = page_rank(graph, None, Some(1000), Some(1), None, true, None)
             .to_hashmap(|value| value.score);
         assert_eq_hashmaps_approx(&results, &expected, 1e-5);
     });
@@ -207,8 +207,7 @@ fn motif_page_rank() {
             ("9".to_string(), 0.06186),
             ("5".to_string(), 0.19658),
         ]);
-
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None)
+        let results = page_rank(graph, None, Some(1000), Some(4), None, true, None)
             .to_hashmap(|value| value.score);
 
         assert_eq_hashmaps_approx(&results, &expected, 1e-5);
@@ -228,8 +227,7 @@ fn two_nodes_page_rank() {
     test_storage!(&graph, |graph| {
         let expected: HashMap<String, f64> =
             HashMap::from([("1".to_string(), 0.5), ("2".to_string(), 0.5)]);
-
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, false, None)
+        let results = page_rank(graph, None, Some(1000), Some(4), None, false, None)
             .to_hashmap(|value| value.score);
 
         assert_eq_hashmaps_approx(&results, &expected, 1e-3);
@@ -252,8 +250,7 @@ fn three_nodes_page_rank_one_dangling() {
             ("2".to_string(), 0.393),
             ("3".to_string(), 0.303),
         ]);
-
-        let results = unweighted_page_rank(graph, Some(10), Some(4), None, false, None)
+        let results = page_rank(graph, None, Some(10), Some(4), None, false, None)
             .to_hashmap(|value| value.score);
 
         assert_eq_hashmaps_approx(&results, &expected, 1e-3);
@@ -302,10 +299,138 @@ fn dangling_page_rank() {
             ("10".to_string(), 0.117),
             ("11".to_string(), 0.122),
         ]);
-
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None)
+        let results = page_rank(graph, None, Some(1000), Some(4), None, true, None)
             .to_hashmap(|value| value.score);
 
         assert_eq_hashmaps_approx(&results, &expected, 1e-3);
+    });
+}
+#[test]
+fn page_rank_non_uniform_weights() {
+    let graph = Graph::new();
+    graph
+        .add_edge(0, 1, 2, [("weight", Prop::F64(0.37))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 1, 3, [("weight", Prop::F64(4.2))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 2, 1, [("weight", Prop::F64(0.9))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 2, 4, [("weight", Prop::F64(1.7))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 1, [("weight", Prop::F64(2.6))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 2, [("weight", Prop::F64(0.05))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 4, 3, [("weight", Prop::F64(3.3))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 4, 1, [("weight", Prop::F64(0.8))], None)
+        .unwrap();
+
+    test_storage!(&graph, |graph| {
+        let expected: HashMap<String, f64> = HashMap::from([
+            ("1".to_string(), 0.42499),
+            ("2".to_string(), 0.07353),
+            ("3".to_string(), 0.42311),
+            ("4".to_string(), 0.07837),
+        ]);
+        let results = page_rank(
+            graph,
+            Some("weight"),
+            Some(1000),
+            Some(1),
+            Some(1e-10),
+            true,
+            None,
+        )
+        .to_hashmap(|value| value.score);
+
+        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
+    });
+}
+
+#[test]
+fn page_rank_dangling_weighted() {
+    let graph = Graph::new();
+    graph
+        .add_edge(0, 1, 2, [("weight", Prop::F64(0.12))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 1, 3, [("weight", Prop::F64(7.1))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 2, 4, [("weight", Prop::F64(0.004))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 1, [("weight", Prop::F64(1.9))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 5, [("weight", Prop::F64(0.63))], None)
+        .unwrap();
+
+    test_storage!(&graph, |graph| {
+        let expected: HashMap<String, f64> = HashMap::from([
+            ("1".to_string(), 0.28736),
+            ("2".to_string(), 0.08587),
+            ("3".to_string(), 0.32201),
+            ("4".to_string(), 0.15480),
+            ("5".to_string(), 0.14997),
+        ]);
+        let results = page_rank(
+            graph,
+            Some("weight"),
+            Some(1000),
+            Some(1),
+            Some(1e-10),
+            true,
+            None,
+        )
+        .to_hashmap(|value| value.score);
+
+        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
+    });
+}
+
+#[test]
+fn page_rank_uniform_weights_match_unweighted() {
+    let graph = Graph::new();
+    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
+    for (src, dst) in edges {
+        graph
+            .add_edge(0, src, dst, [("weight", Prop::F64(1.0))], None)
+            .unwrap();
+    }
+
+    test_storage!(&graph, |graph| {
+        let expected = page_rank(graph, None, Some(1000), Some(1), None, true, None)
+            .to_hashmap(|value| value.score);
+        let results = page_rank(graph, Some("weight"), Some(1000), Some(1), None, true, None)
+            .to_hashmap(|value| value.score);
+
+        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
+    });
+}
+
+#[test]
+fn page_rank_missing_property_defaults_to_unweighted() {
+    let graph = Graph::new();
+    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
+    for (src, dst) in edges {
+        graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
+    }
+
+    test_storage!(&graph, |graph| {
+        let expected = page_rank(graph, None, Some(1000), Some(1), None, true, None)
+            .to_hashmap(|value| value.score);
+        let results = page_rank(graph, Some("weight"), Some(1000), Some(1), None, true, None)
+            .to_hashmap(|value| value.score);
+
+        assert_eq_hashmaps_approx(&results, &expected, 1e-5);
     });
 }

--- a/raphtory-tests/tests/db_tests.rs
+++ b/raphtory-tests/tests/db_tests.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use proptest::{arbitrary::any, prop_assert, prop_assert_eq, proptest, sample::subsequence};
 use raphtory::{
     algorithms::{
-        centrality::{degree_centrality::degree_centrality, pagerank::unweighted_page_rank},
+        centrality::{degree_centrality::degree_centrality, pagerank::page_rank},
         components::weakly_connected_components,
     },
     db::{
@@ -2933,7 +2933,7 @@ fn test_node_state_merge() {
 
     let sg = graph.subgraph(1..200);
     let degs = degree_centrality(&graph);
-    let pr = unweighted_page_rank(&sg, None, None, None, false, None);
+    let pr = page_rank(&sg, None, None, None, None, false, None);
 
     let m1 = pr.state.merge(
         &degs.state,

--- a/raphtory/src/algorithms/centrality/pagerank.rs
+++ b/raphtory/src/algorithms/centrality/pagerank.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{
         api::{
             state::NodeState,
-            view::{NodeViewOps, StaticGraphViewOps},
+            view::{EdgeViewOps, NodeViewOps, StaticGraphViewOps},
         },
         task::{
             context::Context,
@@ -11,21 +11,22 @@ use crate::{
             task_runner::TaskRunner,
         },
     },
-    prelude::GraphViewOps,
+    prelude::{GraphViewOps, PropertiesOps},
 };
 use num_traits::abs;
+use raphtory_api::core::entities::properties::prop::PropUnwrap;
 
 #[derive(Clone, Debug, Default)]
 struct PageRankState {
     score: f64,
-    out_degree: usize,
+    weighted_out_degree: f64,
 }
 
 impl PageRankState {
     fn new(num_nodes: usize) -> Self {
         Self {
             score: 1f64 / num_nodes as f64,
-            out_degree: 0,
+            weighted_out_degree: 0f64,
         }
     }
 
@@ -40,6 +41,7 @@ impl PageRankState {
 /// # Arguments
 ///
 /// - `g`: A GraphView object
+/// - `weight`: Edge property key to use as weight. If None, all edges have weight 1.0.
 /// - `iter_count`: Number of iterations to run the algorithm for
 /// - `threads`: Number of threads to use for parallel execution
 /// - `tol`: The tolerance value for convergence
@@ -50,8 +52,9 @@ impl PageRankState {
 ///
 /// An [AlgorithmResult] object containing the mapping from node ID to the PageRank score of the node
 ///
-pub fn unweighted_page_rank<G: StaticGraphViewOps>(
+pub fn page_rank<G: StaticGraphViewOps>(
     g: &G,
+    weight: Option<&str>,
     iter_count: Option<usize>,
     threads: Option<usize>,
     tol: Option<f64>,
@@ -76,38 +79,53 @@ pub fn unweighted_page_rank<G: StaticGraphViewOps>(
 
     ctx.global_agg_reset(total_sink_contribution);
 
-    let step1 = ATask::new(move |s| {
-        let out_degree = s.out_degree();
-        let state: &mut PageRankState = s.get_mut();
-        state.out_degree = out_degree;
-        Step::Continue
+    let weight_key: Option<String> = weight.map(|s| s.to_string());
+
+    let step1 = ATask::new({
+        let weight_key = weight_key.clone();
+        move |s| {
+            let weighted_out_degree = s.out_edges().iter().fold(0.0f64, |acc, edge| {
+                weight_key
+                    .as_ref()
+                    .and_then(|key| edge.properties().get(key))
+                    .and_then(|p| p.as_f64())
+                    .unwrap_or(1.0)
+                    + acc
+            });
+            let state: &mut PageRankState = s.get_mut();
+            state.weighted_out_degree = weighted_out_degree;
+            Step::Continue
+        }
     });
 
     let step2: ATask<G, ComputeStateVec, PageRankState, _> = ATask::new(move |s| {
-        // reset score
         {
             let state: &mut PageRankState = s.get_mut();
             state.reset();
         }
 
-        for t in s.in_neighbours() {
-            let prev = t.prev();
-
-            s.get_mut().score += prev.score / prev.out_degree as f64;
+        for edge in s.in_edges() {
+            let w = weight_key
+                .as_ref()
+                .and_then(|key| edge.properties().get(key))
+                .and_then(|p| p.as_f64())
+                .unwrap_or(1.0);
+            let nbr = edge.nbr();
+            let prev = nbr.prev();
+            if prev.weighted_out_degree > 0.0 {
+                s.get_mut().score += prev.score * w / prev.weighted_out_degree;
+            }
         }
 
         s.get_mut().score *= damp;
-
         s.get_mut().score += teleport_prob;
         Step::Continue
     });
 
     let step3 = ATask::new(move |s| {
         let state: &mut PageRankState = s.get_mut();
-
-        if state.out_degree == 0 {
+        if state.weighted_out_degree == 0.0 {
             let curr = s.prev().score;
-
             let ts_contrib = factor * curr;
             s.global_update(&total_sink_contribution, ts_contrib);
         }

--- a/raphtory/src/algorithms/centrality/pagerank.rs
+++ b/raphtory/src/algorithms/centrality/pagerank.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{
         api::{
             state::{GenericNodeState, TypedNodeState},
-            view::{NodeViewOps, StaticGraphViewOps},
+            view::{EdgeViewOps, NodeViewOps, StaticGraphViewOps},
         },
         task::{
             context::Context,
@@ -11,9 +11,10 @@ use crate::{
             task_runner::TaskRunner,
         },
     },
-    prelude::GraphViewOps,
+    prelude::{GraphViewOps, PropertiesOps},
 };
 use num_traits::abs;
+use raphtory_api::core::entities::properties::prop::PropUnwrap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
@@ -21,16 +22,17 @@ pub struct PageRankState {
     #[serde(rename = "pagerank_score")]
     pub score: f64,
     #[serde(skip)]
-    out_degree: usize,
+    weighted_out_degree: f64,
 }
 
 impl PageRankState {
     fn new(num_nodes: usize) -> Self {
         Self {
             score: 1f64 / num_nodes as f64,
-            out_degree: 0,
+            weighted_out_degree: 0f64,
         }
     }
+
     fn reset(&mut self) {
         self.score = 0f64;
     }
@@ -42,6 +44,7 @@ impl PageRankState {
 /// # Arguments
 ///
 /// - `g`: A GraphView object
+/// - `weight`: Edge property key to use as weight. If None, all edges have weight 1.0.
 /// - `iter_count`: Number of iterations to run the algorithm for
 /// - `threads`: Number of threads to use for parallel execution
 /// - `tol`: The tolerance value for convergence
@@ -52,8 +55,9 @@ impl PageRankState {
 ///
 /// An [AlgorithmResult] object containing the mapping from node ID to the PageRank score of the node
 ///
-pub fn unweighted_page_rank<G: StaticGraphViewOps>(
+pub fn page_rank<G: StaticGraphViewOps>(
     g: &G,
+    weight: Option<&str>,
     iter_count: Option<usize>,
     threads: Option<usize>,
     tol: Option<f64>,
@@ -78,11 +82,21 @@ pub fn unweighted_page_rank<G: StaticGraphViewOps>(
 
     ctx.global_agg_reset(total_sink_contribution);
 
-    let step1 = ATask::new(move |s| {
-        let out_degree = s.out_degree();
-        let state: &mut PageRankState = s.get_mut();
-        state.out_degree = out_degree;
-        Step::Continue
+    let weight_id = weight.and_then(|key| g.edge_meta().get_prop_id(key, false));
+
+    let step1 = ATask::new({
+        move |s| {
+            let weighted_out_degree = s.out_edges().iter().fold(0.0f64, |acc, edge| {
+                weight_id
+                    .and_then(|id| edge.properties().get_by_id(id))
+                    .and_then(|p| p.as_f64())
+                    .unwrap_or(1.0)
+                    + acc
+            });
+            let state: &mut PageRankState = s.get_mut();
+            state.weighted_out_degree = weighted_out_degree;
+            Step::Continue
+        }
     });
 
     let step2: ATask<G, ComputeStateVec, PageRankState, _> = ATask::new(move |s| {
@@ -92,10 +106,17 @@ pub fn unweighted_page_rank<G: StaticGraphViewOps>(
             state.reset();
         }
 
-        for t in s.in_neighbours() {
-            let prev = t.prev();
+        for edge in s.in_edges() {
+            let w = weight_id
+                .and_then(|id| edge.properties().get_by_id(id))
+                .and_then(|p| p.as_f64())
+                .unwrap_or(1.0);
+            let nbr = edge.nbr();
+            let prev = nbr.prev();
 
-            s.get_mut().score += prev.score / prev.out_degree as f64;
+            if prev.weighted_out_degree > 0.0 {
+                s.get_mut().score += prev.score * w / prev.weighted_out_degree;
+            }
         }
 
         s.get_mut().score *= damp;
@@ -107,7 +128,7 @@ pub fn unweighted_page_rank<G: StaticGraphViewOps>(
     let step3 = ATask::new(move |s| {
         let state: &mut PageRankState = s.get_mut();
 
-        if state.out_degree == 0 {
+        if state.weighted_out_degree.abs() < f64::EPSILON {
             let curr = s.prev().score;
 
             let ts_contrib = factor * curr;

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -6,7 +6,7 @@ use crate::{
         centrality::{
             betweenness::betweenness_centrality as betweenness_rs,
             degree_centrality::degree_centrality as degree_centrality_rs, hits::hits as hits_rs,
-            pagerank::unweighted_page_rank,
+            pagerank::page_rank,
         },
         community_detection::{
             label_propagation::label_propagation as label_propagation_rs,
@@ -268,20 +268,23 @@ pub fn out_component(
 ///         is less than the max diff value given.
 ///     use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
 ///     damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
+///     weight (Optional[str]): Edge property key to use as weight. If None, all edges have weight 1.0.
 ///
 /// Returns:
 ///     NodeStateF64: Mapping of nodes to their pagerank value.
 #[pyfunction]
-#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85))]
+#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85, weight=None))]
 pub fn pagerank(
     graph: &PyGraphView,
     iter_count: usize,
     max_diff: Option<f64>,
     use_l2_norm: bool,
     damping_factor: Option<f64>,
+    weight: Option<&str>,
 ) -> NodeState<'static, f64, DynamicGraph> {
-    unweighted_page_rank(
+    page_rank(
         &graph.graph,
+        weight,
         Some(iter_count),
         None,
         max_diff,

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -7,7 +7,7 @@ use crate::{
         centrality::{
             betweenness::betweenness_centrality as betweenness_rs,
             degree_centrality::degree_centrality as degree_centrality_rs, hits::hits as hits_rs,
-            pagerank::unweighted_page_rank,
+            pagerank::page_rank,
         },
         community_detection::{
             label_propagation::label_propagation as label_propagation_rs,
@@ -256,20 +256,23 @@ pub fn out_component(
 ///         is less than the max diff value given.
 ///     use_l2_norm (bool): Flag for choosing the norm to use for convergence checks, True for l2 norm, False for l1 norm. Defaults to True.
 ///     damping_factor (float): The damping factor for the PageRank calculation. Defaults to 0.85.
+///     weight (Optional[str]): Edge property key to use as weight. If None, all edges have weight 1.0.
 ///
 /// Returns:
 ///     OutputNodeState: NodeState mapping nodes to their pagerank score.
 #[pyfunction]
-#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85))]
+#[pyo3(signature = (graph, iter_count=20, max_diff=None, use_l2_norm=true, damping_factor=0.85, weight=None))]
 pub fn pagerank(
     graph: &PyGraphView,
     iter_count: usize,
     max_diff: Option<f64>,
     use_l2_norm: bool,
     damping_factor: Option<f64>,
+    weight: Option<&str>,
 ) -> OutputTypedNodeState<'static, DynamicGraph> {
-    unweighted_page_rank(
+    page_rank(
         &graph.graph,
+        weight,
         Some(iter_count),
         None,
         max_diff,

--- a/raphtory/tests/algo_tests/centrality.rs
+++ b/raphtory/tests/algo_tests/centrality.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use raphtory::{
     algorithms::centrality::{
         betweenness::betweenness_centrality, degree_centrality::degree_centrality, hits::hits,
-        pagerank::unweighted_page_rank,
+        pagerank::page_rank,
     },
     prelude::*,
     test_storage,
@@ -144,7 +144,7 @@ fn test_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(1), None, true, None);
+        let results = page_rank(graph, None, Some(1000), Some(1), None, true, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.38694), 5);
         assert_eq_f64(results.get_by_node("2"), Some(&0.20195), 5);
@@ -188,7 +188,7 @@ fn motif_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None);
+        let results = page_rank(graph, None, Some(1000), Some(4), None, true, None);
 
         assert_eq_f64(results.get_by_node("10"), Some(&0.072082), 5);
         assert_eq_f64(results.get_by_node("8"), Some(&0.136473), 5);
@@ -215,7 +215,7 @@ fn two_nodes_page_rank() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, false, None);
+        let results = page_rank(graph, None, Some(1000), Some(4), None, false, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.5), 3);
         assert_eq_f64(results.get_by_node("2"), Some(&0.5), 3);
@@ -233,7 +233,7 @@ fn three_nodes_page_rank_one_dangling() {
     }
 
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(10), Some(4), None, false, None);
+        let results = page_rank(graph, None, Some(10), Some(4), None, false, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.303), 3);
         assert_eq_f64(results.get_by_node("2"), Some(&0.393), 3);
@@ -270,7 +270,7 @@ fn dangling_page_rank() {
         graph.add_edge(t, src, dst, NO_PROPS, None).unwrap();
     }
     test_storage!(&graph, |graph| {
-        let results = unweighted_page_rank(graph, Some(1000), Some(4), None, true, None);
+        let results = page_rank(graph, None, Some(1000), Some(4), None, true, None);
 
         assert_eq_f64(results.get_by_node("1"), Some(&0.055), 3);
         assert_eq_f64(results.get_by_node("2"), Some(&0.079), 3);
@@ -283,6 +283,124 @@ fn dangling_page_rank() {
         assert_eq_f64(results.get_by_node("9"), Some(&0.110), 3);
         assert_eq_f64(results.get_by_node("10"), Some(&0.117), 3);
         assert_eq_f64(results.get_by_node("11"), Some(&0.122), 3);
+    });
+}
+
+#[test]
+fn page_rank_non_uniform_weights() {
+    let graph = Graph::new();
+    graph
+        .add_edge(0, 1, 2, [("weight", Prop::F64(0.37))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 1, 3, [("weight", Prop::F64(4.2))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 2, 1, [("weight", Prop::F64(0.9))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 2, 4, [("weight", Prop::F64(1.7))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 1, [("weight", Prop::F64(2.6))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 2, [("weight", Prop::F64(0.05))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 4, 3, [("weight", Prop::F64(3.3))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 4, 1, [("weight", Prop::F64(0.8))], None)
+        .unwrap();
+
+    test_storage!(&graph, |graph| {
+        let results =
+            page_rank(graph, Some("weight"), Some(1000), Some(1), Some(1e-10), true, None);
+
+        assert_eq_f64(results.get_by_node("1"), Some(&0.42499), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.07353), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.42311), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.07837), 5);
+    });
+}
+
+#[test]
+fn page_rank_dangling_weighted() {
+    let graph = Graph::new();
+    graph
+        .add_edge(0, 1, 2, [("weight", Prop::F64(0.12))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 1, 3, [("weight", Prop::F64(7.1))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 2, 4, [("weight", Prop::F64(0.004))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 1, [("weight", Prop::F64(1.9))], None)
+        .unwrap();
+    graph
+        .add_edge(0, 3, 5, [("weight", Prop::F64(0.63))], None)
+        .unwrap();
+
+    test_storage!(&graph, |graph| {
+        let results =
+            page_rank(graph, Some("weight"), Some(1000), Some(1), Some(1e-10), true, None);
+
+        assert_eq_f64(results.get_by_node("1"), Some(&0.28736), 5);
+        assert_eq_f64(results.get_by_node("2"), Some(&0.08587), 5);
+        assert_eq_f64(results.get_by_node("3"), Some(&0.32201), 5);
+        assert_eq_f64(results.get_by_node("4"), Some(&0.15480), 5);
+        assert_eq_f64(results.get_by_node("5"), Some(&0.14997), 5);
+    });
+}
+
+#[test]
+fn page_rank_uniform_weights_match_unweighted() {
+    let graph = Graph::new();
+    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
+    for (src, dst) in edges {
+        graph
+            .add_edge(0, src, dst, [("weight", Prop::F64(1.0))], None)
+            .unwrap();
+    }
+
+    test_storage!(&graph, |graph| {
+        let unweighted = page_rank(graph, None, Some(1000), Some(1), None, true, None);
+        let weighted =
+            page_rank(graph, Some("weight"), Some(1000), Some(1), None, true, None);
+
+        for node in ["1", "2", "3", "4"] {
+            assert_eq_f64(
+                weighted.get_by_node(node),
+                unweighted.get_by_node(node),
+                5,
+            );
+        }
+    });
+}
+
+#[test]
+fn page_rank_missing_property_defaults_to_unweighted() {
+    let graph = Graph::new();
+    let edges = vec![(1, 2), (1, 4), (2, 3), (3, 1), (4, 1)];
+    for (src, dst) in edges {
+        graph.add_edge(0, src, dst, NO_PROPS, None).unwrap();
+    }
+
+    test_storage!(&graph, |graph| {
+        let unweighted = page_rank(graph, None, Some(1000), Some(1), None, true, None);
+        let weighted =
+            page_rank(graph, Some("weight"), Some(1000), Some(1), None, true, None);
+
+        for node in ["1", "2", "3", "4"] {
+            assert_eq_f64(
+                weighted.get_by_node(node),
+                unweighted.get_by_node(node),
+                5,
+            );
+        }
     });
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an optional weight parameter to pagerank

### Why are the changes needed?

To capture the semantics of weighted pagerank. For example, in fraud detection

### Does this PR introduce any user-facing change? If yes is this documented?

Yes, it adds an extra param which is captured in the docstrings

### How was this patch tested?

Test scenarios were checked for exact match with networkx. Additionally, basic semantic sanity checking like 'weight =None' should be treated as equivalent to all weights = 1.0

### Are there any further changes required?

No