### PR TITLE
Check the sort keys are shared by using them, not by naming them twice

### DIFF
--- a/python/tests/test_base_install/test_graphql/parity/test_parity_entities.py
+++ b/python/tests/test_base_install/test_graphql/parity/test_parity_entities.py
@@ -177,11 +177,22 @@ def test_edges_sorted_parity():
 
 
 def test_sort_key_types_are_shared():
-    """One set of sort-key classes serves both sides: `raphtory.NodeSortBy`
-    and `raphtory.graphql.NodeSortBy` are the same class."""
+    """One set of sort-key classes serves both sides.
+
+    They are exported from `raphtory` alone. Re-exporting them from
+    `raphtory.graphql` as well made each stub declaration a redefinition of the
+    other, so the check is that the remote collections take the very classes the
+    local ones do, rather than that a second name for them exists.
+    """
     import raphtory
     import raphtory.graphql as gql
 
-    assert raphtory.NodeSortBy is gql.NodeSortBy
-    assert raphtory.EdgeSortBy is gql.EdgeSortBy
-    assert raphtory.SortByTime is gql.SortByTime
+    for name in ("NodeSortBy", "EdgeSortBy", "SortByTime"):
+        assert hasattr(raphtory, name), f"raphtory.{name} is the canonical home"
+        assert not hasattr(gql, name), f"raphtory.graphql.{name} would be a duplicate"
+
+    with graph_pair(_build_sortable) as pair:
+        key = raphtory.NodeSortBy.by_name()
+        local = [n.name for n in pair.local.nodes.sorted([key])]
+        remote = [n.name for n in pair.remote.nodes.sorted([key])]
+        assert local == remote, f"the same key sorted differently: {local} vs {remote}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

`test_sort_key_types_are_shared` asserted `raphtory.NodeSortBy is raphtory.graphql.NodeSortBy`. That stopped holding when #2739 removed the duplicate export, so `db_v4` is currently red:

```
>       assert raphtory.NodeSortBy is gql.NodeSortBy
E       AttributeError: module 'graphql' has no attribute 'NodeSortBy'
```

The test now checks what that name was standing in for: the classes live in `raphtory` alone, are not duplicated under `graphql` (which is what made each stub declaration a redefinition of the other), and the same key object sorts a local and a remote collection identically.

## Why are the changes needed?

`db_v4` fails this test today, so every PR branching from it inherits the failure. It is currently red on Pometry/pometry-storage#352, which changed nothing in this area.

## Does this PR introduce any user-facing change? If yes is this documented?

No, test only.

## How was this patch tested?

The whole parity suite rather than the sorting subset — 1670 passed, 9 xfailed. Running only the sorting tests is what let the original break through, since the assertion lived in `test_parity_entities.py`.