### PR TITLE
Export the sort keys from the module that owns them

### DIFF
--- a/python/tests/test_base_install/test_graphql/parity/test_parity_sorting.py
+++ b/python/tests/test_base_install/test_graphql/parity/test_parity_sorting.py
@@ -14,7 +14,7 @@ it, remote does not" — here it is the other way round.
 """
 
 import pytest
-from raphtory.graphql import EdgeSortBy, NodeSortBy
+from raphtory import EdgeSortBy, NodeSortBy
 
 from _parity import graph_pair
 

--- a/python/tests/test_base_install/test_graphql/test_remote_graph_transport.py
+++ b/python/tests/test_base_install/test_graphql/test_remote_graph_transport.py
@@ -18,7 +18,8 @@ import tempfile
 
 import pytest
 
-from raphtory.graphql import EdgeSortBy, GraphServer, NodeSortBy, SortByTime
+from raphtory import EdgeSortBy, NodeSortBy, SortByTime
+from raphtory.graphql import GraphServer
 
 # The shared server-startup context managers live in test_utils so every test
 # file stands servers up the same way; population differs per test, so callers

--- a/raphtory-graphql/src/python/pymodule.rs
+++ b/raphtory-graphql/src/python/pymodule.rs
@@ -32,7 +32,6 @@ use crate::{
     },
 };
 use pyo3::{create_exception, exceptions::PyException, prelude::*};
-use raphtory::python::graph::sorting::{PyEdgeSortBy, PyNodeSortBy, PySortByTime};
 
 create_exception!(
     raphtory.graphql,
@@ -88,12 +87,6 @@ pub fn base_graphql_module(py: Python<'_>) -> Result<Bound<'_, PyModule>, PyErr>
     graphql_module.add_class::<PyPropsInput>()?;
     graphql_module.add_class::<PySomePropertySpec>()?;
     graphql_module.add_class::<PyAllPropertySpec>()?;
-    // The sort-key classes live in the base `raphtory` module (they are the
-    // same types the local `Nodes.sorted` / `Edges.sorted` take); re-exported
-    // here so `raphtory.graphql.NodeSortBy` keeps working.
-    graphql_module.add_class::<PySortByTime>()?;
-    graphql_module.add_class::<PyNodeSortBy>()?;
-    graphql_module.add_class::<PyEdgeSortBy>()?;
 
     graphql_module.add(
         "RemotePermissionError",

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -337,8 +337,8 @@ pub fn local_clustering_coefficient(graph: &PyGraphView, v: PyNodeRef) -> Option
 /// Uses path-counting for its triangle-counting step.
 ///
 /// Arguments:
-///     graph: Raphtory graph, can be directed or undirected but will be treated as undirected.
-///     v: vec of node ids, if empty, will return results for every node in the graph
+///     graph (GraphView): Raphtory graph, can be directed or undirected but will be treated as undirected.
+///     v (list[NodeInput], optional): node ids; if omitted, returns results for every node in the graph
 ///
 /// Returns:
 ///     OutputNodeState: Mapping of vertices to lcc score

--- a/raphtory/src/python/packages/graph_gen.rs
+++ b/raphtory/src/python/packages/graph_gen.rs
@@ -17,10 +17,10 @@ use pyo3::prelude::*;
 /// Physical Review E 64.4 (2001): 041902.
 ///
 /// Arguments:
-///   g: The graph you wish to add nodes and edges to
-///   nodes_to_add: The amount of nodes you wish to add to the graph (steps)
-///   edges_per_step: The amount of edges a joining node should add to the graph
-///   seed: The seed used in rng, an array of length 32 containing ints (ints must have a max size of u8)
+///   g (Graph): The graph you wish to add nodes and edges to
+///   nodes_to_add (int): The amount of nodes you wish to add to the graph (steps)
+///   edges_per_step (int): The amount of edges a joining node should add to the graph
+///   seed (list[int], optional): The seed used in rng, an array of length 32 containing ints (ints must have a max size of u8)
 ///
 /// Returns:
 ///  None:
@@ -49,10 +49,10 @@ pub fn random_attachment(
 /// the min number of both will be added before generation begins.
 ///
 /// Arguments:
-///    g: The graph you wish to add nodes and edges to
-///    nodes_to_add: The amount of nodes you wish to add to the graph (steps)
-///    edges_per_step: The amount of edges a joining node should add to the graph
-///    seed: The seed used in rng, an array of length 32 containing ints (ints must have a max size of u8)
+///    g (Graph): The graph you wish to add nodes and edges to
+///    nodes_to_add (int): The amount of nodes you wish to add to the graph (steps)
+///    edges_per_step (int): The amount of edges a joining node should add to the graph
+///    seed (list[int], optional): The seed used in rng, an array of length 32 containing ints (ints must have a max size of u8)
 ///
 /// Returns:
 ///     None:


### PR DESCRIPTION
## What changes were proposed in this pull request?

The sort-key classes declare `raphtory` as their module and were also added to `raphtory.graphql`. Both stub trees then declared them, and the top-level stub star-imports graphql, so each one was a redefinition of itself:

```
__init__.pyi:5282: error: Name "SortByTime" already defined (possibly by an import)
__init__.pyi:5309: error: Name "NodeSortBy" already defined
__init__.pyi:5378: error: Name "EdgeSortBy" already defined
```

They keep the home their pyclass attribute names. Callers reach them through `from raphtory import ...`, which is the same import the local `sorted()` takes.

## Why are the changes needed?

The stub job regenerates and then type-checks, so this fails for anyone whose submodule pointer is new enough to include the sort keys. It is currently red on Pometry/pometry-storage#352, which changed nothing in this area.

## Does this PR introduce any user-facing change? If yes is this documented?

Yes, small: `raphtory.graphql.NodeSortBy` and friends no longer resolve. `from raphtory import NodeSortBy` does, and is the import the local sorted() already takes. The two test files that used the graphql path are updated.

## How was this patch tested?

Regenerated the stubs from a wheel built on this branch alone: `mypy -m raphtory` goes from three errors to `Success`. `test_parity_sorting` 12 passing, the sorting cases in `test_remote_graph_transport` 9 passing, `cargo check --features python` clean.