### PR TITLE
Make graph loaders take a DataSource which can be a local path or a multipart upload

### DIFF
--- a/docs/reference/graphql/graphql_API.md
+++ b/docs/reference/graphql/graphql_API.md
@@ -4490,6 +4490,16 @@ int:
 </td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong id="metagraph.graphtype">graphType</strong></td>
+<td valign="top"><a href="#graphtype">GraphType</a>!</td>
+<td>
+
+Whether the stored graph carries event or persistent semantics.
+Served from the cached metadata, so it costs no graph load.
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong id="metagraph.metadata">metadata</strong></td>
 <td valign="top">[<a href="#property">Property</a>!]!</td>
 <td>

--- a/docs/reference/graphql/graphql_API.md
+++ b/docs/reference/graphql/graphql_API.md
@@ -297,11 +297,11 @@ Graph path relative to the root namespace.
 </td>
 </tr>
 <tr>
-<td colspan="2" align="right" valign="top">dataPath</td>
-<td valign="top"><a href="#string">String</a>!</td>
+<td colspan="2" align="right" valign="top">dataSource</td>
+<td valign="top"><a href="#datasource">DataSource</a>!</td>
 <td>
 
-Path to the parquet directory.
+Where to read the parquet from: a server path or an upload.
 
 </td>
 </tr>
@@ -414,11 +414,11 @@ Graph path relative to the root namespace.
 </td>
 </tr>
 <tr>
-<td colspan="2" align="right" valign="top">dataPath</td>
-<td valign="top"><a href="#string">String</a>!</td>
+<td colspan="2" align="right" valign="top">dataSource</td>
+<td valign="top"><a href="#datasource">DataSource</a>!</td>
 <td>
 
-Path to the parquet directory.
+Where to read the parquet from: a server path or an upload.
 
 </td>
 </tr>
@@ -8368,6 +8368,41 @@ Optional `{start, end}` to restrict matches to edges active in that interval.
 </table>
 
 ## Inputs
+
+### DataSource
+
+Where a loader reads its parquet from: a directory already on the server, or
+data supplied with the request.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong id="datasource.path">path</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Path to a parquet directory on the server. Subject to the parquet allowlist.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="datasource.upload">upload</strong></td>
+<td valign="top"><a href="#upload">Upload</a></td>
+<td>
+
+Multipart upload of a single parquet file.
+
+</td>
+</tr>
+</tbody>
+</table>
 
 ### DegreeFilterNew
 

--- a/python/python/raphtory/__init__.pyi
+++ b/python/python/raphtory/__init__.pyi
@@ -1086,7 +1086,9 @@ class Graph(GraphView):
 
     @staticmethod
     def load(
-        path: str | PathLike, config: Optional[Config] = None, read_only: bool = False
+        path: str | PathLike,
+        config: Optional[Config] = None,
+        read_only: Optional[bool] = False,
     ) -> Graph:
         """
         Load a disk graph from path
@@ -1095,9 +1097,9 @@ class Graph(GraphView):
             path (str | PathLike): the path of the graph folder
             config (Config, optional): specify a new config to override the values saved for the graph
                                        (note that the page sizes cannot be overridden and are ignored)
-            read_only (bool): open as a read-only snapshot. Multiple processes can hold
+            read_only (bool, optional): open as a read-only snapshot. Multiple processes can hold
                               a read-only handle to the same graph directory concurrently;
-                              mutating the returned graph will fail. Defaults to ``False``.
+                              mutating the returned graph will fail. Defaults to False.
 
         Returns:
             Graph: the graph
@@ -1733,7 +1735,9 @@ class PersistentGraph(GraphView):
 
     @staticmethod
     def load(
-        path: str | PathLike, config: Optional[Config] = None, read_only: bool = False
+        path: str | PathLike,
+        config: Optional[Config] = None,
+        read_only: Optional[bool] = False,
     ) -> PersistentGraph:
         """
         Load a disk graph from path
@@ -1742,9 +1746,9 @@ class PersistentGraph(GraphView):
             path (str | PathLike): the path of the graph folder
             config (Config, optional): specify a new config to override the values saved for the graph
                                        (note that the page sizes cannot be overridden and are ignored)
-            read_only (bool): open as a read-only snapshot. Multiple processes can hold
+            read_only (bool, optional): open as a read-only snapshot. Multiple processes can hold
                               a read-only handle to the same graph directory concurrently;
-                              mutating the returned graph will fail. Defaults to ``False``.
+                              mutating the returned graph will fail. Defaults to False.
 
         Returns:
             PersistentGraph: the graph
@@ -5831,7 +5835,18 @@ class PyPropValueList(object):
     def __repr__(self):
         """Return repr(self)."""
 
-    def arrow_compute(self, graph, col_name): ...
+    def arrow_compute(self, graph: GraphView, col_name: str) -> OutputNodeState:
+        """
+        Compute a node state from these property values using an arrow compute kernel.
+
+        Arguments:
+            graph (GraphView): the graph the property values belong to.
+            col_name (str): the property column name to compute over.
+
+        Returns:
+            OutputNodeState: the computed node state.
+        """
+
     def average(self) -> PropValue:
         """
         Compute the average of all property values. Alias for mean().

--- a/python/python/raphtory/filter/__init__.pyi
+++ b/python/python/raphtory/filter/__init__.pyi
@@ -342,12 +342,12 @@ class Node(object):
         """
 
     @staticmethod
-    def degree():
+    def degree() -> filter.FilterOps:
         """
         Selects total node degree for filtering.
 
         Returns:
-            filter.FilterOps
+            filter.FilterOps: a builder that selects the node degree for filtering.
         """
 
     @staticmethod
@@ -360,12 +360,12 @@ class Node(object):
         """
 
     @staticmethod
-    def in_degree():
+    def in_degree() -> filter.FilterOps:
         """
         Selects incoming node degree for filtering.
 
         Returns:
-            filter.FilterOps
+            filter.FilterOps: a builder that selects the node degree for filtering.
         """
 
     @staticmethod
@@ -443,12 +443,12 @@ class Node(object):
         """
 
     @staticmethod
-    def out_degree():
+    def out_degree() -> filter.FilterOps:
         """
         Selects outgoing node degree for filtering.
 
         Returns:
-            filter.FilterOps
+            filter.FilterOps: a builder that selects the node degree for filtering.
         """
 
     @staticmethod

--- a/python/python/raphtory/graphql/__init__.pyi
+++ b/python/python/raphtory/graphql/__init__.pyi
@@ -57,30 +57,9 @@ class GraphServer(object):
 
     Arguments:
         work_dir (str | PathLike): the working directory for the server
-        cache_capacity (int, optional): the maximum number of graphs to keep in memory at once
-        cache_tti_seconds (int, optional): the inactive time in seconds after which a graph is evicted from the cache
-        log_level (str, optional): the log level for the server
-        tracing (bool, optional): whether tracing should be enabled
-        tracing_level (str, optional): tracing verbosity (e.g. "ERROR", "WARN", "INFO", "DEBUG", "TRACE").
-        otlp_agent_host (str, optional): OTLP agent host for tracing
-        otlp_agent_port(str, optional): OTLP agent port for tracing
-        otlp_tracing_service_name (str, optional): The OTLP tracing service name
-        config_path (str | PathLike, optional): Path to the config file
-        auth_public_key (str, optional): Base64-encoded public key used to verify bearer tokens
-        require_auth_for_reads (bool, optional): Require auth tokens for read queries
-        create_index (bool, optional): Build a search index on startup
-        heavy_query_limit (int, optional): Maximum number of expensive traversal queries (outComponent, inComponent, edges, outEdges, inEdges, neighbours, outNeighbours, inNeighbours) allowed to run simultaneously. Extra queries are parked on a semaphore.
-        exclusive_writes (bool, optional): If True, ingestion/write operations run one at a time and block reads until complete.
-        disable_batching (bool, optional): If True, batched GraphQL requests are rejected. Prevents bypassing per-request depth/complexity limits.
-        max_batch_size (int, optional): Caps the number of queries accepted in a single batched request. Defaults to 10; set to null for unlimited (subject to disable_batching).
-        disable_lists (bool, optional): If True, bulk `list` endpoints on collections are disabled. Clients must use `page` instead.
-        max_page_size (int, optional): Maximum page size allowed on paged collection queries.
-        max_query_depth (int, optional): Maximum nesting depth of a query.
-        max_query_complexity (int, optional): Maximum estimated cost of a query, based on the number of fields selected.
-        max_recursive_depth (int, optional): Internal safety limit to prevent stack overflows from pathologically structured queries (async-graphql default is 32).
-        max_directives_per_field (int, optional): Maximum number of directives on any single field.
-        disable_introspection (bool, optional): If True, schema introspection is disabled entirely.
+        config_path (str | PathLike, optional): Path to a config file whose values seed the server configuration.
         permissions_store_path (str | PathLike, optional): Path to the permissions store (used by the optional auth extension).
+        config (dict, optional): Configuration overrides applied on top of `config_path`. Recognised keys include caching (`cache_capacity`, `cache_tti_seconds`), logging/tracing (`log_level`, `tracing`, `tracing_level`, `otlp_agent_host`, `otlp_agent_port`, `otlp_tracing_service_name`), auth (`auth_public_key`, `require_auth_for_reads`), indexing (`create_index`), and GraphQL limits (`heavy_query_limit`, `exclusive_writes`, `disable_batching`, `max_batch_size`, `disable_lists`, `max_page_size`, `max_query_depth`, `max_query_complexity`, `max_recursive_depth`, `max_directives_per_field`, `disable_introspection`).
     """
 
     def __new__(
@@ -88,7 +67,7 @@ class GraphServer(object):
         work_dir: str | PathLike,
         config_path: Optional[str | PathLike] = None,
         permissions_store_path: Optional[str | PathLike] = None,
-        config=None,
+        config: Optional[dict] = None,
     ) -> GraphServer:
         """Create and return a new object.  See help(type) for accurate signature."""
 
@@ -173,8 +152,13 @@ class RunningGraphServer(object):
             RaphtoryClient: the client.
         """
 
-    def port(self):
-        """Get the port the server is listening on"""
+    def port(self) -> int:
+        """
+        Get the port the server is listening on
+
+        Returns:
+            int: the port the server is listening on.
+        """
 
     def stop(self) -> None:
         """

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -2521,6 +2521,11 @@ type MetaGraph {
 	"""
 	edgeCount: Int!
 	"""
+	Whether the stored graph carries event or persistent semantics.
+	Served from the cached metadata, so it costs no graph load.
+	"""
+	graphType: GraphType!
+	"""
 	Returns the metadata of the graph.
 	
 	Reads metadata without forcing a full graph load: from the

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -5666,3 +5666,4 @@ schema {
 	query: QueryRoot
 	mutation: MutRoot
 }
+

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -116,6 +116,21 @@ type CollectionOfNamespacedItem {
 }
 
 """
+Where a loader reads its parquet from: a directory already on the server, or
+data supplied with the request.
+"""
+input DataSource @oneOf {
+	"""
+	Path to a parquet directory on the server. Subject to the parquet allowlist.
+	"""
+	path: String
+	"""
+	Multipart upload of a single parquet file.
+	"""
+	upload: Upload
+}
+
+"""
 Filters nodes by computed degree with a directional scope.
 
 `DegreeFilterNew` lets callers filter on:
@@ -2601,9 +2616,9 @@ type MutRoot {
 		"""
 		graphPath: String!,
 		"""
-		Path to the parquet directory.
+		Where to read the parquet from: a server path or an upload.
 		"""
-		dataPath: String!,
+		dataSource: DataSource!,
 		"""
 		The column name for the timestamps.
 		"""
@@ -2654,9 +2669,9 @@ type MutRoot {
 		"""
 		graphPath: String!,
 		"""
-		Path to the parquet directory.
+		Where to read the parquet from: a server path or an upload.
 		"""
-		dataPath: String!,
+		dataSource: DataSource!,
 		"""
 		The column name for the update timestamps.
 		"""

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -2454,37 +2454,12 @@ mod graphql_test {
     #[tokio::test]
     async fn test_load_nodes_from_parquet() {
         use crate::config::app_config::AppConfigBuilder;
-        use arrow::{
-            array::{Int64Array, StringArray},
-            datatypes::{DataType, Field, Schema as ArrowSchema},
-            record_batch::RecordBatch,
-        };
-        use parquet::arrow::ArrowWriter;
-        use std::{fs::File, sync::Arc};
 
         let graph_dir = tempdir().unwrap();
         let tmp_dir = tempdir().unwrap();
 
-        // Write a minimal parquet file: two nodes "a" and "b" at t=1 with a weight property.
         let parquet_path = tmp_dir.path().join("nodes.parquet");
-        let arrow_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("id", DataType::Utf8, false),
-            Field::new("time", DataType::Int64, false),
-            Field::new("weight", DataType::Int64, true),
-        ]));
-        let batch = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["a", "b"])),
-                Arc::new(Int64Array::from(vec![1, 1])),
-                Arc::new(Int64Array::from(vec![10, 20])),
-            ],
-        )
-        .unwrap();
-        let file = File::create(&parquet_path).unwrap();
-        let mut writer = ArrowWriter::try_new(file, arrow_schema, None).unwrap();
-        writer.write(&batch).unwrap();
-        writer.close().unwrap();
+        write_nodes_parquet_with_ids(&parquet_path, &["a", "b"]);
 
         // Build an AppConfig that permits the temp dir as a parquet source.
         let app_config = AppConfigBuilder::new()
@@ -2508,7 +2483,7 @@ mod graphql_test {
             r#"mutation {{
                 loadNodes(
                     graphPath: "mygraph",
-                    dataPath: "{}",
+                    dataSource: {{ path: "{}" }},
                     time: "time",
                     id: "id",
                     properties: ["weight"]
@@ -2538,6 +2513,228 @@ mod graphql_test {
             .collect();
         names.sort();
         assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn test_load_nodes_from_upload() {
+        use std::fs::File;
+
+        let tmp_dir = tempdir().unwrap();
+        let graph_dir = tempdir().unwrap();
+        let parquet_path = tmp_dir.path().join("nodes.parquet");
+        write_nodes_parquet_with_ids(&parquet_path, &["a", "b"]);
+
+        let data = Data::new(graph_dir.path(), &Default::default(), Config::default());
+        let folder = data
+            .work_dir_write()
+            .await
+            .validate_path_for_insert("mygraph", false)
+            .unwrap();
+        data.insert_graph(folder, Graph::new().into())
+            .await
+            .unwrap();
+        let schema = App::create_schema().data(data).finish().unwrap();
+
+        let mutation = r#"mutation Load($ds: DataSource!) {
+            loadNodes(graphPath: "mygraph", dataSource: $ds, time: "time", id: "id", properties: ["weight"])
+        }"#;
+        let mut req = Request::new(mutation).variables(Variables::from_json(json!({
+            "ds": {"upload": null}
+        })));
+        req.set_upload(
+            "variables.ds.upload",
+            UploadValue {
+                filename: "nodes.parquet".to_string(),
+                content_type: Some("application/octet-stream".to_string()),
+                content: File::open(&parquet_path).unwrap(),
+            },
+        );
+
+        let res = schema.execute(req.data(Access::Rw)).await;
+        assert_eq!(res.errors, vec![], "loadNodes upload returned errors");
+        assert_eq!(res.data.into_json().unwrap(), json!({"loadNodes": true}));
+
+        let query = r#"{ graph(path: "mygraph") { nodes { list { name } } } }"#;
+        let res = schema.execute(Request::new(query).data(Access::Rw)).await;
+        assert_eq!(res.errors, vec![], "node query returned errors");
+        let mut names: Vec<String> = res.data.into_json().unwrap()["graph"]["nodes"]["list"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["name"].as_str().unwrap().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn test_load_edges_from_upload() {
+        use std::fs::File;
+
+        let tmp_dir = tempdir().unwrap();
+        let graph_dir = tempdir().unwrap();
+        let parquet_path = tmp_dir.path().join("edges.parquet");
+        write_edges_parquet(&parquet_path, &[("a", "b"), ("b", "c")]);
+
+        let data = Data::new(graph_dir.path(), &Default::default(), Config::default());
+        let folder = data
+            .work_dir_write()
+            .await
+            .validate_path_for_insert("mygraph", false)
+            .unwrap();
+        data.insert_graph(folder, Graph::new().into())
+            .await
+            .unwrap();
+        let schema = App::create_schema().data(data).finish().unwrap();
+
+        let mutation = r#"mutation Load($ds: DataSource!) {
+            loadEdges(graphPath: "mygraph", dataSource: $ds, time: "time", src: "src", dst: "dst", properties: ["weight"])
+        }"#;
+        let mut req = Request::new(mutation).variables(Variables::from_json(json!({
+            "ds": {"upload": null}
+        })));
+        req.set_upload(
+            "variables.ds.upload",
+            UploadValue {
+                filename: "edges.parquet".to_string(),
+                content_type: Some("application/octet-stream".to_string()),
+                content: File::open(&parquet_path).unwrap(),
+            },
+        );
+
+        let res = schema.execute(req.data(Access::Rw)).await;
+        assert_eq!(res.errors, vec![], "loadEdges upload returned errors");
+        assert_eq!(res.data.into_json().unwrap(), json!({"loadEdges": true}));
+
+        let query =
+            r#"{ graph(path: "mygraph") { edges { list { src { name } dst { name } } } } }"#;
+        let res = schema.execute(Request::new(query).data(Access::Rw)).await;
+        assert_eq!(res.errors, vec![], "edge query returned errors");
+        let mut edges: Vec<(String, String)> = res.data.into_json().unwrap()["graph"]["edges"]
+            ["list"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| {
+                (
+                    e["src"]["name"].as_str().unwrap().to_string(),
+                    e["dst"]["name"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+        edges.sort();
+        assert_eq!(
+            edges,
+            vec![
+                ("a".to_string(), "b".to_string()),
+                ("b".to_string(), "c".to_string())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_data_source_requires_exactly_one_field() {
+        use crate::config::app_config::AppConfigBuilder;
+
+        let graph_dir = tempdir().unwrap();
+        let parquet_dir = tempdir().unwrap();
+        let parquet_path = write_nodes_parquet(parquet_dir.path());
+
+        // Allowlisting the parquet leaves the oneOf rule as the only thing that can
+        // reject the both-fields-supplied case.
+        let app_config = AppConfigBuilder::new()
+            .with_allowed_parquet_paths(vec![parquet_dir.path().to_path_buf()])
+            .build();
+        let data = Data::new(graph_dir.path(), &app_config, Config::default());
+        let folder = data
+            .work_dir_write()
+            .await
+            .validate_path_for_insert("g", false)
+            .unwrap();
+        data.insert_graph(folder, Graph::new().into())
+            .await
+            .unwrap();
+        let schema = App::create_schema().data(data).finish().unwrap();
+
+        let allowed = parquet_path.to_str().unwrap().replace('\\', "/");
+        let load = |ds: String| {
+            format!(
+                r#"mutation {{ loadNodes(graphPath: "g", dataSource: {ds}, time: "time", id: "id") }}"#
+            )
+        };
+
+        // The allowlisted path on its own loads, so any rejection below is the oneOf rule.
+        let res = run_mutation(&schema, &load(format!(r#"{{ path: "{allowed}" }}"#))).await;
+        assert_eq!(res.errors, vec![], "single-field dataSource should load");
+
+        for ds in [
+            "{}".to_string(),
+            format!(r#"{{ path: "{allowed}", upload: null }}"#),
+        ] {
+            let res = run_mutation(&schema, &load(ds.clone())).await;
+            assert!(
+                res.errors.iter().any(|e| e
+                    .message
+                    .contains("Oneof input objects requires have exactly one field")),
+                "dataSource {ds} should be rejected by the oneOf contract, got: {:?}",
+                res.errors
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_nodes_from_large_upload() {
+        use std::fs::File;
+
+        let tmp_dir = tempdir().unwrap();
+        let graph_dir = tempdir().unwrap();
+        let parquet_path = tmp_dir.path().join("many.parquet");
+        // Enough distinct ids to put the parquet comfortably past any 2MB body default.
+        let ids: Vec<String> = (0..250_000).map(|i| format!("n{i}")).collect();
+        write_nodes_parquet_with_ids(
+            &parquet_path,
+            &ids.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+        let payload_size = fs::metadata(&parquet_path).unwrap().len();
+        assert!(
+            payload_size > 2 * 1024 * 1024,
+            "test payload must exceed 2MB to be meaningful, got {payload_size} bytes"
+        );
+
+        let data = Data::new(graph_dir.path(), &Default::default(), Config::default());
+        let folder = data
+            .work_dir_write()
+            .await
+            .validate_path_for_insert("big", false)
+            .unwrap();
+        data.insert_graph(folder, Graph::new().into())
+            .await
+            .unwrap();
+        let schema = App::create_schema().data(data).finish().unwrap();
+
+        let mutation = r#"mutation Load($ds: DataSource!) {
+            loadNodes(graphPath: "big", dataSource: $ds, time: "time", id: "id")
+        }"#;
+        let mut req =
+            Request::new(mutation).variables(Variables::from_json(json!({"ds": {"upload": null}})));
+        req.set_upload(
+            "variables.ds.upload",
+            UploadValue {
+                filename: "many.parquet".to_string(),
+                content_type: Some("application/octet-stream".to_string()),
+                content: File::open(&parquet_path).unwrap(),
+            },
+        );
+        let res = schema.execute(req.data(Access::Rw)).await;
+        assert_eq!(res.errors, vec![], "large upload returned errors");
+
+        let query = r#"{ graphMetadata(path: "big") { nodeCount } }"#;
+        let res = schema.execute(Request::new(query).data(Access::Rw)).await;
+        assert_eq!(res.errors, vec![], "graphMetadata query returned errors");
+        assert_eq!(
+            res.data.into_json().unwrap()["graphMetadata"]["nodeCount"],
+            250_000
+        );
     }
 
     #[tokio::test]
@@ -2586,39 +2783,12 @@ mod graphql_test {
     #[tokio::test]
     async fn test_load_edges_from_parquet() {
         use crate::config::app_config::AppConfigBuilder;
-        use arrow::{
-            array::{Int64Array, StringArray},
-            datatypes::{DataType, Field, Schema as ArrowSchema},
-            record_batch::RecordBatch,
-        };
-        use parquet::arrow::ArrowWriter;
-        use std::{fs::File, sync::Arc};
 
         let graph_dir = tempdir().unwrap();
         let tmp_dir = tempdir().unwrap();
 
-        // Write a minimal parquet file: two edges a→b and b→c at t=1 with a weight property.
         let parquet_path = tmp_dir.path().join("edges.parquet");
-        let arrow_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("src", DataType::Utf8, false),
-            Field::new("dst", DataType::Utf8, false),
-            Field::new("time", DataType::Int64, false),
-            Field::new("weight", DataType::Int64, true),
-        ]));
-        let batch = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["a", "b"])),
-                Arc::new(StringArray::from(vec!["b", "c"])),
-                Arc::new(Int64Array::from(vec![1, 1])),
-                Arc::new(Int64Array::from(vec![10, 20])),
-            ],
-        )
-        .unwrap();
-        let file = File::create(&parquet_path).unwrap();
-        let mut writer = ArrowWriter::try_new(file, arrow_schema, None).unwrap();
-        writer.write(&batch).unwrap();
-        writer.close().unwrap();
+        write_edges_parquet(&parquet_path, &[("a", "b"), ("b", "c")]);
 
         // Build an AppConfig that permits the temp dir as a parquet source.
         let app_config = AppConfigBuilder::new()
@@ -2642,7 +2812,7 @@ mod graphql_test {
             r#"mutation {{
                 loadEdges(
                     graphPath: "mygraph",
-                    dataPath: "{}",
+                    dataSource: {{ path: "{}" }},
                     time: "time",
                     src: "src",
                     dst: "dst",
@@ -2689,8 +2859,9 @@ mod graphql_test {
 
     // ── allowed-paths tests ──────────────────────────────────────────────────
 
-    /// Write a one-row nodes parquet file into `dir` and return its path.
-    fn write_nodes_parquet(dir: &std::path::Path) -> std::path::PathBuf {
+    /// Write a nodes parquet file at `path` with one row per id, all at t=1 and
+    /// carrying an ascending `weight` property.
+    fn write_nodes_parquet_with_ids(path: &std::path::Path, ids: &[&str]) {
         use arrow::{
             array::{Int64Array, StringArray},
             datatypes::{DataType, Field, Schema as ArrowSchema},
@@ -2699,24 +2870,70 @@ mod graphql_test {
         use parquet::arrow::ArrowWriter;
         use std::{fs::File, sync::Arc};
 
-        let path = dir.join("nodes.parquet");
-        let schema = Arc::new(ArrowSchema::new(vec![
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
             Field::new("id", DataType::Utf8, false),
             Field::new("time", DataType::Int64, false),
+            Field::new("weight", DataType::Int64, true),
         ]));
+        let times: Vec<i64> = ids.iter().map(|_| 1).collect();
+        let weights: Vec<i64> = (0..ids.len() as i64).collect();
         let batch = RecordBatch::try_new(
-            schema.clone(),
+            arrow_schema.clone(),
             vec![
-                Arc::new(StringArray::from(vec!["x"])),
-                Arc::new(Int64Array::from(vec![1i64])),
+                Arc::new(StringArray::from(ids.to_vec())),
+                Arc::new(Int64Array::from(times)),
+                Arc::new(Int64Array::from(weights)),
             ],
         )
         .unwrap();
-        let file = File::create(&path).unwrap();
-        let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+        let file = File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema, None).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
+    }
+
+    /// Write a one-row nodes parquet file into `dir` and return its path.
+    fn write_nodes_parquet(dir: &std::path::Path) -> std::path::PathBuf {
+        let path = dir.join("nodes.parquet");
+        write_nodes_parquet_with_ids(&path, &["x"]);
         path
+    }
+
+    /// Write an edges parquet file at `path`, one row per `(src, dst)` pair at t=1
+    /// carrying an ascending `weight` property.
+    fn write_edges_parquet(path: &std::path::Path, pairs: &[(&str, &str)]) {
+        use arrow::{
+            array::{Int64Array, StringArray},
+            datatypes::{DataType, Field, Schema as ArrowSchema},
+            record_batch::RecordBatch,
+        };
+        use parquet::arrow::ArrowWriter;
+        use std::{fs::File, sync::Arc};
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("src", DataType::Utf8, false),
+            Field::new("dst", DataType::Utf8, false),
+            Field::new("time", DataType::Int64, false),
+            Field::new("weight", DataType::Int64, true),
+        ]));
+        let srcs: Vec<&str> = pairs.iter().map(|(src, _)| *src).collect();
+        let dsts: Vec<&str> = pairs.iter().map(|(_, dst)| *dst).collect();
+        let times: Vec<i64> = pairs.iter().map(|_| 1).collect();
+        let weights: Vec<i64> = (0..pairs.len() as i64).collect();
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(srcs)),
+                Arc::new(StringArray::from(dsts)),
+                Arc::new(Int64Array::from(times)),
+                Arc::new(Int64Array::from(weights)),
+            ],
+        )
+        .unwrap();
+        let file = File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
     }
 
     #[tokio::test]
@@ -2743,7 +2960,7 @@ mod graphql_test {
         let schema = App::create_schema().data(data).finish().unwrap();
         let parquet_path_str = parquet_path.to_str().unwrap().replace('\\', "/");
         let mutation = format!(
-            r#"mutation {{ loadNodes(graphPath: "g", dataPath: "{}", time: "time", id: "id") }}"#,
+            r#"mutation {{ loadNodes(graphPath: "g", dataSource: {{ path: "{}" }}, time: "time", id: "id") }}"#,
             parquet_path_str
         );
         let res = run_mutation(&schema, &mutation).await;
@@ -2778,7 +2995,7 @@ mod graphql_test {
         let schema = App::create_schema().data(data).finish().unwrap();
         let parquet_path_str = parquet_path.to_str().unwrap().replace('\\', "/");
         let mutation = format!(
-            r#"mutation {{ loadNodes(graphPath: "g", dataPath: "{}", time: "time", id: "id") }}"#,
+            r#"mutation {{ loadNodes(graphPath: "g", dataSource: {{ path: "{}" }}, time: "time", id: "id") }}"#,
             parquet_path_str
         );
         let res = run_mutation(&schema, &mutation).await;
@@ -2819,7 +3036,7 @@ mod graphql_test {
         let schema = App::create_schema().data(data).finish().unwrap();
         let parquet_path_str = parquet_path.to_str().unwrap().replace('\\', "/");
         let mutation = format!(
-            r#"mutation {{ loadNodes(graphPath: "g", dataPath: "{}", time: "time", id: "id") }}"#,
+            r#"mutation {{ loadNodes(graphPath: "g", dataSource: {{ path: "{}" }}, time: "time", id: "id") }}"#,
             parquet_path_str
         );
         let res = run_mutation(&schema, &mutation).await;
@@ -2861,7 +3078,7 @@ mod graphql_test {
         let schema = App::create_schema().data(data).finish().unwrap();
         let parquet_path_str = parquet_path.to_str().unwrap().replace('\\', "/");
         let mutation = format!(
-            r#"mutation {{ loadNodes(graphPath: "g", dataPath: "{}", time: "time", id: "id") }}"#,
+            r#"mutation {{ loadNodes(graphPath: "g", dataSource: {{ path: "{}" }}, time: "time", id: "id") }}"#,
             parquet_path_str
         );
         let res = run_mutation(&schema, &mutation).await;
@@ -2933,7 +3150,7 @@ mod graphql_test {
             r#"mutation {{
                 loadNodes(
                     graphPath: "g",
-                    dataPath: "{}",
+                    dataSource: {{ path: "{}" }},
                     time: "time",
                     id: "id",
                     properties: ["score"],
@@ -2996,7 +3213,7 @@ mod graphql_test {
         let schema = App::create_schema().data(data).finish().unwrap();
         let parquet_path_str = parquet_path.to_str().unwrap().replace('\\', "/");
         let mutation = format!(
-            r#"mutation {{ loadNodes(graphPath: "g", dataPath: "{}", time: "time", id: "id") }}"#,
+            r#"mutation {{ loadNodes(graphPath: "g", dataSource: {{ path: "{}" }}, time: "time", id: "id") }}"#,
             parquet_path_str
         );
         let res = run_mutation(&schema, &mutation).await;

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -2541,6 +2541,49 @@ mod graphql_test {
     }
 
     #[tokio::test]
+    async fn test_meta_graph_exposes_graph_type() {
+        let graph_dir = tempdir().unwrap();
+        let data = Data::new(graph_dir.path(), &Default::default(), Config::default());
+
+        for (path, graph) in [
+            ("event", MaterializedGraph::from(Graph::new())),
+            (
+                "persistent",
+                MaterializedGraph::from(PersistentGraph::new()),
+            ),
+        ] {
+            let folder = data
+                .work_dir_write()
+                .await
+                .validate_path_for_insert(path, false)
+                .unwrap();
+            data.insert_graph(folder, graph).await.unwrap();
+        }
+
+        let schema = App::create_schema().data(data).finish().unwrap();
+        let res = schema
+            .execute(
+                Request::new(
+                    r#"{
+                        event: graphMetadata(path: "event") { graphType }
+                        persistent: graphMetadata(path: "persistent") { graphType }
+                    }"#,
+                )
+                .data(Access::Rw),
+            )
+            .await;
+
+        assert_eq!(res.errors, vec![], "graphMetadata query returned errors");
+        assert_eq!(
+            res.data.into_json().unwrap(),
+            json!({
+                "event": {"graphType": "EVENT"},
+                "persistent": {"graphType": "PERSISTENT"},
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn test_load_edges_from_parquet() {
         use crate::config::app_config::AppConfigBuilder;
         use arrow::{

--- a/raphtory-graphql/src/model/data_source.rs
+++ b/raphtory-graphql/src/model/data_source.rs
@@ -1,0 +1,50 @@
+use super::GqlGraphError;
+use crate::data::Data;
+use dynamic_graphql::{Context, OneOfInput, Result, Upload};
+use std::{fs, io, path::PathBuf};
+use tempfile::TempDir;
+
+/// Where a loader reads its parquet from: a directory already on the server, or
+/// data supplied with the request.
+#[derive(OneOfInput)]
+#[graphql(name = "DataSource")]
+pub enum GqlDataSource {
+    /// Path to a parquet directory on the server. Subject to the parquet allowlist.
+    Path(String),
+    /// Multipart upload of a single parquet file.
+    Upload(Upload),
+}
+
+/// A parquet directory plus, for uploads, the temp dir that owns it. Dropping the
+/// guard removes the spooled file, so callers must hold it until the load returns.
+pub struct ParquetInput {
+    pub path: PathBuf,
+    _guard: Option<TempDir>,
+}
+
+impl ParquetInput {
+    /// A client-supplied path is only usable if the allowlist permits it, so the
+    /// check belongs here rather than at the call site: no caller can hold an
+    /// unvalidated path input. An upload's path is server-chosen and so exempt.
+    pub(crate) async fn from_path(data: &Data, path: String) -> Result<Self> {
+        let path = PathBuf::from(path);
+        data.is_parquet_path_allowed(&path)
+            .await
+            .map_err(|e| GqlGraphError::LoadError(e.to_string()))?;
+        Ok(Self { path, _guard: None })
+    }
+
+    /// The loaders take a directory, so the uploaded file is placed inside one.
+    pub(crate) fn from_upload(ctx: &Context<'_>, upload: Upload) -> Result<Self> {
+        let mut content = upload.value(ctx)?.content;
+        let dir = TempDir::new()?;
+        let path = dir.path().join("part.parquet");
+        let mut out = fs::File::create(&path)?;
+        io::copy(&mut content, &mut out)?;
+        out.sync_all()?;
+        Ok(Self {
+            path: dir.path().to_path_buf(),
+            _guard: Some(dir),
+        })
+    }
+}

--- a/raphtory-graphql/src/model/graph/meta_graph.rs
+++ b/raphtory-graphql/src/model/graph/meta_graph.rs
@@ -1,5 +1,5 @@
 use crate::{
-    data::Data,
+    data::{Data, GqlGraphType},
     model::graph::property::GqlProperty,
     paths::{ExistingGraphFolder, ValidGraphPaths},
 };
@@ -11,7 +11,10 @@ use raphtory::{
     prelude::{GraphViewOps, PropertiesOps},
     serialise::{metadata::build_graph_metadata, parquet::decode_graph_metadata},
 };
-use raphtory_api::core::storage::graph_folder::{GraphMetadata, GraphPaths};
+use raphtory_api::{
+    core::storage::graph_folder::{GraphMetadata, GraphPaths},
+    GraphType,
+};
 use std::{cmp::Ordering, sync::Arc};
 use tokio::sync::OnceCell;
 
@@ -111,6 +114,16 @@ impl MetaGraph {
     async fn edge_count(&self, ctx: &Context<'_>) -> Result<usize> {
         let data: &Data = ctx.data_unchecked();
         Ok(self.meta(data).await?.edge_count)
+    }
+
+    /// Whether the stored graph carries event or persistent semantics.
+    /// Served from the cached metadata, so it costs no graph load.
+    async fn graph_type(&self, ctx: &Context<'_>) -> Result<GqlGraphType> {
+        let data: &Data = ctx.data_unchecked();
+        Ok(match self.meta(data).await?.graph_type {
+            GraphType::EventGraph => GqlGraphType::Event,
+            GraphType::PersistentGraph => GqlGraphType::Persistent,
+        })
     }
 
     /// Returns the metadata of the graph.

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     auth_policy::{AuthorizationPolicy, NamespacePermission},
     data::{parent_namespace, require_graph_write, Data, GqlGraphType, PermissionError},
     model::{
+        data_source::{GqlDataSource, ParquetInput},
         graph::{
             collection::GqlCollection, graph::GqlGraph, meta_graph::MetaGraph,
             mutable_graph::GqlMutableGraph, namespace::Namespace, namespaced_item::NamespacedItem,
@@ -38,16 +39,28 @@ use raphtory::{
     version,
 };
 use raphtory_api::core::entities::properties::prop::PropType;
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 use tracing::warn;
 
 #[cfg(feature = "vectors")]
 use crate::model::graph::vectorised_graph::{GqlVectorisedGraph, VectorQuery};
 
+pub mod data_source;
 pub mod graph;
 pub mod plugins;
 pub(crate) mod schema;
 pub(crate) mod sorting;
+
+async fn resolve_parquet_input<'a>(
+    ctx: &Context<'a>,
+    data: &Data,
+    data_source: GqlDataSource,
+) -> Result<ParquetInput> {
+    match data_source {
+        GqlDataSource::Path(path) => ParquetInput::from_path(data, path).await,
+        GqlDataSource::Upload(upload) => ParquetInput::from_upload(ctx, upload),
+    }
+}
 
 pub(crate) fn parse_json_schema(
     json: Option<&str>,
@@ -320,7 +333,8 @@ impl Mut {
     async fn load_nodes<'a>(
         ctx: &Context<'a>,
         #[graphql(desc = "Graph path relative to the root namespace.")] graph_path: String,
-        #[graphql(desc = "Path to the parquet directory.")] data_path: String,
+        #[graphql(desc = "Where to read the parquet from: a server path or an upload.")]
+        data_source: GqlDataSource,
         #[graphql(desc = "The column name for the timestamps.")] time: String,
         #[graphql(desc = "The column name for the node IDs.")] id: String,
         #[graphql(
@@ -364,19 +378,14 @@ impl Mut {
 
         let schema = parse_json_schema(schema.as_deref())?;
 
-        // extracting PathBuf handles Strings too
-        let data_path = PathBuf::from(data_path);
-
-        data.is_parquet_path_allowed(&data_path)
-            .await
-            .map_err(|e| GqlGraphError::LoadError(e.to_string()))?;
+        let input = resolve_parquet_input(ctx, data, data_source).await?;
 
         // wrap in Arc to avoid cloning the entire schema for inner loops
         let arced_schema = schema.map(Arc::new);
 
         load_nodes_from_parquet(
             &graph,
-            &data_path,
+            &input.path,
             &time,
             event_id.as_deref(),
             &id,
@@ -399,7 +408,8 @@ impl Mut {
     async fn load_edges<'a>(
         ctx: &Context<'a>,
         #[graphql(desc = "Graph path relative to the root namespace.")] graph_path: String,
-        #[graphql(desc = "Path to the parquet directory.")] data_path: String,
+        #[graphql(desc = "Where to read the parquet from: a server path or an upload.")]
+        data_source: GqlDataSource,
         #[graphql(desc = "The column name for the update timestamps.")] time: String,
         #[graphql(desc = "The column name for the source node IDs.")] src: String,
         #[graphql(desc = "The column name for the destination node IDs.")] dst: String,
@@ -439,19 +449,14 @@ impl Mut {
 
         let schema = parse_json_schema(schema.as_deref())?;
 
-        // extracting PathBuf handles Strings too
-        let data_path = PathBuf::from(data_path);
-
-        data.is_parquet_path_allowed(&data_path)
-            .await
-            .map_err(|e| GqlGraphError::LoadError(e.to_string()))?;
+        let input = resolve_parquet_input(ctx, data, data_source).await?;
 
         // wrap in Arc to avoid cloning the entire schema for inner loops
         let arced_schema = schema.map(Arc::new);
 
         load_edges_from_parquet(
             &graph,
-            &data_path,
+            &input.path,
             ColumnNames::new(
                 time.as_str(),
                 event_id.as_deref(),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add GqlDataSource which can represent either a file path or multipart upload, and use it in load_nodes/load_edges allowing both APIs to support either loading in data from local data, or from a multipart upload from the client.

### Why are the changes needed?

Allows these APIs to work remotely; clients can upload nodes/edges directly to a new graph rather than requiring the parquet file to exist on the server already.

### Does this PR introduce any user-facing change? If yes is this documented?

Yes. Additional documentation added to graphql_API.md

### How was this patch tested?

Tests added to lib.rs

### Are there any further changes required?

No
