### PR TITLE
Optimise node id filters when used as graph view

### DIFF
--- a/raphtory/src/db/graph/views/filter/node_filtered_graph.rs
+++ b/raphtory/src/db/graph/views/filter/node_filtered_graph.rs
@@ -5,9 +5,10 @@ use crate::{
         },
         state::ops::NodeFilterOp,
         view::internal::{
-            Immutable, InheritAllEdgeFilterOps, InheritEdgeHistoryFilter, InheritLayerOps,
-            InheritListOps, InheritMaterialize, InheritNodeHistoryFilter, InheritStorageOps,
-            InheritTimeSemantics, InternalNodeFilterOps, Static,
+            EdgeList, GraphView, Immutable, InheritAllEdgeFilterOps, InheritEdgeHistoryFilter,
+            InheritLayerOps, InheritListOps, InheritMaterialize, InheritNodeHistoryFilter,
+            InheritStorageOps, InheritTimeSemantics, InternalNodeFilterOps, ListOps, NodeList,
+            Static,
         },
     },
     prelude::GraphViewOps,
@@ -50,7 +51,6 @@ impl<'graph, G: GraphViewOps<'graph>, F: NodeFilterOp> InheritStorageOps
 {
 }
 impl<'graph, G: GraphViewOps<'graph>, F: NodeFilterOp> InheritLayerOps for NodeFilteredGraph<G, F> {}
-impl<'graph, G: GraphViewOps<'graph>, F: NodeFilterOp> InheritListOps for NodeFilteredGraph<G, F> {}
 impl<'graph, G: GraphViewOps<'graph>, F: NodeFilterOp> InheritMaterialize
     for NodeFilteredGraph<G, F>
 {
@@ -95,5 +95,22 @@ impl<'graph, G: GraphViewOps<'graph>, F: NodeFilterOp> InternalNodeFilterOps
     fn internal_filter_node(&self, node: NodeStorageRef, layer_ids: &LayerIds) -> bool {
         self.graph.internal_filter_node(node, layer_ids)
             && self.filter.apply(self.graph.core_graph(), node.vid())
+    }
+
+    fn internal_node_list_trusted(&self) -> bool {
+        self.graph.internal_node_list_trusted()
+            && self.filter.const_value_in_domain().is_some_and(|v| v)
+    }
+}
+
+impl<G: GraphView, F: NodeFilterOp> ListOps for NodeFilteredGraph<G, F> {
+    fn node_list(&self) -> NodeList {
+        self.filter
+            .domain(self.graph.core_graph())
+            .intersection(&self.graph.node_list())
+    }
+
+    fn edge_list(&self) -> EdgeList {
+        self.graph.edge_list()
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`NodeFilteredGraph` was not calling the `domain` on the filter when computing the node list, resulting in sub-optimal traversals when using node id filters as a graph view.

### Why are the changes needed?

performance

### Does this PR introduce any user-facing change? If yes is this documented?

no

### How was this patch tested?

### Are there any further changes required?


