### PR TITLE
graphql: flush mutations rewrite the metadata counts sidecar

### DIFF
--- a/raphtory-graphql/src/cache.rs
+++ b/raphtory-graphql/src/cache.rs
@@ -8,7 +8,6 @@ use quick_cache::{
     sync::{Cache, EntryAction, EntryResult},
     DefaultHashBuilder, Lifecycle, UnitWeighter,
 };
-use raphtory::prelude::AdditionOps;
 use std::future::Future;
 use tracing::{debug, error};
 
@@ -16,16 +15,9 @@ use tracing::{debug, error};
 pub struct ArcPinned;
 
 fn flush_graph(val: GraphWithVectors) -> () {
-    val.set_flushing(true);
-    val.set_dirty(false); // make sure this is reset before the flush so any mutation that gets triggered afterwards will set the graph back to dirty
-    let graph = val.graph();
-    if let Err(e) = graph.flush() {
+    if let Err(e) = val.persist() {
         error!("Failed to flush graph {}: {e}", val.folder().local_path())
     }
-    if let Err(e) = val.folder().replace_graph_data(graph.clone()) {
-        error!("Failed to write graph {}: {e}", val.folder().local_path())
-    }
-    val.set_flushing(false);
 }
 
 impl Lifecycle<String, GraphWithVectors> for ArcPinned {

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -981,6 +981,77 @@ pub(crate) mod data_tests {
         }
     }
 
+    /// After remote-style mutations, an explicit persist must rewrite the
+    /// metadata sidecar so cache-miss namespace listings report true counts.
+    #[tokio::test]
+    async fn test_persist_refreshes_metadata_sidecar_counts() {
+        use crate::paths::ExistingGraphFolder;
+
+        let tmp_work_dir = tempfile::tempdir().unwrap();
+        let data = Data::new(tmp_work_dir.path(), &Default::default(), Default::default());
+
+        // A fresh empty graph — its sidecar starts at 0 nodes / 0 edges.
+        let path = "people";
+        let folder = data
+            .work_dir_write()
+            .await
+            .validate_path_for_insert(path, false)
+            .unwrap();
+        let empty: MaterializedGraph = Graph::new().into();
+        data.insert_graph(folder, empty).await.unwrap();
+
+        // Remote-style mutations against the resident graph, without touching the sidecar.
+        let graph = data.get_graph_for_test(path).await.unwrap();
+        graph.add_edge(0, "a", "b", NO_PROPS, None).unwrap();
+        graph.add_node(0, "c", NO_PROPS, None, None).unwrap();
+        graph.set_dirty(true);
+
+        graph.persist().unwrap();
+
+        // The persisted sidecar (what cache-miss listings read) must reflect the writes.
+        let read_folder = ExistingGraphFolder::try_from(data.work_dir_read().await, path).unwrap();
+        let meta = read_folder.graph_folder().read_metadata().unwrap();
+        assert_eq!(meta.node_count, 3, "sidecar node_count stale after persist");
+        assert_eq!(meta.edge_count, 1, "sidecar edge_count stale after persist");
+    }
+
+    /// Eviction (here via `flush_and_clear`) must also persist true counts —
+    /// regression guard now that eviction and explicit flush share `persist`.
+    #[tokio::test]
+    async fn test_eviction_persists_metadata_sidecar_counts() {
+        use crate::paths::ExistingGraphFolder;
+
+        let tmp_work_dir = tempfile::tempdir().unwrap();
+        let data = Data::new(tmp_work_dir.path(), &Default::default(), Default::default());
+
+        let path = "people";
+        let folder = data
+            .work_dir_write()
+            .await
+            .validate_path_for_insert(path, false)
+            .unwrap();
+        let empty: MaterializedGraph = Graph::new().into();
+        data.insert_graph(folder, empty).await.unwrap();
+
+        let graph = data.get_graph_for_test(path).await.unwrap();
+        graph.add_edge(0, "a", "b", NO_PROPS, None).unwrap();
+        graph.set_dirty(true);
+        drop(graph);
+
+        data.cache.flush_and_clear();
+
+        let read_folder = ExistingGraphFolder::try_from(data.work_dir_read().await, path).unwrap();
+        let meta = read_folder.graph_folder().read_metadata().unwrap();
+        assert_eq!(
+            meta.node_count, 2,
+            "sidecar node_count stale after eviction"
+        );
+        assert_eq!(
+            meta.edge_count, 1,
+            "sidecar edge_count stale after eviction"
+        );
+    }
+
     #[tokio::test]
     async fn test_eviction() {
         let tmp_work_dir = tempfile::tempdir().unwrap();

--- a/raphtory-graphql/src/graph.rs
+++ b/raphtory-graphql/src/graph.rs
@@ -21,7 +21,7 @@ use raphtory::{
         graph::{edge::EdgeView, node::NodeView},
     },
     errors::{GraphError, GraphResult},
-    prelude::{EdgeViewOps, StableDecode},
+    prelude::{AdditionOps, EdgeViewOps, StableDecode},
 };
 use raphtory_api::core::storage::graph_folder::GraphPaths;
 use raphtory_storage::{
@@ -124,6 +124,24 @@ impl GraphWithVectors {
 
     pub fn ref_count(&self) -> usize {
         Arc::strong_count(&self.inner)
+    }
+
+    /// Flush in-memory writes to the storage engine and rewrite the on-disk
+    /// metadata sidecar, so cache-miss namespace listings report accurate
+    /// counts. The dirty flag is cleared up front so a mutation racing the
+    /// flush re-marks the graph dirty. Both steps are attempted independently
+    /// and the first error is returned; callers decide whether a failure
+    /// should re-mark the graph dirty for a later retry.
+    pub fn persist(&self) -> Result<(), GraphError> {
+        self.set_flushing(true);
+        self.set_dirty(false);
+        let flushed = self.graph().flush();
+        let written = self
+            .folder()
+            .replace_graph_data(self.graph().clone())
+            .map_err(|e| GraphError::ExternalError(Arc::new(e)));
+        self.set_flushing(false);
+        flushed.and(written)
     }
 
     /// Generates and stores embeddings for a batch of nodes.

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -3134,4 +3134,64 @@ mod graphql_test {
         assert_eq!(res.errors, vec![], "flush mutation returned errors");
         assert_eq!(res.data.into_json().unwrap(), json!({"flush": true}));
     }
+
+    /// End-to-end reproduction of the stale namespace-listing counts bug:
+    /// create a graph, populate it, and flush — all over GraphQL — then read
+    /// the listing from a cold-cache session (as after a server restart),
+    /// which resolves `nodeCount`/`edgeCount` from the persisted sidecar.
+    /// Before the fix, `updateGraph{ flush }` never rewrote the sidecar, so
+    /// this reported 0/0.
+    #[tokio::test]
+    async fn test_namespace_listing_counts_after_flush() {
+        use crate::test_support::{run_mutation, setup_with_graphs};
+
+        let work_dir = tempdir().unwrap();
+
+        let session = setup_with_graphs(&[], work_dir.path()).await;
+
+        // Graph lives inside the `people` namespace so we can list it below.
+        let created = run_mutation(
+            &session.schema,
+            r#"mutation { newGraph(path: "people/g", graphType: EVENT) }"#,
+        )
+        .await;
+        assert_eq!(created.errors, vec![], "newGraph errored");
+
+        // `updateGraph` is a side-effecting field on the query root.
+        // `addEdge` implicitly creates both endpoints: 2 nodes, 1 edge.
+        let written = run_mutation(
+            &session.schema,
+            r#"query { updateGraph(path: "people/g") { addEdge(time: 0, src: "a", dst: "b") { success } } }"#,
+        )
+        .await;
+        assert_eq!(written.errors, vec![], "addEdge errored");
+
+        // Separate request so `flush` is ordered after the writes.
+        let flushed = run_mutation(
+            &session.schema,
+            r#"query { updateGraph(path: "people/g") { flush } }"#,
+        )
+        .await;
+        assert_eq!(flushed.errors, vec![], "flush errored");
+
+        // Fresh session over the same work dir → cold cache, so the listing
+        // reads counts from the persisted sidecar (the bug surface).
+        let restarted = setup_with_graphs(&[], work_dir.path()).await;
+        let listed = restarted
+            .schema
+            .execute(Request::new(
+                r#"query { namespace(path: "people") { graphs { list { nodeCount edgeCount } } } }"#,
+            ))
+            .await;
+        assert_eq!(listed.errors, vec![], "namespace listing errored");
+
+        let json = listed.data.into_json().unwrap();
+        let row = &json["namespace"]["graphs"]["list"][0];
+        assert_eq!(row["nodeCount"], 2, "listing nodeCount stale after flush");
+        assert_eq!(row["edgeCount"], 1, "listing edgeCount stale after flush");
+
+        // Keep session 1 alive past the assertion: its `Drop` runs
+        // `flush_and_clear`, which would rewrite the sidecar and mask the bug.
+        drop(session);
+    }
 }

--- a/raphtory-graphql/src/model/graph/mutable_graph.rs
+++ b/raphtory-graphql/src/model/graph/mutable_graph.rs
@@ -524,13 +524,10 @@ impl GqlMutableGraph {
     async fn flush(&self) -> Result<bool, GraphError> {
         let self_clone = self.clone();
         blocking_write(move || {
-            self_clone.graph.set_flushing(true);
-            self_clone.graph.set_dirty(false);
-            let res = self_clone.graph.graph().flush();
+            let res = self_clone.graph.persist();
             if res.is_err() {
-                self_clone.graph.set_dirty(true)
+                self_clone.graph.set_dirty(true);
             }
-            self_clone.graph.set_flushing(false);
             res.map(|_| true)
         })
         .await

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         },
     },
     paths::{ExistingGraphFolder, ValidGraphPaths, ValidWriteableGraphFolder},
-    rayon::blocking_compute,
+    rayon::{blocking_compute, blocking_write},
     url_encode::{url_decode_graph_at, url_encode_graph},
 };
 use async_graphql::Context;
@@ -873,10 +873,15 @@ impl Mut {
         let data = ctx.data_unchecked::<Data>();
         let graph = data
             .get_graph_with_write_permission(ctx, &graph_path)
-            .await?
-            .graph()
-            .clone();
-        graph.flush()?;
+            .await?;
+        blocking_write(move || {
+            let res = graph.persist();
+            if res.is_err() {
+                graph.set_dirty(true);
+            }
+            res
+        })
+        .await?;
         Ok(true)
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

There was a bug where when calling updateGraph would not update the metadata

Both flush entry points — `updateGraph{ flush }` and the root `flush(graphPath:)` — flushed the storage engine but never rewrote the metadata file, and by clearing the dirty flag they disarmed the eviction path that otherwise would have. The metadata stayed frozen at the creation-time 0/0, so cache-miss namespace listings reported nodeCount/edgeCount 0 while the same row's lastUpdated and metadata were fresh.

Extract the flush-and-persist sequence into `GraphWithVectors::persist` (engine flush + `replace_graph_data`, both attempted, first error returned) and route the eviction-time `cache::flush_graph` and both flush mutations through it. Each caller keeps its own dirty-on-error policy, so the eviction/shutdown behaviour is unchanged; the only behavioural change is that the flush mutations now write the .meta file.

The new persist method does not call set_dirty on errors because flush_graph does not do so on errors, while flush does.

This was apparently also fixed in disk graph by arien? But it does seem to be present in OS raphtory, as the e2e test fails in `db_v4` right now

### Why are the changes needed?

There was a bug where when calling updateGraph would not update the metadata

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

Some unit tests and one e2e test testing newGraph and updateGraph actually update the metadata

### Are there any further changes required?

For newGraph and updateGraph since the e2e test verifies their behavior now there shouldn't be...