### PR TITLE
don't set port in tests

### DIFF
--- a/python/test_utils/utils.py
+++ b/python/test_utils/utils.py
@@ -113,8 +113,8 @@ def with_disk_variants(init_fn, variants=None):
 
                 with tempfile.TemporaryDirectory() as tmpdir:
                     if (
-                            "event_disk_graph" in variants
-                            or "persistent_disk_graph" in variants
+                        "event_disk_graph" in variants
+                        or "persistent_disk_graph" in variants
                     ):
                         g = init_fn(Graph())
                         g.to_disk_graph(tmpdir)
@@ -167,7 +167,7 @@ def run_graphql_test(query, expected_output, graph, sort_output=False):
             response_dict = sort_by_gql_name_or_id(response_dict)
             expected_output = sort_by_gql_name_or_id(expected_output)
         assert (
-                response_dict == expected_output
+            response_dict == expected_output
         ), f"left={sort_dict_recursive(response_dict)}\nright={sort_dict_recursive(expected_output)}"
 
 
@@ -186,7 +186,7 @@ def run_group_graphql_test(queries_and_expected_outputs, graph, sort_output=Fals
                 response_dict = sort_by_gql_name_or_id(response_dict)
                 expected_output = sort_by_gql_name_or_id(expected_output)
             assert (
-                    response_dict == expected_output
+                response_dict == expected_output
             ), f"Expected:\n{sort_dict_recursive(expected_output)}\nGot:\n{sort_dict_recursive(response_dict)}"
 
 
@@ -204,7 +204,7 @@ def run_graphql_error_test(query, expected_error_message, graph):
         error_message = match.group(1) if match else ""
 
         assert (
-                error_message == expected_error_message
+            error_message == expected_error_message
         ), f"Expected '{expected_error_message}', but got '{error_message}'"
 
 
@@ -221,7 +221,7 @@ def run_group_graphql_error_test(queries_and_expected_error_messages, graph):
             match = re.search(r'"message":"(.*?)"', full_error_message)
             error_message = match.group(1) if match else ""
             assert (
-                    error_message == expected_error_message
+                error_message == expected_error_message
             ), f"Expected '{expected_error_message}', but got '{error_message}'"
 
 

--- a/python/test_utils/utils.py
+++ b/python/test_utils/utils.py
@@ -14,8 +14,6 @@ from raphtory.graphql import GraphServer
 
 B = TypeVar("B")
 
-PORT = 1737
-
 
 def sort_dict_recursive(d) -> dict:
     if isinstance(d, dict):
@@ -115,8 +113,8 @@ def with_disk_variants(init_fn, variants=None):
 
                 with tempfile.TemporaryDirectory() as tmpdir:
                     if (
-                        "event_disk_graph" in variants
-                        or "persistent_disk_graph" in variants
+                            "event_disk_graph" in variants
+                            or "persistent_disk_graph" in variants
                     ):
                         g = init_fn(Graph())
                         g.to_disk_graph(tmpdir)
@@ -158,7 +156,7 @@ def measure(name: str, f: Callable[..., B], *args, print_result: bool = True) ->
 
 def run_graphql_test(query, expected_output, graph, sort_output=False):
     tmp_work_dir = tempfile.mkdtemp()
-    with GraphServer(tmp_work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(tmp_work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
         response = client.query(query)
@@ -169,13 +167,13 @@ def run_graphql_test(query, expected_output, graph, sort_output=False):
             response_dict = sort_by_gql_name_or_id(response_dict)
             expected_output = sort_by_gql_name_or_id(expected_output)
         assert (
-            response_dict == expected_output
+                response_dict == expected_output
         ), f"left={sort_dict_recursive(response_dict)}\nright={sort_dict_recursive(expected_output)}"
 
 
 def run_group_graphql_test(queries_and_expected_outputs, graph, sort_output=False):
     tmp_work_dir = tempfile.mkdtemp()
-    with GraphServer(tmp_work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(tmp_work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
 
@@ -188,13 +186,13 @@ def run_group_graphql_test(queries_and_expected_outputs, graph, sort_output=Fals
                 response_dict = sort_by_gql_name_or_id(response_dict)
                 expected_output = sort_by_gql_name_or_id(expected_output)
             assert (
-                response_dict == expected_output
+                    response_dict == expected_output
             ), f"Expected:\n{sort_dict_recursive(expected_output)}\nGot:\n{sort_dict_recursive(response_dict)}"
 
 
 def run_graphql_error_test(query, expected_error_message, graph):
     tmp_work_dir = tempfile.mkdtemp()
-    with GraphServer(tmp_work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(tmp_work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
 
@@ -206,13 +204,13 @@ def run_graphql_error_test(query, expected_error_message, graph):
         error_message = match.group(1) if match else ""
 
         assert (
-            error_message == expected_error_message
+                error_message == expected_error_message
         ), f"Expected '{expected_error_message}', but got '{error_message}'"
 
 
 def run_group_graphql_error_test(queries_and_expected_error_messages, graph):
     tmp_work_dir = tempfile.mkdtemp()
-    with GraphServer(tmp_work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(tmp_work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
         for query, expected_error_message in queries_and_expected_error_messages:
@@ -223,13 +221,13 @@ def run_group_graphql_error_test(queries_and_expected_error_messages, graph):
             match = re.search(r'"message":"(.*?)"', full_error_message)
             error_message = match.group(1) if match else ""
             assert (
-                error_message == expected_error_message
+                    error_message == expected_error_message
             ), f"Expected '{expected_error_message}', but got '{error_message}'"
 
 
 def run_graphql_error_test_contains(query, expected_substrings, graph):
     tmp_work_dir = tempfile.mkdtemp()
-    with GraphServer(tmp_work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(tmp_work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
 
@@ -246,7 +244,7 @@ def run_graphql_error_test_contains(query, expected_substrings, graph):
 
 def run_graphql_compare_test(query_a, query_b, graph):
     tmp_work_dir = tempfile.mkdtemp()
-    with GraphServer(tmp_work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(tmp_work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
 

--- a/python/tests/test_base_install/test_graphql/test_gql_graph_type.py
+++ b/python/tests/test_base_install/test_graphql/test_gql_graph_type.py
@@ -16,8 +16,6 @@ import tempfile
 from raphtory import Graph, PersistentGraph
 from raphtory.graphql import GraphServer
 
-from utils import PORT
-
 
 def _query(server, q: str) -> dict:
     response = server.get_client().query(q)
@@ -30,7 +28,7 @@ def test_event_graph_default_uses_event_semantics():
     work_dir = tempfile.mkdtemp()
     g = Graph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -54,7 +52,7 @@ def test_event_graph_read_as_persistent_carries_value_forward():
     work_dir = tempfile.mkdtemp()
     g = Graph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -78,7 +76,7 @@ def test_persistent_graph_default_carries_value_forward():
     work_dir = tempfile.mkdtemp()
     g = PersistentGraph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -102,7 +100,7 @@ def test_persistent_graph_read_as_event_drops_carried_values():
     work_dir = tempfile.mkdtemp()
     g = PersistentGraph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -125,7 +123,7 @@ def test_mutable_event_graph_default_uses_event_semantics():
     work_dir = tempfile.mkdtemp()
     g = Graph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -149,7 +147,7 @@ def test_mutable_event_graph_read_as_persistent_carries_value_forward():
     work_dir = tempfile.mkdtemp()
     g = Graph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -173,7 +171,7 @@ def test_mutable_persistent_graph_default_carries_value_forward():
     work_dir = tempfile.mkdtemp()
     g = PersistentGraph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -197,7 +195,7 @@ def test_mutable_persistent_graph_read_as_event_drops_carried_values():
     work_dir = tempfile.mkdtemp()
     g = PersistentGraph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -222,7 +220,7 @@ def test_mutable_graph_reads_pending_mutations_through_override():
     work_dir = tempfile.mkdtemp()
     g = Graph()
     g.add_edge(1, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(
@@ -253,7 +251,7 @@ def test_persistent_deletes_visible_via_persistent_view():
     g = PersistentGraph()
     g.add_edge(1, "a", "b")
     g.delete_edge(5, "a", "b")
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         server.get_client().send_graph(path="g", graph=g)
 
         result = _query(

--- a/python/tests/test_base_install/test_graphql/test_gql_misc_surface.py
+++ b/python/tests/test_base_install/test_graphql/test_gql_misc_surface.py
@@ -11,7 +11,7 @@
 import json
 import tempfile
 
-from utils import PORT, run_group_graphql_test
+from utils import run_group_graphql_test
 from raphtory import Graph
 from raphtory.graphql import GraphServer
 
@@ -65,7 +65,7 @@ def test_nodes_ids():
     ]
 
     tmp = tempfile.mkdtemp()
-    with GraphServer(tmp, create_index=True).start(PORT) as server:
+    with GraphServer(tmp, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
         for query, path, expected in cases:

--- a/python/tests/test_base_install/test_graphql/test_gql_mutation_time_input.py
+++ b/python/tests/test_base_install/test_graphql/test_gql_mutation_time_input.py
@@ -11,11 +11,7 @@ was used.
 
 import json
 import tempfile
-
-from raphtory import Graph
 from raphtory.graphql import GraphServer
-
-from utils import PORT
 
 
 def _query(server, q: str) -> dict:
@@ -28,7 +24,7 @@ def test_add_node_accepts_int_string_and_object_time():
     `{timestamp, eventId}` object. Each insertion lands at its expected
     timestamp and is queryable afterwards."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -65,7 +61,7 @@ def test_add_edge_and_delete_edge_accept_time_input_shapes():
     """`addEdge` / `deleteEdge` accept the same forms; verify on a persistent
     graph so the deletion is visible via `isValid`."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "PERSISTENT")
 
@@ -105,7 +101,7 @@ def test_add_properties_accepts_time_input_shapes():
     """`addProperties` (graph-level temporal properties) accepts Int, string,
     and object."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -148,7 +144,7 @@ def test_temporal_property_input_accepts_time_input_in_batch():
     """Inside `addNodes` / `addEdges`, the `time` field on each per-update
     `TemporalPropertyInput` accepts every `TimeInput` shape."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -195,7 +191,7 @@ def test_add_edges_batch_accepts_time_input_shapes():
     `time` field on its `TemporalPropertyInput` entries accepts every
     `TimeInput` shape — Int, RFC3339 string, and `{timestamp, eventId}` object."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -241,7 +237,7 @@ def test_mutable_node_and_edge_add_updates_accept_time_input():
     """`MutableNode.addUpdates` and `MutableEdge.addUpdates` / `delete` accept
     every `TimeInput` shape via the `node()` / `edge()` lookups."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "PERSISTENT")
 

--- a/python/tests/test_base_install/test_graphql/test_gql_node_id.py
+++ b/python/tests/test_base_install/test_graphql/test_gql_node_id.py
@@ -10,11 +10,7 @@ queried and mutated through the GraphQL server.
 
 import json
 import tempfile
-
-from raphtory import Graph
 from raphtory.graphql import GraphServer
-
-from utils import PORT
 
 
 def _query(server, q: str) -> dict:
@@ -27,7 +23,7 @@ def test_addnode_and_node_lookup_with_integer_ids():
     GraphQL server. Raphtory enforces a single id type per graph, so this
     test uses integers throughout."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -66,7 +62,7 @@ def test_addnode_and_node_lookup_with_integer_ids():
 def test_addedge_and_edge_lookup_with_integer_endpoints():
     """Edge mutations and lookups accept integer ids on src/dst."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -105,7 +101,7 @@ def test_view_transforms_with_integer_node_ids():
     """`subgraph`, `excludeNodes`, and `sharedNeighbours` accept integer
     node ids."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -144,7 +140,7 @@ def test_view_transforms_with_integer_node_ids():
 def test_batch_addnodes_addedges_with_integer_ids():
     """`addNodes` and `addEdges` accept integer ids in `name`/`src`/`dst`."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -186,7 +182,7 @@ def test_batch_addnodes_addedges_with_integer_ids():
 def test_view_transforms_with_string_node_ids():
     """`subgraph`, `excludeNodes`, and `sharedNeighbours` accept string node ids."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -223,7 +219,7 @@ def test_view_transforms_with_string_node_ids():
 def test_batch_addnodes_addedges_with_string_ids():
     """`addNodes` and `addEdges` accept string ids in `name`/`src`/`dst`."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -266,7 +262,7 @@ def test_string_ids_remain_unchanged_for_existing_clients():
     """Existing clients passing string node ids continue to work without
     modification — the schema change is wire-compatible for strings."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 
@@ -297,7 +293,7 @@ def test_string_ids_remain_unchanged_for_existing_clients():
 def test_negative_integer_rejected():
     """Schema rejects negative integers — `NodeId` only accepts non-negative."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.new_graph("g", "EVENT")
 

--- a/python/tests/test_base_install/test_graphql/test_gql_same_timestamp_writes.py
+++ b/python/tests/test_base_install/test_graphql/test_gql_same_timestamp_writes.py
@@ -15,10 +15,7 @@ fail.
 
 import json
 import tempfile
-
 from raphtory.graphql import GraphServer
-
-from utils import PORT
 
 
 def _query(server, q: str) -> dict:
@@ -44,7 +41,7 @@ def test_add_properties_same_timestamp_appends():
     """`addProperties` three times at the same ms → three history entries
     with the same timestamp and distinct values."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             {
@@ -77,7 +74,7 @@ def test_add_node_same_timestamp_appends():
     both updates land. Verified on the node's `history` and on the
     temporal property's `history`."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             {
@@ -113,7 +110,7 @@ def test_add_edge_same_timestamp_appends():
     """`addEdge` twice at the same ms → both edge updates land. Verified on
     the edge's `history` and on the temporal property's `history`."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             {
@@ -149,7 +146,7 @@ def test_create_node_then_add_node_same_timestamp_appends():
     """`createNode` followed by `addNode` at the same ms → both updates
     land (createNode creates the node, addNode appends an update)."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             {
@@ -186,7 +183,7 @@ def test_create_node_then_add_node_same_timestamp_appends():
 
 def test_mutable_node_add_updates_same_timestamp_appends():
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             { updateGraph(path: "g") { addNode(time: 0, name: "n") { success } } }
@@ -226,7 +223,7 @@ def test_mutable_node_add_updates_same_timestamp_appends():
 
 def test_mutable_edge_add_updates_same_timestamp_appends():
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             { updateGraph(path: "g") { addEdge(time: 0, src: "a", dst: "b") { success } } }
@@ -271,7 +268,7 @@ def test_add_nodes_batch_same_timestamp_appends():
     """A single batch `addNodes` with three updates at the same ms on the
     same node should produce three history entries."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             {
@@ -310,7 +307,7 @@ def test_add_nodes_batch_same_timestamp_appends():
 
 def test_add_edges_batch_same_timestamp_appends():
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             {
@@ -354,7 +351,7 @@ def test_delete_edge_same_timestamp_appends():
     """Multiple `deleteEdge` calls at the same ms on a persistent graph all
     land in the deletion history with the same timestamp."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         client = server.get_client()
         client.new_graph("g", "PERSISTENT")
         client.query("""
@@ -387,7 +384,7 @@ def test_object_time_input_distinct_event_ids_append():
     """Two writes at the same timestamp with distinct explicit event_ids
     both land — the user-provided event_ids partition the events."""
     work_dir = tempfile.mkdtemp()
-    with GraphServer(work_dir).start(PORT) as server:
+    with GraphServer(work_dir).start() as server:
         _new_event_graph(server)
         server.get_client().query("""
             {

--- a/python/tests/test_base_install/test_graphql/test_gql_temporal_aggregates.py
+++ b/python/tests/test_base_install/test_graphql/test_gql_temporal_aggregates.py
@@ -1,7 +1,7 @@
 import json
 import tempfile
 
-from utils import PORT, run_group_graphql_test
+from utils import run_group_graphql_test
 from raphtory import Graph
 from raphtory.graphql import GraphServer
 
@@ -477,7 +477,7 @@ def _run_typed_accessors_cases(graph, cases):
     (needed for fields like `unique` whose ordering is non-deterministic).
     """
     tmp_work_dir = tempfile.mkdtemp()
-    with GraphServer(tmp_work_dir, create_index=True).start(PORT) as server:
+    with GraphServer(tmp_work_dir, create_index=True).start() as server:
         client = server.get_client()
         client.send_graph(path="g", graph=graph)
         for query, expected, transform in cases:

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -5614,4 +5614,3 @@ schema {
 	query: QueryRoot
 	mutation: MutRoot
 }
-

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -5614,3 +5614,4 @@ schema {
 	query: QueryRoot
 	mutation: MutRoot
 }
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

- remove more hard-coded ports in python tests so they don't fail if a server is running on that port

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


