### PR TITLE
Making the get_graph method public

### DIFF
--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -232,7 +232,7 @@ impl Data {
     /// # ⚠ Bypasses all permission checks — do not call from resolvers directly.
     /// Use `get_graph_with_read_permission`, `get_raw_graph_with_read_permission`, or
     /// `get_graph_with_write_permission` instead.
-    async fn get_graph(&self, path: &str) -> Result<GraphWithVectors, Arc<GQLError>> {
+    pub async fn get_graph(&self, path: &str) -> Result<GraphWithVectors, Arc<GQLError>> {
         self.cache
             .try_get_with(path.into(), self.read_graph_from_disk(path))
             .await


### PR DESCRIPTION
### What changes were proposed in this pull request?
Just making the get_graph method public

### Why are the changes needed?
Because compilation errors.

### Does this PR introduce any user-facing change? If yes is this documented?
No

### How was this patch tested?
It hasn't been tested.

### Are there any further changes required?
Not that I can think of.

