### PR TITLE
Test lake house formats + small RBAC fix + default batch size on graphql

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,8 +33,15 @@ pyvis = ["pyvis >= 0.3.2"]
 networkx = ["networkx >= 2.6.3"]
 export = ["raphtory[pyvis,networkx]"]
 all = ["raphtory[export,plot]"]
-dev = ["raphtory[all,test,tox]", "docstring_parser >= 0.16", "pandas-stubs", "pyarrow-stubs", "maturin>=1.8.3", "tox>=4.25"]
-test = ["requests >= 2.34.2", "pyjwt[crypto] >= 2.13.0", "pytz>=2025.2", "polars >= 1.35.2",  "duckdb >= 1.5.3"]
+# TODO(cachetools): remove the `<4.36` tox cap once pyiceberg allows cachetools>=7.
+#   pyiceberg (a `test` dep) pins cachetools<7, but tox>=4.36 requires cachetools>=7, so the two
+#   cannot share one environment; the cap keeps a flat `.[dev]` install consistent.
+#   To check if it can be lifted: `pip index versions pyiceberg` then confirm the latest release's
+#   cachetools requirement allows >=7 (e.g. `python -c "import importlib.metadata as m; print([r for r in m.requires('pyiceberg') if 'cachetools' in r])"`).
+#   CI is unaffected either way: it installs the tox tool in its own environment and `tox run` builds
+#   isolated testenvs, so tox and pyiceberg never coexist there.
+dev = ["raphtory[all,test,tox]", "docstring_parser >= 0.16", "pandas-stubs", "pyarrow-stubs", "maturin>=1.8.3", "tox>=4.25,<4.36"]
+test = ["requests >= 2.34.2", "pyjwt[crypto] >= 2.13.0", "pytz>=2025.2", "polars >= 1.35.2",  "duckdb >= 1.5.3", "pyiceberg[sql-sqlite] >= 0.8.0", "deltalake >= 1.0"]
 tox = ["nbmake", "pytest >= 8", "pytest-benchmark >= 5.1.0"]
 
 [tool.maturin]

--- a/python/python/raphtory/graphql/__init__.pyi
+++ b/python/python/raphtory/graphql/__init__.pyi
@@ -72,7 +72,7 @@ class GraphServer(object):
         heavy_query_limit (int, optional): Maximum number of expensive traversal queries (outComponent, inComponent, edges, outEdges, inEdges, neighbours, outNeighbours, inNeighbours) allowed to run simultaneously. Extra queries are parked on a semaphore.
         exclusive_writes (bool, optional): If True, ingestion/write operations run one at a time and block reads until complete.
         disable_batching (bool, optional): If True, batched GraphQL requests are rejected. Prevents bypassing per-request depth/complexity limits.
-        max_batch_size (int, optional): Caps the number of queries accepted in a single batched request.
+        max_batch_size (int, optional): Caps the number of queries accepted in a single batched request. Defaults to 10; set to null for unlimited (subject to disable_batching).
         disable_lists (bool, optional): If True, bulk `list` endpoints on collections are disabled. Clients must use `page` instead.
         max_page_size (int, optional): Maximum page size allowed on paged collection queries.
         max_query_depth (int, optional): Maximum nesting depth of a query.

--- a/python/python/raphtory/node_state/__init__.pyi
+++ b/python/python/raphtory/node_state/__init__.pyi
@@ -7818,17 +7818,6 @@ class OutputNodeState(object):
             Optional[dict]: the value for the node or the default value
         """
 
-    def groups(self, cols: list[str]) -> list[tuple[dict, Nodes]]:
-        """
-        Group by value
-
-        Arguments:
-            cols (list[str]): columns by which to group nodes
-
-        Returns:
-            list[tuple[dict, Nodes]]: The grouped nodes
-        """
-
     def items(self) -> Iterator[Tuple[Node, Dict]]:
         """
         Iterate over items
@@ -7865,17 +7854,6 @@ class OutputNodeState(object):
             Nodes: The nodes
         """
 
-    def sort_by(self, sort_params: Dict) -> OutputNodeState:
-        """
-        Get value for node
-
-        Arguments:
-            sort_params (Dict): Map of sort keys to sort option ('asc' or 'desc'). None defaults to 'asc'
-
-        Returns:
-            OutputNodeState: Sorted NodeState
-        """
-
     def to_parquet(self, file_path: str, id_column: str = "id") -> None:
         """
         Convert OutputNodeState to Parquet
@@ -7886,18 +7864,6 @@ class OutputNodeState(object):
 
         Returns:
             None:
-        """
-
-    def top_k(self, sort_params: Dict, k: int) -> OutputNodeState:
-        """
-        Get value for node
-
-        Arguments:
-            sort_params (Dict): Map of sort keys to sort option ('asc' or 'desc'). None defaults to 'asc'
-            k (int): Number of top entries to return.
-
-        Returns:
-            OutputNodeState: Sorted NodeState
         """
 
     def values(self) -> Iterator[Dict]:

--- a/python/tests/test_auth.py
+++ b/python/tests/test_auth.py
@@ -112,6 +112,79 @@ def test_expired_token():
         assert response.status_code == 401
 
 
+def test_not_yet_valid_token_rejected():
+    """A token whose `nbf` (not-before) is in the future must be rejected now."""
+    work_dir = tempfile.mkdtemp()
+    with GraphServer(
+        work_dir, config={"auth": {"public_key": PUB_KEY}}
+    ).start() as server:
+        port = server.port()
+        nbf = time() + 3600  # only becomes valid an hour from now
+        for access in ("ro", "rw"):
+            token = jwt.encode(
+                {"access": access, "nbf": nbf}, PRIVATE_KEY, algorithm="EdDSA"
+            )
+            headers = {
+                "Authorization": f"Bearer {token}",
+            }
+            response = requests.post(
+                raphtory_url(port),
+                headers=headers,
+                data=json.dumps({"query": QUERY_ROOT}),
+            )
+            assert response.status_code == 401
+
+
+def test_already_valid_nbf_token_accepted():
+    """A token whose `nbf` is in the past is honoured normally (nbf validation must
+    not reject already-valid tokens)."""
+    work_dir = tempfile.mkdtemp()
+    with GraphServer(
+        work_dir, config={"auth": {"public_key": PUB_KEY}}
+    ).start() as server:
+        port = server.port()
+        nbf = time() - 3600  # became valid an hour ago
+        token = jwt.encode({"access": "ro", "nbf": nbf}, PRIVATE_KEY, algorithm="EdDSA")
+        headers = {
+            "Authorization": f"Bearer {token}",
+        }
+        response = requests.post(
+            raphtory_url(port), headers=headers, data=json.dumps({"query": QUERY_ROOT})
+        )
+        assert_successful_response(response)
+
+
+def test_nbf_and_exp_window():
+    """Combine `nbf` and `exp` to define a validity *window* and check the server
+    honours both ends. The default 60s clock-skew leeway applies to both claims."""
+    work_dir = tempfile.mkdtemp()
+    with GraphServer(
+        work_dir, config={"auth": {"public_key": PUB_KEY}}
+    ).start() as server:
+        port = server.port()
+        now = int(time())
+
+        def read_with(claims):
+            token = jwt.encode(claims, PRIVATE_KEY, algorithm="EdDSA")
+            return requests.post(
+                raphtory_url(port),
+                headers={"Authorization": f"Bearer {token}"},
+                data=json.dumps({"query": QUERY_ROOT}),
+            )
+
+        # Valid for one minute, starting 5s from now: the 5s start is inside the 60s
+        # leeway, so the token is already valid and its exp (65s out) hasn't passed.
+        assert_successful_response(read_with({"access": "ro", "nbf": now + 5, "exp": now + 65}))
+
+        # Same one-minute window, placed an hour ahead (well beyond leeway):
+        # not yet valid -> rejected.
+        assert read_with({"access": "ro", "nbf": now + 3600, "exp": now + 3660}).status_code == 401
+
+        # Same one-minute window, but it closed over a minute ago (beyond leeway):
+        # expired -> rejected.
+        assert read_with({"access": "ro", "nbf": now - 120, "exp": now - 65}).status_code == 401
+
+
 @pytest.mark.parametrize("query", TEST_QUERIES)
 def test_default_read_access(query):
     work_dir = tempfile.mkdtemp()

--- a/python/tests/test_auth.py
+++ b/python/tests/test_auth.py
@@ -174,15 +174,25 @@ def test_nbf_and_exp_window():
 
         # Valid for one minute, starting 5s from now: the 5s start is inside the 60s
         # leeway, so the token is already valid and its exp (65s out) hasn't passed.
-        assert_successful_response(read_with({"access": "ro", "nbf": now + 5, "exp": now + 65}))
+        assert_successful_response(
+            read_with({"access": "ro", "nbf": now + 5, "exp": now + 65})
+        )
 
         # Same one-minute window, placed an hour ahead (well beyond leeway):
         # not yet valid -> rejected.
-        assert read_with({"access": "ro", "nbf": now + 3600, "exp": now + 3660}).status_code == 401
+        assert (
+            read_with(
+                {"access": "ro", "nbf": now + 3600, "exp": now + 3660}
+            ).status_code
+            == 401
+        )
 
         # Same one-minute window, but it closed over a minute ago (beyond leeway):
         # expired -> rejected.
-        assert read_with({"access": "ro", "nbf": now - 120, "exp": now - 65}).status_code == 401
+        assert (
+            read_with({"access": "ro", "nbf": now - 120, "exp": now - 65}).status_code
+            == 401
+        )
 
 
 @pytest.mark.parametrize("query", TEST_QUERIES)

--- a/python/tests/test_base_install/test_loaders/test_load_from_delta.py
+++ b/python/tests/test_base_install/test_loaders/test_load_from_delta.py
@@ -174,7 +174,11 @@ def test_delta_change_column_type(delta_dir):
 
     g = Graph()
     g.load_edges(
-        _reader(DeltaTable(path)), time="time", src="src", dst="dst", properties=["weight"]
+        _reader(DeltaTable(path)),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
     )
     assert g.edge(3, 4)["weight"] == 30
     assert g.edge(1, 2)["weight"] == 10
@@ -238,9 +242,7 @@ def test_delta_incremental_cdf(delta_dir):
 
     # The diff since version 1: exactly one insert and one delete, nothing else.
     changes = (
-        pa.RecordBatchReader.from_stream(
-            DeltaTable(path).load_cdf(starting_version=1)
-        )
+        pa.RecordBatchReader.from_stream(DeltaTable(path).load_cdf(starting_version=1))
         .read_all()
         .to_pandas()
     )

--- a/python/tests/test_base_install/test_loaders/test_load_from_delta.py
+++ b/python/tests/test_base_install/test_loaders/test_load_from_delta.py
@@ -1,0 +1,266 @@
+import os
+import tempfile
+
+import pyarrow as pa
+import pytest
+from raphtory import Graph, PersistentGraph
+
+# deltalake is an optional test dependency; skip the module if it is absent.
+deltalake = pytest.importorskip("deltalake")
+from deltalake import DeltaTable, write_deltalake
+
+
+@pytest.fixture
+def delta_dir():
+    d = tempfile.TemporaryDirectory()
+    yield d.name
+    d.cleanup()
+
+
+def _reader(dt):
+    """Streaming ``pyarrow.RecordBatchReader`` (exposes ``__arrow_c_stream__``)
+    for a Delta table handle, mirroring PyIceberg's ``to_arrow_batch_reader``."""
+    return dt.to_pyarrow_dataset().scanner().to_reader()
+
+
+def edge_tuples(g):
+    return sorted(e.id for e in g.edges)
+
+
+def test_load_from_delta(delta_dir):
+    nodes_path = os.path.join(delta_dir, "nodes")
+    edges_path = os.path.join(delta_dir, "edges")
+
+    write_deltalake(
+        nodes_path,
+        pa.table(
+            {
+                "id": pa.array([1, 2, 3, 4, 5, 6], pa.int64()),
+                "name": pa.array(
+                    ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank"], pa.string()
+                ),
+                "time": pa.array([1, 2, 3, 4, 5, 6], pa.int64()),
+            }
+        ),
+    )
+    write_deltalake(
+        edges_path,
+        pa.table(
+            {
+                "src": pa.array([1, 2, 3, 4, 5], pa.int64()),
+                "dst": pa.array([2, 3, 4, 5, 6], pa.int64()),
+                "time": pa.array([1, 2, 3, 4, 5], pa.int64()),
+                "weight": pa.array([1.0, 2.0, 3.0, 4.0, 5.0], pa.float64()),
+                "marbles": pa.array(
+                    ["red", "blue", "green", "yellow", "purple"], pa.string()
+                ),
+            }
+        ),
+    )
+
+    for graph in (Graph(), PersistentGraph()):
+        graph.load_edges(
+            _reader(DeltaTable(edges_path)),
+            time="time",
+            src="src",
+            dst="dst",
+            properties=["weight", "marbles"],
+        )
+        graph.load_nodes(
+            _reader(DeltaTable(nodes_path)),
+            time="time",
+            id="id",
+            properties=["name"],
+        )
+
+        assert graph.nodes.id.sorted() == [1, 2, 3, 4, 5, 6]
+        edges = [(*e.id, e["weight"], e["marbles"]) for e in graph.edges]
+        edges.sort()
+        assert edges == [
+            (1, 2, 1.0, "red"),
+            (2, 3, 2.0, "blue"),
+            (3, 4, 3.0, "green"),
+            (4, 5, 4.0, "yellow"),
+            (5, 6, 5.0, "purple"),
+        ]
+
+
+def test_delta_add_column(delta_dir):
+    """A new column added in a later Delta version (schema merge) reads back as
+    null for rows written before it existed; time-travel to v0 predates it."""
+    path = os.path.join(delta_dir, "edges")
+
+    write_deltalake(  # version 0
+        path,
+        pa.table(
+            {
+                "src": pa.array([1, 2, 3], pa.int64()),
+                "dst": pa.array([2, 3, 4], pa.int64()),
+                "time": pa.array([1, 2, 3], pa.int64()),
+                "weight": pa.array([1.0, 2.0, 3.0], pa.float64()),
+            }
+        ),
+    )
+    write_deltalake(  # version 1: adds `colour`
+        path,
+        pa.table(
+            {
+                "src": pa.array([4], pa.int64()),
+                "dst": pa.array([5], pa.int64()),
+                "time": pa.array([4], pa.int64()),
+                "weight": pa.array([4.0], pa.float64()),
+                "colour": pa.array(["red"], pa.string()),
+            }
+        ),
+        mode="append",
+        schema_mode="merge",
+    )
+
+    g = Graph()
+    g.load_edges(
+        _reader(DeltaTable(path)),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight", "colour"],
+    )
+    assert g.edge(4, 5)["colour"] == "red"
+    assert g.edge(1, 2)["colour"] is None  # predates the column
+    assert g.edge(1, 2)["weight"] == 1.0
+
+    old = Graph()
+    dt0 = DeltaTable(path)
+    dt0.load_as_version(0)
+    old.load_edges(
+        _reader(dt0), time="time", src="src", dst="dst", properties=["weight"]
+    )
+    assert (4, 5) not in edge_tuples(old)  # the colour row did not exist at v0
+    assert old.edge(1, 2)["weight"] == 1.0
+
+
+def test_delta_change_column_type(delta_dir):
+    """Changing a column's type across Delta versions (overwrite) is fine for a
+    fresh load, time-travel preserves the old type, and feeding both versions
+    into one graph is rejected because Raphtory properties are strongly typed."""
+    path = os.path.join(delta_dir, "edges")
+
+    write_deltalake(  # version 0: weight is int32
+        path,
+        pa.table(
+            {
+                "src": pa.array([1, 2], pa.int64()),
+                "dst": pa.array([2, 3], pa.int64()),
+                "time": pa.array([1, 2], pa.int64()),
+                "weight": pa.array([10, 20], pa.int32()),
+            }
+        ),
+    )
+    assert DeltaTable(path).schema().to_arrow().field("weight").type == pa.int32()
+
+    write_deltalake(  # version 1: weight widened to int64
+        path,
+        pa.table(
+            {
+                "src": pa.array([1, 2, 3], pa.int64()),
+                "dst": pa.array([2, 3, 4], pa.int64()),
+                "time": pa.array([1, 2, 3], pa.int64()),
+                "weight": pa.array([10, 20, 30], pa.int64()),
+            }
+        ),
+        mode="overwrite",
+        schema_mode="overwrite",
+    )
+    assert DeltaTable(path).schema().to_arrow().field("weight").type == pa.int64()
+
+    g = Graph()
+    g.load_edges(
+        _reader(DeltaTable(path)), time="time", src="src", dst="dst", properties=["weight"]
+    )
+    assert g.edge(3, 4)["weight"] == 30
+    assert g.edge(1, 2)["weight"] == 10
+
+    old = Graph()
+    dt0 = DeltaTable(path)
+    dt0.load_as_version(0)
+    old.load_edges(
+        _reader(dt0), time="time", src="src", dst="dst", properties=["weight"]
+    )
+    assert old.edge(1, 2)["weight"] == 10
+
+    # Same graph, both versions: int then long is a type conflict.
+    mixed = Graph()
+    dt0b = DeltaTable(path)
+    dt0b.load_as_version(0)
+    mixed.load_edges(
+        _reader(dt0b), time="time", src="src", dst="dst", properties=["weight"]
+    )
+    with pytest.raises(Exception, match="Wrong type"):
+        mixed.load_edges(
+            _reader(DeltaTable(path)),
+            time="time",
+            src="src",
+            dst="dst",
+            properties=["weight"],
+        )
+
+
+def test_delta_incremental_cdf(delta_dir):
+    """Change Data Feed returns only the rows changed since a given version,
+    tagged by change type, so you can ingest just the diff: inserts feed
+    load_edges and deletes feed load_edge_deletions on a PersistentGraph."""
+    path = os.path.join(delta_dir, "edges")
+
+    write_deltalake(  # version 0 (the baseline, assumed already ingested)
+        path,
+        pa.table(
+            {
+                "src": pa.array([1, 2], pa.int64()),
+                "dst": pa.array([2, 3], pa.int64()),
+                "time": pa.array([1, 2], pa.int64()),
+                "weight": pa.array([1.0, 2.0], pa.float64()),
+            }
+        ),
+        configuration={"delta.enableChangeDataFeed": "true"},
+    )
+    write_deltalake(  # version 1: a new edge is appended
+        path,
+        pa.table(
+            {
+                "src": pa.array([3], pa.int64()),
+                "dst": pa.array([4], pa.int64()),
+                "time": pa.array([3], pa.int64()),
+                "weight": pa.array([3.0], pa.float64()),
+            }
+        ),
+        mode="append",
+    )
+    DeltaTable(path).delete("src = 1")  # version 2: edge (1, 2) is removed
+
+    # The diff since version 1: exactly one insert and one delete, nothing else.
+    changes = (
+        pa.RecordBatchReader.from_stream(
+            DeltaTable(path).load_cdf(starting_version=1)
+        )
+        .read_all()
+        .to_pandas()
+    )
+    inserts = changes[changes["_change_type"] == "insert"]
+    deletes = changes[changes["_change_type"] == "delete"]
+    assert sorted(zip(inserts["src"].tolist(), inserts["dst"].tolist())) == [(3, 4)]
+    assert sorted(zip(deletes["src"].tolist(), deletes["dst"].tolist())) == [(1, 2)]
+
+    # Seed a graph from the baseline, then apply only the diff.
+    g = PersistentGraph()
+    dt0 = DeltaTable(path)
+    dt0.load_as_version(0)
+    g.load_edges(_reader(dt0), time="time", src="src", dst="dst", properties=["weight"])
+    assert sorted(e.id for e in g.edges) == [(1, 2), (2, 3)]
+
+    g.load_edges(inserts, time="time", src="src", dst="dst", properties=["weight"])
+    deletes = deletes.copy()
+    deletes["time"] = 100  # apply the deletion after all existing events
+    g.load_edge_deletions(deletes, time="time", src="src", dst="dst")
+
+    # Before the deletion edge (1, 2) is live; after it, only the survivors remain.
+    assert sorted(e.id for e in g.at(50).edges) == [(1, 2), (2, 3), (3, 4)]
+    assert sorted(e.id for e in g.at(150).edges) == [(2, 3), (3, 4)]

--- a/python/tests/test_base_install/test_loaders/test_load_from_iceberg.py
+++ b/python/tests/test_base_install/test_loaders/test_load_from_iceberg.py
@@ -1,0 +1,407 @@
+import os
+import tempfile
+
+import pyarrow as pa
+import pytest
+from raphtory import Graph, PersistentGraph, PropType
+
+# PyIceberg is an optional test dependency; skip the whole module if it (or its
+# SQL-catalog extra) is not installed rather than erroring on collection.
+pyiceberg = pytest.importorskip("pyiceberg")
+from pyiceberg.catalog.sql import SqlCatalog
+
+
+@pytest.fixture(scope="session")
+def iceberg_tables():
+    """Build a local Iceberg warehouse backed by a SQLite catalog and populate
+    it with a nodes table and an edges table.
+
+    Yields the two loaded ``pyiceberg`` Table handles. Data mirrors the parquet
+    loader fixtures so the assertions are directly comparable.
+    """
+    dirname = tempfile.TemporaryDirectory()
+    warehouse = os.path.join(dirname.name, "warehouse")
+    os.makedirs(warehouse, exist_ok=True)
+
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{os.path.join(warehouse, 'catalog.db')}",
+        warehouse=f"file://{warehouse}",
+    )
+    catalog.create_namespace("raphtory")
+
+    nodes = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4, 5, 6], pa.int64()),
+            "name": pa.array(
+                ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank"], pa.string()
+            ),
+            "time": pa.array([1, 2, 3, 4, 5, 6], pa.int64()),
+        }
+    )
+    nodes_tbl = catalog.create_table("raphtory.nodes", schema=nodes.schema)
+    nodes_tbl.append(nodes)
+
+    edges = pa.table(
+        {
+            "src": pa.array([1, 2, 3, 4, 5], pa.int64()),
+            "dst": pa.array([2, 3, 4, 5, 6], pa.int64()),
+            "time": pa.array([1, 2, 3, 4, 5], pa.int64()),
+            "weight": pa.array([1.0, 2.0, 3.0, 4.0, 5.0], pa.float64()),
+            "marbles": pa.array(
+                ["red", "blue", "green", "yellow", "purple"], pa.string()
+            ),
+        }
+    )
+    edges_tbl = catalog.create_table("raphtory.edges", schema=edges.schema)
+    edges_tbl.append(edges)
+
+    yield nodes_tbl, edges_tbl
+
+    dirname.cleanup()
+
+
+def assert_expected(g):
+    expected_node_ids = [1, 2, 3, 4, 5, 6]
+    expected_nodes = [
+        (1, "Alice"),
+        (2, "Bob"),
+        (3, "Carol"),
+        (4, "Dave"),
+        (5, "Eve"),
+        (6, "Frank"),
+    ]
+    expected_edges = [
+        (1, 2, 1.0, "red"),
+        (2, 3, 2.0, "blue"),
+        (3, 4, 3.0, "green"),
+        (4, 5, 4.0, "yellow"),
+        (5, 6, 5.0, "purple"),
+    ]
+
+    nodes = [(v.id, v["name"]) for v in g.nodes]
+    nodes.sort()
+    edges = [(*e.id, e["weight"], e["marbles"]) for e in g.edges]
+    edges.sort()
+
+    assert g.nodes.id.sorted() == expected_node_ids
+    assert nodes == expected_nodes
+    assert edges == expected_edges
+
+
+def test_load_from_iceberg_batch_reader(iceberg_tables):
+    """Stream an Iceberg scan into a graph via ``to_arrow_batch_reader()``.
+
+    The reader is a ``pyarrow.RecordBatchReader`` exposing ``__arrow_c_stream__``,
+    which is the streaming path Raphtory consumes without materialising the
+    whole scan up front. A fresh scan is issued per load because the reader is
+    single-use.
+    """
+    nodes_tbl, edges_tbl = iceberg_tables
+
+    graph = Graph()
+    graph.load_edges(
+        edges_tbl.scan().to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight", "marbles"],
+    )
+    graph.load_nodes(
+        nodes_tbl.scan().to_arrow_batch_reader(),
+        time="time",
+        id="id",
+        properties=["name"],
+    )
+    assert_expected(graph)
+
+
+def test_load_from_iceberg_to_arrow(iceberg_tables):
+    """Same load using the collecting ``to_arrow()`` path (materialised
+    ``pyarrow.Table``) to confirm both Arrow C-stream producers behave
+    identically at ingest.
+    """
+    nodes_tbl, edges_tbl = iceberg_tables
+
+    g = Graph()
+    g.load_edges(
+        edges_tbl.scan().to_arrow(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight", "marbles"],
+    )
+    g.load_nodes(
+        nodes_tbl.scan().to_arrow(),
+        time="time",
+        id="id",
+        properties=["name"],
+    )
+    assert_expected(g)
+
+
+@pytest.fixture
+def iceberg_catalog():
+    """A fresh, empty Iceberg catalog per test for schema-evolution scenarios."""
+    dirname = tempfile.TemporaryDirectory()
+    warehouse = os.path.join(dirname.name, "warehouse")
+    os.makedirs(warehouse, exist_ok=True)
+
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{os.path.join(warehouse, 'catalog.db')}",
+        warehouse=f"file://{warehouse}",
+    )
+    catalog.create_namespace("raphtory")
+
+    yield catalog
+
+    dirname.cleanup()
+
+
+def edge_tuples(g):
+    return sorted(e.id for e in g.edges)
+
+
+def test_iceberg_add_column(iceberg_catalog):
+    """A column added in a later Iceberg snapshot reads back as null for rows
+    written before it existed; time-travel to the old snapshot predates it."""
+    from pyiceberg.types import StringType
+
+    v0 = pa.table(
+        {
+            "src": pa.array([1, 2, 3], pa.int64()),
+            "dst": pa.array([2, 3, 4], pa.int64()),
+            "time": pa.array([1, 2, 3], pa.int64()),
+            "weight": pa.array([1.0, 2.0, 3.0], pa.float64()),
+        }
+    )
+    tbl = iceberg_catalog.create_table("raphtory.edges", schema=v0.schema)
+    tbl.append(v0)
+    snapshot_v0 = tbl.current_snapshot().snapshot_id
+
+    with tbl.update_schema() as update:
+        update.add_column("colour", StringType())
+    tbl.append(
+        pa.table(
+            {
+                "src": pa.array([4], pa.int64()),
+                "dst": pa.array([5], pa.int64()),
+                "time": pa.array([4], pa.int64()),
+                "weight": pa.array([4.0], pa.float64()),
+                "colour": pa.array(["red"], pa.string()),
+            }
+        )
+    )
+
+    g = Graph()
+    g.load_edges(
+        tbl.scan().to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight", "colour"],
+    )
+    assert g.edge(4, 5)["colour"] == "red"
+    assert g.edge(1, 2)["colour"] is None  # predates the column
+    assert g.edge(1, 2)["weight"] == 1.0
+
+    old = Graph()
+    old.load_edges(
+        tbl.scan(snapshot_id=snapshot_v0).to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+    )
+    assert (4, 5) not in edge_tuples(old)  # the colour row did not exist at v0
+    assert old.edge(1, 2)["weight"] == 1.0
+
+
+def test_iceberg_change_column_type(iceberg_catalog):
+    """Promoting a column's type across Iceberg snapshots (int -> long) is fine
+    for a fresh load, time-travel preserves the old type, and feeding both
+    snapshots into one graph is rejected by Raphtory's typed properties."""
+    from pyiceberg.types import LongType
+
+    v0 = pa.table(
+        {
+            "src": pa.array([1, 2], pa.int64()),
+            "dst": pa.array([2, 3], pa.int64()),
+            "time": pa.array([1, 2], pa.int64()),
+            "weight": pa.array([10, 20], pa.int32()),  # Iceberg `int` (32-bit)
+        }
+    )
+    tbl = iceberg_catalog.create_table("raphtory.edges", schema=v0.schema)
+    tbl.append(v0)
+    snapshot_v0 = tbl.current_snapshot().snapshot_id
+    assert tbl.scan().to_arrow().schema.field("weight").type == pa.int32()
+
+    with tbl.update_schema() as update:
+        update.update_column("weight", field_type=LongType())  # int -> long
+    tbl.append(
+        pa.table(
+            {
+                "src": pa.array([3], pa.int64()),
+                "dst": pa.array([4], pa.int64()),
+                "time": pa.array([3], pa.int64()),
+                "weight": pa.array([30], pa.int64()),
+            }
+        )
+    )
+    assert tbl.scan().to_arrow().schema.field("weight").type == pa.int64()
+
+    g = Graph()
+    g.load_edges(
+        tbl.scan().to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+    )
+    assert g.edge(3, 4)["weight"] == 30
+    assert g.edge(1, 2)["weight"] == 10
+
+    old = Graph()
+    old.load_edges(
+        tbl.scan(snapshot_id=snapshot_v0).to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+    )
+    assert old.edge(1, 2)["weight"] == 10
+
+    # Same graph, both snapshots: int then long is a type conflict.
+    mixed = Graph()
+    mixed.load_edges(
+        tbl.scan(snapshot_id=snapshot_v0).to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+    )
+    with pytest.raises(Exception, match="Wrong type"):
+        mixed.load_edges(
+            tbl.scan().to_arrow_batch_reader(),
+            time="time",
+            src="src",
+            dst="dst",
+            properties=["weight"],
+        )
+
+
+def test_iceberg_schema_reconciles_type_change(iceberg_catalog):
+    """The loader's `schema` option casts columns on ingest, which resolves the
+    cross-version type conflict above: casting both the pre- and post-promotion
+    snapshots to i64 lets them load into a single graph."""
+    from pyiceberg.types import LongType
+
+    v0 = pa.table(
+        {
+            "src": pa.array([1], pa.int64()),
+            "dst": pa.array([2], pa.int64()),
+            "time": pa.array([1], pa.int64()),
+            "weight": pa.array([10], pa.int32()),
+        }
+    )
+    tbl = iceberg_catalog.create_table("raphtory.edges", schema=v0.schema)
+    tbl.append(v0)
+    snapshot_v0 = tbl.current_snapshot().snapshot_id
+
+    with tbl.update_schema() as update:
+        update.update_column("weight", field_type=LongType())
+    tbl.append(
+        pa.table(
+            {
+                "src": pa.array([1], pa.int64()),
+                "dst": pa.array([2], pa.int64()),
+                "time": pa.array([2], pa.int64()),
+                "weight": pa.array([20], pa.int64()),
+            }
+        )
+    )
+
+    g = Graph()
+    # Force both loads to the same property type instead of inferring per batch.
+    g.load_edges(
+        tbl.scan(snapshot_id=snapshot_v0).to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+        schema={"weight": PropType.i64()},
+    )
+    g.load_edges(
+        tbl.scan().to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+        schema={"weight": PropType.i64()},
+    )
+
+    assert g.edge(1, 2).properties.get_dtype_of("weight") == PropType.i64()
+    assert g.edge(1, 2)["weight"] == 20  # latest value across both snapshots
+
+
+def test_iceberg_incremental_by_watermark(iceberg_catalog):
+    """PyIceberg exposes no incremental-scan API, but append-only temporal data
+    can be loaded incrementally with a row filter on the time column: only rows
+    past the last-ingested watermark are scanned (Iceberg prunes files by their
+    min/max stats), so already-loaded rows are not re-read."""
+    from pyiceberg.expressions import GreaterThan
+
+    tbl = iceberg_catalog.create_table(
+        "raphtory.edges",
+        schema=pa.schema(
+            [("src", pa.int64()), ("dst", pa.int64()), ("time", pa.int64()), ("weight", pa.float64())]
+        ),
+    )
+    tbl.append(
+        pa.table(
+            {
+                "src": pa.array([1, 2], pa.int64()),
+                "dst": pa.array([2, 3], pa.int64()),
+                "time": pa.array([1, 2], pa.int64()),
+                "weight": pa.array([1.0, 2.0], pa.float64()),
+            }
+        )
+    )
+
+    g = Graph()
+    g.load_edges(
+        tbl.scan().to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+    )
+    assert sorted(e.id for e in g.edges) == [(1, 2), (2, 3)]
+    watermark = 2  # in practice: persist the max `time` ingested so far
+
+    # New rows land in a later snapshot.
+    tbl.append(
+        pa.table(
+            {
+                "src": pa.array([3, 4], pa.int64()),
+                "dst": pa.array([4, 5], pa.int64()),
+                "time": pa.array([3, 4], pa.int64()),
+                "weight": pa.array([3.0, 4.0], pa.float64()),
+            }
+        )
+    )
+
+    # The filtered scan returns only rows past the watermark, not the whole table.
+    assert sorted(
+        tbl.scan(row_filter=GreaterThan("time", watermark)).to_arrow()["time"].to_pylist()
+    ) == [3, 4]
+
+    g.load_edges(
+        tbl.scan(row_filter=GreaterThan("time", watermark)).to_arrow_batch_reader(),
+        time="time",
+        src="src",
+        dst="dst",
+        properties=["weight"],
+    )
+    assert sorted(e.id for e in g.edges) == [(1, 2), (2, 3), (3, 4), (4, 5)]

--- a/python/tests/test_base_install/test_loaders/test_load_from_iceberg.py
+++ b/python/tests/test_base_install/test_loaders/test_load_from_iceberg.py
@@ -355,7 +355,12 @@ def test_iceberg_incremental_by_watermark(iceberg_catalog):
     tbl = iceberg_catalog.create_table(
         "raphtory.edges",
         schema=pa.schema(
-            [("src", pa.int64()), ("dst", pa.int64()), ("time", pa.int64()), ("weight", pa.float64())]
+            [
+                ("src", pa.int64()),
+                ("dst", pa.int64()),
+                ("time", pa.int64()),
+                ("weight", pa.float64()),
+            ]
         ),
     )
     tbl.append(
@@ -394,7 +399,9 @@ def test_iceberg_incremental_by_watermark(iceberg_catalog):
 
     # The filtered scan returns only rows past the watermark, not the whole table.
     assert sorted(
-        tbl.scan(row_filter=GreaterThan("time", watermark)).to_arrow()["time"].to_pylist()
+        tbl.scan(row_filter=GreaterThan("time", watermark))
+        .to_arrow()["time"]
+        .to_pylist()
     ) == [3, 4]
 
     g.load_edges(

--- a/python/tests/test_base_install/test_loaders/test_load_from_orc.py
+++ b/python/tests/test_base_install/test_loaders/test_load_from_orc.py
@@ -7,6 +7,8 @@ from raphtory import Graph, PersistentGraph
 
 # ORC support ships with pyarrow but requires the ORC-enabled build.
 orc = pytest.importorskip("pyarrow.orc")
+
+
 @pytest.fixture
 def orc_files():
     d = tempfile.TemporaryDirectory()

--- a/python/tests/test_base_install/test_loaders/test_load_from_orc.py
+++ b/python/tests/test_base_install/test_loaders/test_load_from_orc.py
@@ -1,0 +1,85 @@
+import os
+import tempfile
+
+import pyarrow as pa
+import pytest
+from raphtory import Graph, PersistentGraph
+
+# ORC support ships with pyarrow but requires the ORC-enabled build.
+orc = pytest.importorskip("pyarrow.orc")
+@pytest.fixture
+def orc_files():
+    d = tempfile.TemporaryDirectory()
+    nodes_path = os.path.join(d.name, "nodes.orc")
+    edges_path = os.path.join(d.name, "edges.orc")
+
+    orc.write_table(
+        pa.table(
+            {
+                "id": pa.array([1, 2, 3, 4, 5, 6], pa.int64()),
+                "name": pa.array(
+                    ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank"], pa.string()
+                ),
+                "time": pa.array([1, 2, 3, 4, 5, 6], pa.int64()),
+            }
+        ),
+        nodes_path,
+    )
+    orc.write_table(
+        pa.table(
+            {
+                "src": pa.array([1, 2, 3, 4, 5], pa.int64()),
+                "dst": pa.array([2, 3, 4, 5, 6], pa.int64()),
+                "time": pa.array([1, 2, 3, 4, 5], pa.int64()),
+                "weight": pa.array([1.0, 2.0, 3.0, 4.0, 5.0], pa.float64()),
+                "marbles": pa.array(
+                    ["red", "blue", "green", "yellow", "purple"], pa.string()
+                ),
+            }
+        ),
+        edges_path,
+    )
+
+    yield nodes_path, edges_path
+
+    d.cleanup()
+
+
+def test_load_from_orc(orc_files):
+    nodes_path, edges_path = orc_files
+
+    for graph in (Graph(), PersistentGraph()):
+        graph.load_edges(
+            orc.read_table(edges_path),
+            time="time",
+            src="src",
+            dst="dst",
+            properties=["weight", "marbles"],
+        )
+        graph.load_nodes(
+            orc.read_table(nodes_path),
+            time="time",
+            id="id",
+            properties=["name"],
+        )
+
+        assert graph.nodes.id.sorted() == [1, 2, 3, 4, 5, 6]
+        nodes = [(v.id, v["name"]) for v in graph.nodes]
+        nodes.sort()
+        assert nodes == [
+            (1, "Alice"),
+            (2, "Bob"),
+            (3, "Carol"),
+            (4, "Dave"),
+            (5, "Eve"),
+            (6, "Frank"),
+        ]
+        edges = [(*e.id, e["weight"], e["marbles"]) for e in graph.edges]
+        edges.sort()
+        assert edges == [
+            (1, 2, 1.0, "red"),
+            (2, 3, 2.0, "blue"),
+            (3, 4, 3.0, "green"),
+            (4, 5, 4.0, "yellow"),
+            (5, 6, 5.0, "purple"),
+        ]

--- a/raphtory-graphql/src/auth.rs
+++ b/raphtory-graphql/src/auth.rs
@@ -234,6 +234,7 @@ fn extract_claims_from_header(header: &str, public_key: &PublicKey) -> Option<To
         let mut validation = Validation::new(public_key.algorithms[0]);
         validation.algorithms = public_key.algorithms.clone();
         validation.set_required_spec_claims::<String>(&[]); // we don't require 'exp' to be present
+        validation.validate_nbf = true; // reject not-yet-valid tokens (nbf in the future)
         let decoded = decode::<TokenClaims>(&jwt, &public_key.decoding_key, &validation);
         match decoded {
             Ok(token_data) => Some(token_data.claims),

--- a/raphtory-graphql/src/cli.rs
+++ b/raphtory-graphql/src/cli.rs
@@ -5,7 +5,9 @@ use crate::{
         app_config::AppConfigBuilder,
         auth_config::DEFAULT_REQUIRE_AUTH_FOR_READS,
         cache_config::DEFAULT_CACHE_CAPACITY,
-        concurrency_config::{DEFAULT_DISABLE_BATCHING, DEFAULT_EXCLUSIVE_WRITES},
+        concurrency_config::{
+            DEFAULT_DISABLE_BATCHING, DEFAULT_EXCLUSIVE_WRITES, DEFAULT_MAX_BATCH_SIZE,
+        },
         log_config::DEFAULT_LOG_LEVEL,
         otlp_config::{
             TracingLevel, TracingProtocol, DEFAULT_OTLP_TRACING_SERVICE_NAME,
@@ -146,7 +148,7 @@ struct ServerArgs {
     #[arg(
         long,
         env = "RAPHTORY_MAX_BATCH_SIZE",
-        help = "Caps the number of queries accepted in a single batched HTTP request. Requests whose batch exceeds this size are rejected."
+        help = help_with_default!("Caps the number of queries accepted in a single batched HTTP request. Requests whose batch exceeds this size are rejected.", DEFAULT_MAX_BATCH_SIZE)
     )]
     max_batch_size: Option<usize>,
 

--- a/raphtory-graphql/src/config/concurrency_config.rs
+++ b/raphtory-graphql/src/config/concurrency_config.rs
@@ -4,9 +4,13 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_EXCLUSIVE_WRITES: bool = false;
 pub const DEFAULT_DISABLE_BATCHING: bool = false;
 pub const DEFAULT_DISABLE_LISTS: bool = false;
+/// Default cap on the number of queries accepted in a single batched HTTP request.
+/// Chosen to comfortably cover legitimate batching while preventing a single request
+/// from amplifying its computational cost without bound (see `max_batch_size`).
+pub const DEFAULT_MAX_BATCH_SIZE: usize = 10;
 
 /// Controls how Raphtory schedules concurrent GraphQL work.
-#[derive(Debug, Default, Deserialize, PartialEq, Clone, Serialize, FieldName)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Serialize, FieldName)]
 pub struct ConcurrencyConfig {
     /// Restricts how many expensive graph traversal queries can execute simultaneously.
     /// Covers operations like connected components, edge traversals, and neighbour lookups
@@ -25,8 +29,9 @@ pub struct ConcurrencyConfig {
     pub disable_batching: bool,
 
     /// Caps the number of queries accepted in a single batched HTTP request. Requests
-    /// whose batch exceeds this size are rejected. `None` means unlimited (subject to
-    /// `disable_batching`).
+    /// whose batch exceeds this size are rejected. Defaults to `DEFAULT_MAX_BATCH_SIZE`
+    /// so deployments are bounded out-of-the-box; set to `None` for unlimited (subject
+    /// to `disable_batching`).
     pub max_batch_size: Option<usize>,
 
     /// When true, completely disables bulk list endpoints (e.g. `list` on a collection).
@@ -38,4 +43,17 @@ pub struct ConcurrencyConfig {
     /// of `page` so clients can't circumvent `disable_lists` by requesting huge pages.
     /// `None` means unlimited.
     pub max_page_size: Option<usize>,
+}
+
+impl Default for ConcurrencyConfig {
+    fn default() -> Self {
+        Self {
+            heavy_query_limit: None,
+            exclusive_writes: DEFAULT_EXCLUSIVE_WRITES,
+            disable_batching: DEFAULT_DISABLE_BATCHING,
+            max_batch_size: Some(DEFAULT_MAX_BATCH_SIZE),
+            disable_lists: DEFAULT_DISABLE_LISTS,
+            max_page_size: None,
+        }
+    }
 }

--- a/raphtory-graphql/src/python/server/server.rs
+++ b/raphtory-graphql/src/python/server/server.rs
@@ -46,7 +46,7 @@ use std::{io::Error, path::PathBuf, thread, time::Duration};
 ///     heavy_query_limit (int, optional): Maximum number of expensive traversal queries (outComponent, inComponent, edges, outEdges, inEdges, neighbours, outNeighbours, inNeighbours) allowed to run simultaneously. Extra queries are parked on a semaphore.
 ///     exclusive_writes (bool, optional): If True, ingestion/write operations run one at a time and block reads until complete.
 ///     disable_batching (bool, optional): If True, batched GraphQL requests are rejected. Prevents bypassing per-request depth/complexity limits.
-///     max_batch_size (int, optional): Caps the number of queries accepted in a single batched request.
+///     max_batch_size (int, optional): Caps the number of queries accepted in a single batched request. Defaults to 10; set to null for unlimited (subject to disable_batching).
 ///     disable_lists (bool, optional): If True, bulk `list` endpoints on collections are disabled. Clients must use `page` instead.
 ///     max_page_size (int, optional): Maximum page size allowed on paged collection queries.
 ///     max_query_depth (int, optional): Maximum nesting depth of a query.

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -538,6 +538,89 @@ mod server_tests {
         running.stop().await
     }
 
+    // Builds a GraphQL batch request body containing `n` trivial queries.
+    fn batch_body(n: usize) -> String {
+        let queries = std::iter::repeat(r#"{"query":"{__typename}"}"#)
+            .take(n)
+            .collect::<Vec<_>>()
+            .join(",");
+        format!("[{queries}]")
+    }
+
+    async fn post_batch(port: u16, n: usize) -> reqwest::StatusCode {
+        reqwest::Client::new()
+            .post(format!("http://localhost:{port}/"))
+            .header("content-type", "application/json")
+            .body(batch_body(n))
+            .send()
+            .await
+            .unwrap()
+            .status()
+    }
+
+    // Regression test for the batch-amplification DoS: a single HTTP request must not
+    // be able to smuggle an unbounded number of GraphQL operations past request-level
+    // throttling. Verifies both the secure default cap and an explicit override.
+    #[tokio::test]
+    async fn test_batch_size_limit_enforced() {
+        let work_dir = tempdir().unwrap();
+        // Default config: max_batch_size defaults to 10.
+        let server = GraphServer::new(work_dir.path().to_path_buf(), None, Config::default())
+            .await
+            .unwrap();
+        let running = server.start_with_port(0).await.unwrap();
+        let port = running.port();
+
+        // At the default cap: allowed.
+        assert_eq!(post_batch(port, 10).await, reqwest::StatusCode::OK);
+        // One over the default cap: rejected.
+        assert_eq!(
+            post_batch(port, 11).await,
+            reqwest::StatusCode::BAD_REQUEST
+        );
+        running.stop().await;
+
+        // Explicit lower cap is honoured.
+        let work_dir = tempdir().unwrap();
+        let app_config = AppConfigBuilder::new().with_max_batch_size(Some(2)).build();
+        let server = GraphServer::new(
+            work_dir.path().to_path_buf(),
+            Some(app_config),
+            Config::default(),
+        )
+        .await
+        .unwrap();
+        let running = server.start_with_port(0).await.unwrap();
+        let port = running.port();
+
+        assert_eq!(post_batch(port, 2).await, reqwest::StatusCode::OK);
+        assert_eq!(post_batch(port, 3).await, reqwest::StatusCode::BAD_REQUEST);
+        running.stop().await;
+
+        // A single (non-batched) query is never treated as a batch and is unaffected.
+        let work_dir = tempdir().unwrap();
+        let app_config = AppConfigBuilder::new().with_max_batch_size(Some(2)).build();
+        let server = GraphServer::new(
+            work_dir.path().to_path_buf(),
+            Some(app_config),
+            Config::default(),
+        )
+        .await
+        .unwrap();
+        let running = server.start_with_port(0).await.unwrap();
+        let port = running.port();
+        let status = reqwest::Client::new()
+            .post(format!("http://localhost:{}/", port))
+            .header("content-type", "application/json")
+            .body(r#"{"query":"{__typename}"}"#)
+            .send()
+            .await
+            .unwrap()
+            .status();
+        assert_eq!(status, reqwest::StatusCode::OK);
+        running.stop().await;
+    }
+
     #[tokio::test]
     async fn test_server_start_stop() {
         global_info_logger();

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -581,10 +581,7 @@ mod server_tests {
         // At the default cap: allowed.
         assert_eq!(post_batch(port, 10).await, reqwest::StatusCode::OK);
         // One over the default cap: rejected.
-        assert_eq!(
-            post_batch(port, 11).await,
-            reqwest::StatusCode::BAD_REQUEST
-        );
+        assert_eq!(post_batch(port, 11).await, reqwest::StatusCode::BAD_REQUEST);
         running.stop().await;
 
         // Explicit lower cap is honoured.

--- a/raphtory-graphql/tests/open_telemetry.rs
+++ b/raphtory-graphql/tests/open_telemetry.rs
@@ -1,12 +1,16 @@
 // OpenTelemetry Tests must be separated into their own binary to prevent polluting other tests since the span and log exporters are set globally.
-use raphtory::db::api::storage::storage::Config;
-use raphtory::prelude::{Graph, StableEncode};
-use raphtory_graphql::client::raphtory_client::RaphtoryGraphQLClient;
-use raphtory_graphql::config::{
-    app_config::AppConfigBuilder,
-    otlp_config::{TracingLevel, TracingProtocol, GLOBAL_EXPORTERS},
+use raphtory::{
+    db::api::storage::storage::Config,
+    prelude::{Graph, StableEncode},
 };
-use raphtory_graphql::server::{GraphServer, RunningGraphServer};
+use raphtory_graphql::{
+    client::raphtory_client::RaphtoryGraphQLClient,
+    config::{
+        app_config::AppConfigBuilder,
+        otlp_config::{TracingLevel, TracingProtocol, GLOBAL_EXPORTERS},
+    },
+    server::{GraphServer, RunningGraphServer},
+};
 use std::collections::{HashMap, HashSet};
 use tempfile::{tempdir, TempDir};
 use url::Url;

--- a/raphtory-graphql/tests/open_telemetry_e2e.rs
+++ b/raphtory-graphql/tests/open_telemetry_e2e.rs
@@ -1,14 +1,20 @@
 use mock_collector::{MockServer, Protocol};
-use raphtory::db::api::storage::storage::Config;
-use raphtory::prelude::{Graph, StableEncode};
-use raphtory_graphql::client::raphtory_client::RaphtoryGraphQLClient;
-use raphtory_graphql::config::{
-    app_config::AppConfigBuilder,
-    otlp_config::{TracingLevel, TracingProtocol},
+use raphtory::{
+    db::api::storage::storage::Config,
+    prelude::{Graph, StableEncode},
 };
-use raphtory_graphql::server::GraphServer;
-use std::collections::{HashMap, HashSet};
-use std::time::Duration;
+use raphtory_graphql::{
+    client::raphtory_client::RaphtoryGraphQLClient,
+    config::{
+        app_config::AppConfigBuilder,
+        otlp_config::{TracingLevel, TracingProtocol},
+    },
+    server::GraphServer,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 use tempfile::tempdir;
 use url::Url;
 


### PR DESCRIPTION
## Small security fixes + test coverage

A small batch of security-hardening fixes to `raphtory-graphql`, plus new test coverage for auth and the datalake loaders. Three independent changes, each with tests.

### 1. Fix: RBAC was ignoring the JWT `nbf` (not-before) claim

JWT validation never enabled the not-before check, so a token stamped with an `nbf` in the future was accepted immediately instead of being rejected until it became valid — defeating not-before scheduling for issued tokens. Validation now enforces `nbf`, and new auth tests cover a future-`nbf` token being rejected, a past-`nbf` token being accepted, and a combined `nbf`/`exp` validity window (valid inside, rejected before and after).

### 2. Harden: bounded default batch size

`max_batch_size` previously defaulted to unlimited, so a single HTTP request could smuggle an unbounded number of GraphQL operations past request-level throttling — a batch-amplification DoS vector. It now defaults to a sensible bound (10), so deployments are limited out-of-the-box, with unlimited still available as an explicit opt-out. The CLI help surfaces the new default, and a regression test verifies the default cap, an explicit lower cap, and that a single non-batched query is never treated as a batch.

### 3. Tests: datalake format loaders

Adds Python test coverage for the datalake ingestion paths (Delta, Iceberg, and ORC), along with the dev dependencies needed to exercise them. No production code change.
