### PR TITLE
Serialize `BigDecimal` manually to match Arrow's `Decimal128` format

### DIFF
--- a/db4-storage/src/lib.rs
+++ b/db4-storage/src/lib.rs
@@ -127,6 +127,7 @@ pub mod error {
     }
 
     impl StorageError {
+        /// Propagate external errors from other crates through StorageError.
         pub fn from_external<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
             Self::External(Arc::new(error))
         }

--- a/db4-storage/src/properties/mod.rs
+++ b/db4-storage/src/properties/mod.rs
@@ -187,6 +187,7 @@ impl Properties {
                         _ => None,
                     })
                     .unwrap();
+
                 Some(Arc::new(
                     Decimal128Array::from_iter(indices.map(|i| {
                         lazy_vec.get_opt(i).and_then(|bd| {
@@ -229,6 +230,7 @@ impl Properties {
         }
     }
 
+    /// Convert the temporal property column with `col_id` into an Arrow array.
     pub fn take_t_column(
         &self,
         col_id: usize,
@@ -239,14 +241,15 @@ impl Properties {
         self.column_as_array(column, col_id, meta, indices)
     }
 
+    /// Convert the constant property column with `col_id` into an Arrow array.
     pub fn take_c_column(
         &self,
-        col: usize,
+        col_id: usize,
         meta: &PropMapper,
         indices: impl Iterator<Item = usize>,
     ) -> Option<ArrayRef> {
-        let column = self.c_properties.get(col)?;
-        self.column_as_array(column, col, meta, indices)
+        let column = self.c_properties.get(col_id)?;
+        self.column_as_array(column, col_id, meta, indices)
     }
 
     fn update_earliest_latest(&mut self, t: EventTime) {

--- a/db4-storage/src/properties/mod.rs
+++ b/db4-storage/src/properties/mod.rs
@@ -132,100 +132,106 @@ impl Properties {
         col_id: usize,
         meta: &PropMapper,
         indices: impl Iterator<Item = usize>,
-    ) -> Option<ArrayRef> {
+    ) -> Result<Option<ArrayRef>, StorageError> {
         match column {
-            PropColumn::Empty(_) => None,
-            PropColumn::U32(lazy_vec) => Some(Arc::new(UInt32Array::from_iter(
+            PropColumn::Empty(_) => Ok(None),
+            PropColumn::U32(lazy_vec) => Ok(Some(Arc::new(UInt32Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::Bool(lazy_vec) => Some(Arc::new(BooleanArray::from_iter(
+            )))),
+            PropColumn::Bool(lazy_vec) => Ok(Some(Arc::new(BooleanArray::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::U8(lazy_vec) => Some(Arc::new(UInt8Array::from_iter(
+            )))),
+            PropColumn::U8(lazy_vec) => Ok(Some(Arc::new(UInt8Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::U16(lazy_vec) => Some(Arc::new(UInt16Array::from_iter(
+            )))),
+            PropColumn::U16(lazy_vec) => Ok(Some(Arc::new(UInt16Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::U64(lazy_vec) => Some(Arc::new(UInt64Array::from_iter(
+            )))),
+            PropColumn::U64(lazy_vec) => Ok(Some(Arc::new(UInt64Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::I32(lazy_vec) => Some(Arc::new(Int32Array::from_iter(
+            )))),
+            PropColumn::I32(lazy_vec) => Ok(Some(Arc::new(Int32Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::I64(lazy_vec) => Some(Arc::new(Int64Array::from_iter(
+            )))),
+            PropColumn::I64(lazy_vec) => Ok(Some(Arc::new(Int64Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::F32(lazy_vec) => Some(Arc::new(Float32Array::from_iter(
+            )))),
+            PropColumn::F32(lazy_vec) => Ok(Some(Arc::new(Float32Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::F64(lazy_vec) => Some(Arc::new(Float64Array::from_iter(
+            )))),
+            PropColumn::F64(lazy_vec) => Ok(Some(Arc::new(Float64Array::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i).copied()),
-            ))),
-            PropColumn::Str(lazy_vec) => Some(Arc::new(StringViewArray::from_iter(
+            )))),
+            PropColumn::Str(lazy_vec) => Ok(Some(Arc::new(StringViewArray::from_iter(
                 indices.map(|i| lazy_vec.get_opt(i)),
-            ))),
-            PropColumn::DTime(lazy_vec) => Some(Arc::new(
+            )))),
+            PropColumn::DTime(lazy_vec) => Ok(Some(Arc::new(
                 TimestampMillisecondArray::from_iter(
                     indices.map(|i| lazy_vec.get_opt(i).copied().map(|dt| dt.timestamp_millis())),
                 )
                 .with_timezone("UTC"),
-            )),
-            PropColumn::NDTime(lazy_vec) => Some(Arc::new(TimestampMillisecondArray::from_iter(
-                indices.map(|i| {
+            ))),
+            PropColumn::NDTime(lazy_vec) => Ok(Some(Arc::new(
+                TimestampMillisecondArray::from_iter(indices.map(|i| {
                     lazy_vec
                         .get_opt(i)
                         .copied()
                         .map(|dt| dt.and_utc().timestamp_millis())
-                }),
+                })),
             ))),
             PropColumn::Decimal(lazy_vec) => {
-                let scale = meta
-                    .get_dtype(col_id)
-                    .and_then(|dtype| match dtype {
-                        PropType::Decimal { scale } => Some(scale as i8),
-                        _ => None,
-                    })
-                    .unwrap();
+                let prop_type = meta.get_dtype(col_id).ok_or_else(|| {
+                    StorageError::GenericFailure(format!(
+                        "Missing dtype for decimal column {col_id}"
+                    ))
+                })?;
 
-                Some(Arc::new(
-                    Decimal128Array::from_iter(indices.map(|i| {
-                        lazy_vec.get_opt(i).and_then(|bd| {
-                            let (num, _) = bd.as_bigint_and_scale();
-                            num.to_i128()
-                        })
-                    }))
-                    .with_precision_and_scale(DECIMAL128_MAX_PRECISION, scale)
-                    .unwrap(),
-                ))
+                let PropType::Decimal { scale } = prop_type else {
+                    return Err(StorageError::GenericFailure(format!(
+                        "Expected Decimal dtype for decimal column {col_id}, found {prop_type:?}"
+                    )));
+                };
+
+                let array = Decimal128Array::from_iter(indices.map(|i| {
+                    lazy_vec.get_opt(i).and_then(|bd| {
+                        let (num, _) = bd.as_bigint_and_scale();
+                        num.to_i128()
+                    })
+                }))
+                .with_precision_and_scale(DECIMAL128_MAX_PRECISION, scale as i8)
+                .map_err(StorageError::ArrowRS)?;
+
+                Ok(Some(Arc::new(array)))
             }
             PropColumn::Map(lazy_vec) => {
-                let dt = meta
-                    .get_dtype(col_id)
-                    .as_ref()
-                    .map(arrow_dtype_from_prop_type)?;
+                let prop_type = meta.get_dtype(col_id).ok_or_else(|| {
+                    StorageError::GenericFailure(format!("Missing dtype for map column {col_id}"))
+                })?;
+
+                let dt = arrow_dtype_from_prop_type(&prop_type);
                 let array_iter = indices
                     .map(|i| lazy_vec.get_opt(i))
                     .map(|e| e.map(|m| SerdeArrowMap(m)));
 
-                let struct_array = struct_array_from_props(&dt, array_iter).ok()?;
+                let struct_array =
+                    struct_array_from_props(&dt, array_iter).map_err(StorageError::from_external)?;
 
-                Some(Arc::new(struct_array))
+                Ok(Some(Arc::new(struct_array)))
             }
             PropColumn::List(lazy_vec) => {
-                let dt = meta
-                    .get_dtype(col_id)
-                    .as_ref()
-                    .map(arrow_dtype_from_prop_type)
-                    .unwrap();
+                let prop_type = meta.get_dtype(col_id).ok_or_else(|| {
+                    StorageError::GenericFailure(format!("Missing dtype for list column {col_id}"))
+                })?;
 
+                let dt = arrow_dtype_from_prop_type(&prop_type);
                 let array_iter = indices
                     .map(|i| lazy_vec.get_opt(i))
                     .map(|opt_list| opt_list.map(SerdeArrowList));
 
-                let list_array = list_array_from_props(&dt, array_iter).ok()?;
+                let list_array =
+                    list_array_from_props(&dt, array_iter).map_err(StorageError::from_external)?;
 
-                Some(Arc::new(list_array))
+                Ok(Some(Arc::new(list_array)))
             }
         }
     }
@@ -236,8 +242,11 @@ impl Properties {
         col_id: usize,
         meta: &PropMapper,
         indices: impl ExactSizeIterator<Item = usize>,
-    ) -> Option<ArrayRef> {
-        let column = self.t_properties.get(col_id)?;
+    ) -> Result<Option<ArrayRef>, StorageError> {
+        let Some(column) = self.t_properties.get(col_id) else {
+            return Ok(None);
+        };
+
         self.column_as_array(column, col_id, meta, indices)
     }
 
@@ -247,8 +256,11 @@ impl Properties {
         col_id: usize,
         meta: &PropMapper,
         indices: impl Iterator<Item = usize>,
-    ) -> Option<ArrayRef> {
-        let column = self.c_properties.get(col_id)?;
+    ) -> Result<Option<ArrayRef>, StorageError> {
+        let Some(column) = self.c_properties.get(col_id) else {
+            return Ok(None);
+        };
+
         self.column_as_array(column, col_id, meta, indices)
     }
 

--- a/db4-storage/src/properties/mod.rs
+++ b/db4-storage/src/properties/mod.rs
@@ -193,8 +193,8 @@ impl Properties {
                 };
 
                 let array = Decimal128Array::from_iter(indices.map(|i| {
-                    lazy_vec.get_opt(i).and_then(|bd| {
-                        let (num, _) = bd.as_bigint_and_scale();
+                    lazy_vec.get_opt(i).and_then(|big_decimal| {
+                        let (num, _) = big_decimal.as_bigint_and_scale();
                         num.to_i128()
                     })
                 }))

--- a/db4-storage/src/properties/mod.rs
+++ b/db4-storage/src/properties/mod.rs
@@ -213,8 +213,11 @@ impl Properties {
                     .map(|i| lazy_vec.get_opt(i))
                     .map(|e| e.map(|m| SerdeArrowMap(m)));
 
-                let struct_array =
-                    struct_array_from_props(&dt, array_iter).map_err(StorageError::from_external)?;
+                let struct_array = struct_array_from_props(&dt, array_iter).map_err(|e| {
+                    StorageError::GenericFailure(format!(
+                        "Failed to build struct array for column{col_id}: {e}"
+                    ))
+                })?;
 
                 Ok(Some(Arc::new(struct_array)))
             }
@@ -228,8 +231,11 @@ impl Properties {
                     .map(|i| lazy_vec.get_opt(i))
                     .map(|opt_list| opt_list.map(SerdeArrowList));
 
-                let list_array =
-                    list_array_from_props(&dt, array_iter).map_err(StorageError::from_external)?;
+                let list_array = list_array_from_props(&dt, array_iter).map_err(|e| {
+                    StorageError::GenericFailure(format!(
+                        "Failed to build list array for column {col_id}: {e}"
+                    ))
+                })?;
 
                 Ok(Some(Arc::new(list_array)))
             }

--- a/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
+++ b/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
@@ -15,7 +15,6 @@ use arrow_array::{
     Array, ArrayRef, LargeListArray, StructArray,
 };
 use arrow_schema::{DataType, Field, FieldRef, Fields, TimeUnit, DECIMAL128_MAX_PRECISION};
-use serde_arrow::ArrayBuilder;
 use bigdecimal::{num_bigint::BigInt, BigDecimal};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use itertools::Itertools;
@@ -25,6 +24,7 @@ use serde::{
     ser::{Error, SerializeMap, SerializeSeq},
     Deserialize, Serialize, Serializer,
 };
+use serde_arrow::ArrayBuilder;
 use std::{
     cmp::Ordering,
     collections::HashMap,
@@ -346,11 +346,8 @@ impl<'a> Serialize for SerdeArrowProp<'a> {
                     ))
                 })?;
 
-                let num_formatted = Decimal128Type::format_decimal(
-                    num_i128,
-                    DECIMAL128_MAX_PRECISION,
-                    scale as i8
-                );
+                let num_formatted =
+                    Decimal128Type::format_decimal(num_i128, DECIMAL128_MAX_PRECISION, scale as i8);
 
                 serializer.serialize_str(&num_formatted)
             }
@@ -464,9 +461,7 @@ impl<'a> Serialize for SerdeArrowArray<'a> {
                 for v in self.0.as_primitive::<Decimal128Type>().iter() {
                     // i128 is not supported directly by serde_arrow,
                     // so we format as string manually.
-                    let element = v.map(|v|
-                        Decimal128Type::format_decimal(v, *precision, *scale)
-                    );
+                    let element = v.map(|v| Decimal128Type::format_decimal(v, *precision, *scale));
 
                     state.serialize_element(&element)?
                 }

--- a/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
+++ b/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
@@ -14,7 +14,7 @@ use arrow_array::{
     },
     Array, ArrayRef, LargeListArray, StructArray,
 };
-use arrow_schema::{DataType, Field, FieldRef, Fields, TimeUnit};
+use arrow_schema::{DataType, Field, FieldRef, Fields, TimeUnit, DECIMAL128_MAX_PRECISION};
 use serde_arrow::ArrayBuilder;
 use bigdecimal::{num_bigint::BigInt, BigDecimal};
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -335,8 +335,25 @@ impl<'a> Serialize for SerdeArrowProp<'a> {
             Prop::NDTime(dt) => serializer.serialize_i64(dt.and_utc().timestamp_millis()),
             Prop::List(l) => SerdeArrowList(l).serialize(serializer),
             Prop::Map(m) => SerdeArrowMap(m).serialize(serializer),
-            // TODO: Serialization should match PropColumn::Decimal using precision and scale.
-            Prop::Decimal(dec) => serializer.serialize_str(&dec.to_string()),
+            Prop::Decimal(dec) => {
+                // Serialize BigDecimal as string manually to match
+                // the Arrow Decimal128 format.
+                let (num, scale) = dec.as_bigint_and_scale();
+
+                let num_i128 = num.to_i128().ok_or_else(|| {
+                    serde::ser::Error::custom(format!(
+                        "decimal value {dec} is out of range for i128 representation"
+                    ))
+                })?;
+
+                let num_formatted = Decimal128Type::format_decimal(
+                    num_i128,
+                    DECIMAL128_MAX_PRECISION,
+                    scale as i8
+                );
+
+                serializer.serialize_str(&num_formatted)
+            }
         }
     }
 }
@@ -349,6 +366,7 @@ impl<'a> Serialize for SerdeArrowArray<'a> {
         let dtype = self.0.data_type();
         let len = self.0.len();
         let mut state = serializer.serialize_seq(Some(len))?;
+
         match dtype {
             DataType::Boolean => {
                 for v in self.0.as_boolean().iter() {
@@ -444,9 +462,13 @@ impl<'a> Serialize for SerdeArrowArray<'a> {
             }
             DataType::Decimal128(precision, scale) => {
                 for v in self.0.as_primitive::<Decimal128Type>().iter() {
-                    let element = v.map(|v| Decimal128Type::format_decimal(v, *precision, *scale));
+                    // i128 is not supported directly by serde_arrow,
+                    // so we format as string manually.
+                    let element = v.map(|v|
+                        Decimal128Type::format_decimal(v, *precision, *scale)
+                    );
+
                     state.serialize_element(&element)?
-                    // i128 not supported by serde_arrow!
                 }
             }
             DataType::Struct(_) => {

--- a/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
+++ b/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
@@ -14,7 +14,8 @@ use arrow_array::{
     },
     Array, ArrayRef, LargeListArray, StructArray,
 };
-use arrow_schema::{DataType, Field, FieldRef, TimeUnit};
+use arrow_schema::{DataType, Field, FieldRef, Fields, TimeUnit};
+use serde_arrow::ArrayBuilder;
 use bigdecimal::{num_bigint::BigInt, BigDecimal};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use itertools::Itertools;
@@ -35,7 +36,8 @@ use std::{
 };
 use thiserror::Error;
 
-pub const DECIMAL_MAX: i128 = 99999999999999999999999999999999999999i128; // equivalent to parquet decimal(38, 0)
+// Equivalent to parquet decimal(38, 0).
+pub const DECIMAL_MAX: i128 = 99999999999999999999999999999999999999i128;
 
 #[derive(Error, Debug)]
 #[error("Decimal {0} too large.")]
@@ -780,11 +782,7 @@ pub fn list_array_from_props<P: Serialize + fmt::Debug + Clone>(
     dt: &DataType,
     props: impl IntoIterator<Item = Option<P>>,
 ) -> Result<LargeListArray, serde_arrow::Error> {
-    use arrow_schema::{Field, Fields};
-    use serde_arrow::ArrayBuilder;
-
     let fields: Fields = vec![Field::new("value", dt.clone(), true)].into();
-
     let mut builder = ArrayBuilder::from_arrow(&fields)?;
 
     for value in props {
@@ -800,10 +798,7 @@ pub fn struct_array_from_props<P: Serialize>(
     dt: &DataType,
     props: impl IntoIterator<Item = Option<P>>,
 ) -> Result<StructArray, serde_arrow::Error> {
-    use serde_arrow::ArrayBuilder;
-
     let fields = [FieldRef::new(Field::new("value", dt.clone(), true))];
-
     let mut builder = ArrayBuilder::from_arrow(&fields)?;
 
     for p in props {
@@ -811,6 +806,7 @@ pub fn struct_array_from_props<P: Serialize>(
     }
 
     let arrays = builder.to_arrow()?;
+
     Ok(arrays.first().unwrap().as_struct().clone())
 }
 

--- a/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
+++ b/raphtory-api/src/core/entities/properties/prop/prop_enum.rs
@@ -265,11 +265,13 @@ impl PartialOrd for Prop {
 }
 
 pub struct SerdeArrowProp<'a>(pub &'a Prop);
+
 #[derive(Clone, Copy, Debug)]
 pub struct SerdeArrowList<'a>(pub &'a PropArray);
 
 #[derive(Clone, Copy, Debug)]
 pub struct SerdeArrowArray<'a>(pub &'a ArrayRef);
+
 #[derive(Clone, Copy)]
 pub struct SerdeArrowMap<'a>(pub &'a HashMap<ArcStr, Prop, FxBuildHasher>);
 
@@ -286,9 +288,11 @@ impl<'a> Serialize for SerdeArrowList<'a> {
         match &self.0 {
             PropArray::Vec(list) => {
                 let mut state = serializer.serialize_seq(Some(self.0.len()))?;
+
                 for prop in list.iter() {
                     state.serialize_element(&SerdeArrowProp(prop))?;
                 }
+
                 state.end()
             }
             PropArray::Array(array) => SerdeArrowArray(array).serialize(serializer),
@@ -329,6 +333,7 @@ impl<'a> Serialize for SerdeArrowProp<'a> {
             Prop::NDTime(dt) => serializer.serialize_i64(dt.and_utc().timestamp_millis()),
             Prop::List(l) => SerdeArrowList(l).serialize(serializer),
             Prop::Map(m) => SerdeArrowMap(m).serialize(serializer),
+            // TODO: Serialization should match PropColumn::Decimal using precision and scale.
             Prop::Decimal(dec) => serializer.serialize_str(&dec.to_string()),
         }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Serializes `Prop::Decimal`, which internally holds a `BigDecimal`, to match the `Decimal128` format used in Arrow.

Additionally, modifies `column_as_array` to return a `Result`.

### Why are the changes needed?
`parquet_tests::node_temp_props_decimal` currently fails due to `Prop::Decimal` being serialized incorrectly using scientific notation. `serde_arrow` expects floats to be in standard notation.

Furthermore, having `column_as_array` (and its callers) return a `Result` allows prop serialization errors to bubble up properly. Currently for props that can't be serialized, errors are swallowed using `.ok` and return empty columns.

### Does this PR introduce any user-facing change? If yes is this documented?
No.

### How was this patch tested?
This patch fixes a failing test.

### Are there any further changes required?
No.

