### PR TITLE
edges iter for multiple layers needs to use the sorted variant

### DIFF
--- a/db4-storage/src/api/nodes.rs
+++ b/db4-storage/src/api/nodes.rs
@@ -38,6 +38,7 @@ use crate::{
     wal::LSN,
 };
 use raphtory_api::core::entities::{LayerId, properties::meta::STATIC_GRAPH_LAYER_ID};
+use raphtory_itertools::FastMergeExt;
 use rayon::prelude::*;
 
 pub trait NodeSegmentOps: Send + Sync + Debug + 'static {
@@ -248,6 +249,38 @@ pub trait NodeRefOps<'a>: Copy + Clone + Send + Sync + 'a {
     }
 
     #[box_on_debug_lifetime]
+    fn edges_sorted_dir(
+        self,
+        layer_id: LayerId,
+        dir: Direction,
+    ) -> impl Iterator<Item = EdgeRef> + Send + Sync + 'a
+    where
+        Self: Sized,
+    {
+        let src_pid = self.vid();
+        match dir {
+            Direction::OUT => Iter3::I(
+                self.out_edges_sorted(layer_id)
+                    .map(move |(v, e)| EdgeRef::new_outgoing(e, src_pid, v)),
+            ),
+            Direction::IN => Iter3::J(
+                self.inb_edges_sorted(layer_id)
+                    .map(move |(v, e)| EdgeRef::new_incoming(e, v, src_pid)),
+            ),
+            Direction::BOTH => Iter3::K(
+                self.out_edges_sorted(layer_id)
+                    .map(move |(v, e)| EdgeRef::new_outgoing(e, src_pid, v))
+                    .merge_by(
+                        self.inb_edges_sorted(layer_id)
+                            .map(move |(v, e)| EdgeRef::new_incoming(e, v, src_pid)),
+                        |e1, e2| e1.remote() < e2.remote(),
+                    )
+                    .dedup_by(|l, r| l.pid() == r.pid()),
+            ),
+        }
+    }
+
+    #[box_on_debug_lifetime]
     fn edges_iter<'b>(
         self,
         layers_ids: &'b LayerIds,
@@ -262,8 +295,8 @@ pub trait NodeRefOps<'a>: Copy + Clone + Send + Sync + 'a {
             LayerIds::Multiple(layers) => Iter4::K(
                 layers
                     .into_iter()
-                    .map(|layer_id| self.edges_dir(layer_id, dir))
-                    .kmerge_by(|e1, e2| e1.remote() < e2.remote())
+                    .map(|layer_id| self.edges_sorted_dir(layer_id, dir))
+                    .fast_merge_by(|e1, e2| e1.remote() < e2.remote())
                     .dedup_by(|l, r| l.pid() == r.pid()),
             ),
             LayerIds::None => Iter4::L(std::iter::empty()),


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix degree calculation for graphs with `LayerIds::Multiple` 

### Why are the changes needed?

degree calculation were using the unsorted edge iterators which don't merge correctly

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


