### PR TITLE
Fix graphql meta graph

### DIFF
--- a/python/tests/test_base_install/test_graphql/test_namespace.py
+++ b/python/tests/test_base_install/test_graphql/test_namespace.py
@@ -201,31 +201,16 @@ def test_metagraph_updating():
             """
 
             result = client.query(query)
-            correct_empty = {
-                "graphMetadata": {
-                    "nodeCount": 0,
-                    "edgeCount": 0
-                }
-            }
+            correct_empty = {"graphMetadata": {"nodeCount": 0, "edgeCount": 0}}
             assert result == correct_empty
             client.remote_graph("test").add_node(0, "1")
 
             result = client.query(query)
-            assert result == {
-                "graphMetadata": {
-                    "nodeCount": 1,
-                    "edgeCount": 0
-                }
-            }
+            assert result == {"graphMetadata": {"nodeCount": 1, "edgeCount": 0}}
 
             client.remote_graph("test").add_edge(1, "2", "3")
             result = client.query(query)
-            assert result == {
-                "graphMetadata": {
-                    "nodeCount": 3,
-                    "edgeCount": 1
-                }
-            }
+            assert result == {"graphMetadata": {"nodeCount": 3, "edgeCount": 1}}
 
 
 def test_counting():
@@ -337,8 +322,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                    "Only relative paths are allowed to be used within the working_dir: /test"
-                    in str(excinfo.value)
+                "Only relative paths are allowed to be used within the working_dir: /test"
+                in str(excinfo.value)
             )
 
         query = """{
@@ -352,8 +337,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                    "References to the parent dir are not allowed within the path: test/../../"
-                    in str(excinfo.value)
+                "References to the parent dir are not allowed within the path: test/../../"
+                in str(excinfo.value)
             )
 
         query = """{
@@ -367,8 +352,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                    "References to the current dir are not allowed within the path: ./test"
-                    in str(excinfo.value)
+                "References to the current dir are not allowed within the path: ./test"
+                in str(excinfo.value)
             )
 
         query = """{
@@ -382,8 +367,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                    "The path to the graph contains a subpath to an existing graph: test/second/internal/graph1"
-                    in str(excinfo.value)
+                "The path to the graph contains a subpath to an existing graph: test/second/internal/graph1"
+                in str(excinfo.value)
             )
 
 

--- a/python/tests/test_base_install/test_graphql/test_namespace.py
+++ b/python/tests/test_base_install/test_graphql/test_namespace.py
@@ -185,6 +185,49 @@ def test_namespaces_and_metagraph():
     assert sort_dict(result) == sort_dict(correct)
 
 
+def test_metagraph_updating():
+    with tempfile.TemporaryDirectory() as work_dir:
+        with GraphServer(work_dir).start() as server:
+            client = server.get_client()
+            client.new_graph("test", "EVENT")
+
+            query = """ 
+                {
+                    graphMetadata(path: "test") {
+                        nodeCount
+                        edgeCount
+                    }
+                }
+            """
+
+            result = client.query(query)
+            correct_empty = {
+                "graphMetadata": {
+                    "nodeCount": 0,
+                    "edgeCount": 0
+                }
+            }
+            assert result == correct_empty
+            client.remote_graph("test").add_node(0, "1")
+
+            result = client.query(query)
+            assert result == {
+                "graphMetadata": {
+                    "nodeCount": 1,
+                    "edgeCount": 0
+                }
+            }
+
+            client.remote_graph("test").add_edge(1, "2", "3")
+            result = client.query(query)
+            assert result == {
+                "graphMetadata": {
+                    "nodeCount": 3,
+                    "edgeCount": 1
+                }
+            }
+
+
 def test_counting():
     work_dir = tempfile.mkdtemp()
 
@@ -294,8 +337,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                "Only relative paths are allowed to be used within the working_dir: /test"
-                in str(excinfo.value)
+                    "Only relative paths are allowed to be used within the working_dir: /test"
+                    in str(excinfo.value)
             )
 
         query = """{
@@ -309,8 +352,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                "References to the parent dir are not allowed within the path: test/../../"
-                in str(excinfo.value)
+                    "References to the parent dir are not allowed within the path: test/../../"
+                    in str(excinfo.value)
             )
 
         query = """{
@@ -324,8 +367,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                "References to the current dir are not allowed within the path: ./test"
-                in str(excinfo.value)
+                    "References to the current dir are not allowed within the path: ./test"
+                    in str(excinfo.value)
             )
 
         query = """{
@@ -339,8 +382,8 @@ def test_wrong_paths():
         with pytest.raises(Exception) as excinfo:
             client.query(query)
             assert (
-                "The path to the graph contains a subpath to an existing graph: test/second/internal/graph1"
-                in str(excinfo.value)
+                    "The path to the graph contains a subpath to an existing graph: test/second/internal/graph1"
+                    in str(excinfo.value)
             )
 
 

--- a/raphtory-graphql/src/model/graph/meta_graph.rs
+++ b/raphtory-graphql/src/model/graph/meta_graph.rs
@@ -1,5 +1,6 @@
 use crate::{
     data::Data,
+    graph::GraphWithVectors,
     model::graph::property::GqlProperty,
     paths::{ExistingGraphFolder, ValidGraphPaths},
 };
@@ -60,10 +61,11 @@ impl MetaGraph {
     async fn meta(&self, data: &Data) -> Result<&GraphMetadata> {
         Ok(self
             .meta
-            .get_or_try_init(|| {
-                data.get_cached_graph(self.folder.local_path())
-                    .map(GraphMetadata::from_graph)
-                    .unwrap_or_else(|| self.folder.read_metadata_async())
+            .get_or_try_init(|| async {
+                match data.get_cached_graph(self.folder.local_path()).await {
+                    None => self.folder.read_metadata_async().await,
+                    Some(graph) => Ok(GraphMetadata::from_graph(graph)),
+                }
             })
             .await?)
     }

--- a/raphtory-graphql/src/model/graph/meta_graph.rs
+++ b/raphtory-graphql/src/model/graph/meta_graph.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use async_graphql::Context;
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields, Result};
+use futures_util::TryFutureExt;
 use raphtory::{
     db::api::storage::storage::read_constant_graph_properties,
     errors::GraphError,
@@ -56,10 +57,14 @@ impl MetaGraph {
         self.folder.local_path()
     }
 
-    async fn meta(&self) -> Result<&GraphMetadata> {
+    async fn meta(&self, data: &Data) -> Result<&GraphMetadata> {
         Ok(self
             .meta
-            .get_or_try_init(|| self.folder.read_metadata_async())
+            .get_or_try_init(|| {
+                data.get_cached_graph(self.folder.local_path())
+                    .map(GraphMetadata::from_graph)
+                    .unwrap_or_else(|| self.folder.read_metadata_async())
+            })
             .await?)
     }
 }
@@ -93,16 +98,18 @@ impl MetaGraph {
     }
 
     /// Returns the number of nodes in the graph.
-    async fn node_count(&self) -> Result<usize> {
-        Ok(self.meta().await?.node_count)
+    async fn node_count(&self, ctx: &Context<'_>) -> Result<usize> {
+        let data: &Data = ctx.data_unchecked();
+        Ok(self.meta(data).await?.node_count)
     }
 
     /// Returns the number of edges in the graph.
     ///
     /// Returns:
     ///     int:
-    async fn edge_count(&self) -> Result<usize> {
-        Ok(self.meta().await?.edge_count)
+    async fn edge_count(&self, ctx: &Context<'_>) -> Result<usize> {
+        let data: &Data = ctx.data_unchecked();
+        Ok(self.meta(data).await?.edge_count)
     }
 
     /// Returns the metadata of the graph.
@@ -123,7 +130,7 @@ impl MetaGraph {
                 .collect());
         }
 
-        if self.meta().await?.is_diskgraph {
+        if self.meta(data).await?.is_diskgraph {
             let graph_path = self
                 .folder
                 .graph_folder()


### PR DESCRIPTION
### What changes were proposed in this pull request?

- `node_count` and `edge_count` on `MetaGraph` update when the graph is modified in memory

### Why are the changes needed?

- on-disk metadata is only updated when the graph is evicted from the cache

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

added a test to check the counts update properly

### Are there any further changes required?


