### PR TITLE
clean up the workflows so they should actually work on an external PR

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,10 +38,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-      - uses: webfactory/ssh-agent@v0.10.0
-        name: Load raphtory-disk_graph key
-        with:
-          ssh-private-key: ${{ secrets.RA_SSH_PRIVATE_KEY }}
       - name: Run benchmark (Unix)
         run: |
           set -o pipefail

--- a/.github/workflows/test_python_workflow.yml
+++ b/.github/workflows/test_python_workflow.yml
@@ -1,6 +1,5 @@
 name: Run Python test
-permissions:
-  contents: write
+permissions: { }
 on:
   workflow_call:
     inputs:
@@ -34,8 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         name: Checkout
-        with:
-          ref: ${{ github.head_ref }}
       - uses: maxim-lobanov/setup-xcode@v1
         name: Xcode version
         if: "contains(matrix.os, 'macOS')"

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{ fromJson(needs.select-strategy.outputs.python-versions) }}
-        browser: [chromium, firefox]
-        shard: [1, 2, 3]
+        browser: [ chromium, firefox ]
+        shard: [ 1, 2, 3 ]
     runs-on: windows-latest
     env:
       NUM_SHARDS: 3
@@ -30,8 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         name: Checkout
-        with:
-          ref: ${{ github.head_ref }}
       - uses: ./.github/actions/setup_rust
         name: Setup Rust
       - name: Install Server-Media-Foundation (firefox needs it on Windows Server)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clean up old private crud from the workflows

### Why are the changes needed?

Workflows should be able to run against external PRs now as there are no more private submodules


