### PR TITLE
Move `load` out of ControlFileOps

### DIFF
--- a/db4-storage/src/pages/mod.rs
+++ b/db4-storage/src/pages/mod.rs
@@ -363,9 +363,9 @@ impl<
         let wal = self.ext.wal();
         let control_file = self.ext.control_file();
 
-        // Skip running a clean flush if the DB is in shutdown or crash recovery state.
-        // Note that the state can be Shutdown after the graph is loaded and before recovery
-        // is complete.
+        // Skip running a clean flush if the DB is in shutdown or crash recovery.
+        // Note that the state can be Shutdown after load is called and before recovery is complete.
+        // If state is NotSupported, the WAL is disabled and we should flush anyways.
         if matches!(
             control_file.db_state(),
             DBState::Shutdown | DBState::CrashRecovery

--- a/db4-storage/src/persist/control_file.rs
+++ b/db4-storage/src/persist/control_file.rs
@@ -1,6 +1,5 @@
 use crate::{error::StorageError, wal::LSN};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum DBState {
@@ -13,9 +12,7 @@ pub enum DBState {
 // Starting value for `last_checkpoint` in the control file.
 pub const LAST_CHECKPOINT_INIT: LSN = 0;
 
-pub trait ControlFileOps: Sized {
-    fn load(dir: &Path) -> Result<Self, StorageError>;
-
+pub trait ControlFileOps {
     fn save(&self) -> Result<(), StorageError>;
 
     fn db_state(&self) -> DBState;
@@ -31,10 +28,6 @@ pub trait ControlFileOps: Sized {
 pub struct NoControlFile;
 
 impl ControlFileOps for NoControlFile {
-    fn load(_dir: &Path) -> Result<Self, StorageError> {
-        Ok(NoControlFile)
-    }
-
     fn save(&self) -> Result<(), StorageError> {
         Ok(())
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move the `load` method out of the `ControlFileOps` trait.

### Why are the changes needed?
`ControlFile` and `MaybeControlFile` require different `load` signatures in https://github.com/Pometry/pometry-storage/pull/311.

### Does this PR introduce any user-facing change? If yes is this documented?
No.

### How was this patch tested?
Added a few tests in https://github.com/Pometry/pometry-storage/pull/311.

### Are there any further changes required?
See https://github.com/Pometry/pometry-storage/pull/311.

