### PR TITLE
Fix 404 "not found" when fetching non-root paths with --public-dir enabled

### DIFF
--- a/raphtory-graphql/src/routes.rs
+++ b/raphtory-graphql/src/routes.rs
@@ -78,6 +78,7 @@ where
             self.gql.call(req).await
         } else if let Some(public_dir) = &self.public_dir {
             StaticFilesEndpoint::new(public_dir)
+                .index_file("index.html")
                 .fallback_to_index()
                 .call(req)
                 .await
@@ -101,5 +102,65 @@ where
                 EmbeddedFilesEndpoint::<PublicFolder>::new().call(req).await
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PublicFilesEndpoint;
+    use poem::{
+        endpoint::make_sync,
+        http::{Method, StatusCode},
+        Endpoint, Request, Response,
+    };
+    use std::{fs, path::Path};
+    use tempfile::tempdir;
+
+    fn public_dir_endpoint(dir: &Path) -> impl Endpoint<Output = Response> {
+        PublicFilesEndpoint::new(
+            Some(dir.to_path_buf()),
+            make_sync(|_| Response::builder().body("gql")),
+        )
+    }
+
+    async fn get(endpoint: &impl Endpoint<Output = Response>, path: &str) -> Response {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(path.parse().unwrap())
+            .finish();
+        endpoint
+            .call(req)
+            .await
+            .unwrap_or_else(|err| err.into_response())
+    }
+
+    #[tokio::test]
+    async fn public_dir_serves_index_for_spa_routes() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("index.html"), "<html>ui</html>").unwrap();
+        let endpoint = public_dir_endpoint(dir.path());
+
+        for path in ["/", "/index.html", "/graphs", "/graphs/nested/route"] {
+            let resp = get(&endpoint, path).await;
+            assert_eq!(resp.status(), StatusCode::OK, "GET {path}");
+            assert_eq!(
+                resp.into_body().into_string().await.unwrap(),
+                "<html>ui</html>",
+                "GET {path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn public_dir_serves_real_files() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("index.html"), "<html>ui</html>").unwrap();
+        fs::create_dir(dir.path().join("assets")).unwrap();
+        fs::write(dir.path().join("assets").join("app.js"), "js-content").unwrap();
+        let endpoint = public_dir_endpoint(dir.path());
+
+        let resp = get(&endpoint, "/assets/app.js").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.into_body().into_string().await.unwrap(), "js-content");
     }
 }

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -494,7 +494,7 @@ async fn server_termination(
 
 #[cfg(test)]
 mod server_tests {
-    use crate::server::GraphServer;
+    use crate::{config::app_config::AppConfigBuilder, server::GraphServer};
     use chrono::prelude::*;
     use raphtory::{
         db::api::storage::storage::Config,
@@ -505,6 +505,36 @@ mod server_tests {
     use tempfile::tempdir;
     use tokio::time::{sleep, Duration};
     use tracing::info;
+
+    #[tokio::test]
+    async fn test_public_dir_serves_index_for_subpages() {
+        let work_dir = tempdir().unwrap();
+        let public_dir = tempdir().unwrap();
+        std::fs::write(public_dir.path().join("index.html"), "<html>ui</html>").unwrap();
+
+        let app_config = AppConfigBuilder::new()
+            .with_public_dir(Some(public_dir.path().to_path_buf()))
+            .build();
+        let server = GraphServer::new(
+            work_dir.path().to_path_buf(),
+            Some(app_config),
+            Config::default(),
+        )
+        .await
+        .unwrap();
+        let running = server.start_with_port(0).await.unwrap();
+        let port = running.port();
+
+        for path in ["/", "/graphs", "/graphs/nested/route"] {
+            let resp = reqwest::get(format!("http://localhost:{port}{path}"))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), 200, "GET {path}");
+            assert_eq!(resp.text().await.unwrap(), "<html>ui</html>", "GET {path}");
+        }
+
+        running.stop().await
+    }
 
     #[tokio::test]
     async fn test_server_start_stop() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the index file to "index.html" for the `--public-dir` command of raphtory-graphql's CLI

### Why are the changes needed?

poem's fallback_to_index() only falls back to the configured index file, but none was actually configured, so direct navigation to any UI subpage (e.g. /graphs) returned 404 "not found" instead of index.html when using the --public-dir option (when using the server .

### Does this PR introduce any user-facing change? If yes is this documented?

No, it's probably expected behaviour.

### How was this patch tested?

Unit tests were added in routes.rs for PublicFilesEndpoint, and a test was added to server.rs which tests the server with AppWithConfig.with_public_dir enabled.

### Are there any further changes required?

No
