### PR TITLE
fix week alignment (should align to Monday, not Thursday)

### DIFF
--- a/python/tests/test_base_install/test_graphdb/test_rolling_expanding_alignment.py
+++ b/python/tests/test_base_install/test_graphdb/test_rolling_expanding_alignment.py
@@ -49,7 +49,7 @@ def test_rolling_month_alignment_default_true(example_graph):
 
     # Validate the first three windows
     for i, (exp_start, exp_end) in enumerate(
-            [(exp0_start, exp0_end), (exp1_start, exp1_end), (exp2_start, exp2_end)]
+        [(exp0_start, exp0_end), (exp1_start, exp1_end), (exp2_start, exp2_end)]
     ):
         w = windows[i]
         start = w.start.dt

--- a/python/tests/test_base_install/test_graphdb/test_rolling_expanding_alignment.py
+++ b/python/tests/test_base_install/test_graphdb/test_rolling_expanding_alignment.py
@@ -49,7 +49,7 @@ def test_rolling_month_alignment_default_true(example_graph):
 
     # Validate the first three windows
     for i, (exp_start, exp_end) in enumerate(
-        [(exp0_start, exp0_end), (exp1_start, exp1_end), (exp2_start, exp2_end)]
+            [(exp0_start, exp0_end), (exp1_start, exp1_end), (exp2_start, exp2_end)]
     ):
         w = windows[i]
         start = w.start.dt
@@ -218,7 +218,7 @@ def test_expanding_custom_align_month(example_graph):
 def test_expanding_custom_align_week(example_graph):
     g: Graph = example_graph
     ws = list(g.expanding("1 day", alignment_unit="weeks"))
-    exp_end0 = datetime(2025, 3, 14, 0, 0, 0, tzinfo=timezone.utc)
+    exp_end0 = datetime(2025, 3, 11, 0, 0, 0, tzinfo=timezone.utc)
     exp_end_last = datetime(2025, 11, 23, 0, 0, 0, tzinfo=timezone.utc)
     assert ws[0].end.dt == exp_end0
     assert ws[-1].end.dt == exp_end_last
@@ -227,10 +227,10 @@ def test_expanding_custom_align_week(example_graph):
 def test_week_alignment_epoch_buckets():
     g = Graph()
     g.add_edge("1970-01-10 12:00:00", 0, 1)  # 9.5 days after epoch
-    # weeks align to multiples of 7 days since 1970-01-01 00:00:00 UTC
+    # weeks align to Monday
     ws = list(g.rolling("1 week"))
-    exp_start0 = datetime(1970, 1, 8, 0, 0, 0, tzinfo=timezone.utc)
-    exp_end0 = datetime(1970, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+    exp_start0 = datetime(1970, 1, 5, 0, 0, 0, tzinfo=timezone.utc)
+    exp_end0 = datetime(1970, 1, 12, 0, 0, 0, tzinfo=timezone.utc)
     # only one window
     assert ws[0].start.dt == exp_start0
     assert ws[0].end.dt == exp_end0

--- a/python/tests/test_base_install/test_graphql/test_rolling_expanding.py
+++ b/python/tests/test_base_install/test_graphql/test_rolling_expanding.py
@@ -4882,7 +4882,7 @@ def test_alignment():
                         "end": {
                             "timestamp": int(
                                 datetime(
-                                    2025, 4, 13, 0, 0, 0, tzinfo=timezone.utc
+                                    2025, 4, 10, 0, 0, 0, tzinfo=timezone.utc
                                 ).timestamp()
                                 * 1000
                             )
@@ -4892,7 +4892,7 @@ def test_alignment():
                         "end": {
                             "timestamp": int(
                                 datetime(
-                                    2025, 5, 13, 0, 0, 0, tzinfo=timezone.utc
+                                    2025, 5, 10, 0, 0, 0, tzinfo=timezone.utc
                                 ).timestamp()
                                 * 1000
                             )
@@ -5252,7 +5252,7 @@ def test_alignment():
                                             datetime(
                                                 2025,
                                                 5,
-                                                22,
+                                                19,
                                                 0,
                                                 0,
                                                 0,
@@ -5272,7 +5272,7 @@ def test_alignment():
                                             datetime(
                                                 2025,
                                                 7,
-                                                31,
+                                                28,
                                                 0,
                                                 0,
                                                 0,
@@ -5292,7 +5292,7 @@ def test_alignment():
                                             datetime(
                                                 2025,
                                                 10,
-                                                9,
+                                                6,
                                                 0,
                                                 0,
                                                 0,
@@ -5312,7 +5312,7 @@ def test_alignment():
                                             datetime(
                                                 2025,
                                                 12,
-                                                18,
+                                                15,
                                                 0,
                                                 0,
                                                 0,

--- a/raphtory-core/src/utils/time.rs
+++ b/raphtory-core/src/utils/time.rs
@@ -90,7 +90,10 @@ impl AlignmentUnit {
             AlignmentUnit::Minute => Self::floor_ms(timestamp, MINUTE_MS),
             AlignmentUnit::Hour => Self::floor_ms(timestamp, HOUR_MS),
             AlignmentUnit::Day => Self::floor_ms(timestamp, DAY_MS),
-            AlignmentUnit::Week => Self::floor_ms(timestamp, WEEK_MS),
+            AlignmentUnit::Week => {
+                let offset = DAY_MS * 4; // 0 is a Thursday
+                Self::floor_ms(timestamp - offset, WEEK_MS) + offset
+            }
             // Month and Year are variable (28, 30, or 31 days / 365 or 366 days so we can't simply use division)
             AlignmentUnit::Month => {
                 let naive = DateTime::from_timestamp_millis(timestamp)
@@ -495,8 +498,27 @@ impl Add<Interval> for EventTime {
 
 #[cfg(test)]
 mod time_tests {
-    use crate::utils::time::Interval;
-    use raphtory_api::core::utils::time::{ParseTimeError, TryIntoTime};
+    use crate::utils::time::{AlignmentUnit, Interval, WEEK_MS};
+    use chrono::{DateTime, Datelike, NaiveTime, Utc, Weekday};
+    use proptest::{arbitrary::any, prelude::Strategy, proptest};
+    use raphtory_api::core::{
+        storage::timeindex::AsTime,
+        utils::time::{ParseTimeError, TryIntoTime},
+    };
+
+    #[test]
+    fn alignment_week_proptest() {
+        proptest!(|(dt in (-8334601228800000i64..8210266876800000).prop_filter_map("not a valid date", DateTime::from_timestamp_millis))| {
+            let ts = dt.timestamp_millis();
+            let aligned = AlignmentUnit::Week.align_timestamp(ts);
+            let aligned_dt = aligned.dt().unwrap();
+            assert_eq!(aligned_dt, aligned_dt.with_time(NaiveTime::from_num_seconds_from_midnight_opt(0, 0).unwrap()).unwrap());
+            assert!(ts - aligned < WEEK_MS);
+            assert_eq!(aligned_dt.weekday(), Weekday::Mon);
+
+
+        })
+    }
 
     #[test]
     fn interval_parsing() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`AlignmentUnit::Week` now uses Monday as the start of the week 

### Why are the changes needed?

1970-1-1 is a Thursday...

### Does this PR introduce any user-facing change? If yes is this documented?

Fixes an alignment bug

### How was this patch tested?

Added a prop test to verify the alignment



