### PR TITLE
Add `WalDisabled` as a state in the `ControlFile`

### DIFF
--- a/db4-storage/src/lib.rs
+++ b/db4-storage/src/lib.rs
@@ -124,6 +124,9 @@ pub mod error {
 
         #[error("Disk storage not supported")]
         DiskStorageNotSupported,
+
+        #[error("Graph requires WAL recovery; load with WAL enabled")]
+        RecoveryRequired,
     }
 
     impl StorageError {

--- a/db4-storage/src/pages/mod.rs
+++ b/db4-storage/src/pages/mod.rs
@@ -365,7 +365,7 @@ impl<
 
         // Skip running a clean flush if the DB is in shutdown or crash recovery.
         // Note that the state can be Shutdown after load is called and before recovery is complete.
-        // If state is NotSupported, the WAL is disabled and we should flush anyways.
+        // A clean flush is performed even when state is WalDisabled or NotSupported.
         if matches!(
             control_file.db_state(),
             DBState::Shutdown | DBState::CrashRecovery

--- a/db4-storage/src/persist/control_file.rs
+++ b/db4-storage/src/persist/control_file.rs
@@ -6,6 +6,7 @@ pub enum DBState {
     Running,
     Shutdown,
     CrashRecovery,
+    WalDisabled,
     NotSupported,
 }
 

--- a/raphtory-storage/src/recovery_ops.rs
+++ b/raphtory-storage/src/recovery_ops.rs
@@ -44,6 +44,10 @@ pub trait RecoveryOps: DurabilityOps + InternalAdditionOps<Error = MutationError
                 // Set the next LSN for future writes to the end of the WAL stream.
                 wal.set_position(end_of_wal_lsn)?;
             }
+            DBState::WalDisabled => {
+                // A graph that was created with WAL disabled is now loaded with WAL enabled.
+                // No recovery is needed.
+            }
             DBState::NotSupported => {
                 // Recovery is not supported, skip.
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds `WalDisabled` to the `DBState` enum in `ControlFile`.

### Why are the changes needed?
To support throwing an error if a crashed graph is loaded without WAL enabled.
See https://github.com/Pometry/pometry-storage/pull/311.

### Does this PR introduce any user-facing change? If yes is this documented?
No.

### How was this patch tested?
Added some tests in https://github.com/Pometry/pometry-storage/pull/311.

### Are there any further changes required?
No.