### PR TITLE
add flush on create_subgraph as it's not covered by WAL

### DIFF
--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -800,6 +800,7 @@ impl Mut {
             }
         })
         .await?;
+        new_subgraph.flush()?;
 
         data.insert_graph(folder, new_subgraph).await?;
         if let Err(e) = auto_grant_on_create(ctx, &data.auth_policy, &new_path) {


### PR DESCRIPTION
crate_subgraph can loose data because materialize is not covered by the WAL so we need to flush it