### PR TITLE
make some of the auth apis public so they can be used in extensions

### DIFF
--- a/docs/reference/graphql/graphql_API.md
+++ b/docs/reference/graphql/graphql_API.md
@@ -6720,6 +6720,28 @@ Graphs directly inside this namespace (excludes graphs in nested
 namespaces). Filtered by the caller's permissions — only graphs the
 caller is allowed to see are returned.
 
+`filter` and `sort` are applied before the returned collection is paged,
+so `count` reflects the filtered total and `page` slices the sorted
+order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#metagraphfilter">MetaGraphFilter</a></td>
+<td>
+
+Restricts which graphs are listed.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">sort</td>
+<td valign="top">[<a href="#metagraphsort">MetaGraphSort</a>!]</td>
+<td>
+
+Sort keys applied in order, before paging.
+
 </td>
 </tr>
 <tr>
@@ -6729,6 +6751,19 @@ caller is allowed to see are returned.
 
 Path of this namespace relative to the root namespace. Empty string for
 the root namespace itself.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="namespace.lastupdated">lastUpdated</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Most recent `lastUpdated` across the graphs directly inside this
+namespace, or null when it holds none.
+
+Computed here so a listing can show a folder's recency without the client
+walking every graph in every folder it displays.
 
 </td>
 </tr>
@@ -6749,6 +6784,26 @@ Parent namespace, or null at the root.
 Sub-namespaces directly inside this one (one level down, not recursive).
 Filtered by permissions.
 
+`filter` and `sort` are applied before the returned collection is paged.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#namespacefilter">NamespaceFilter</a></td>
+<td>
+
+Restricts which sub-namespaces are listed.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">sort</td>
+<td valign="top"><a href="#namespacesort">NamespaceSort</a></td>
+<td>
+
+Ordering applied before paging.
+
 </td>
 </tr>
 <tr>
@@ -6759,6 +6814,29 @@ Filtered by permissions.
 Everything in this namespace — sub-namespaces and graphs — as a single
 heterogeneous collection. Sub-namespaces are listed before graphs.
 Filtered by permissions.
+
+`filter` and `sort` are applied before the returned collection is paged.
+`sort` orders the graphs; sub-namespaces keep path order and stay ahead of
+them, so a client paging this collection walks folders before graphs
+regardless of how the graphs are ordered.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#namespaceditemfilter">NamespacedItemFilter</a></td>
+<td>
+
+Restricts which items are listed.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">sort</td>
+<td valign="top">[<a href="#metagraphsort">MetaGraphSort</a>!]</td>
+<td>
+
+Sort keys for the graphs, applied in order before paging.
 
 </td>
 </tr>
@@ -13606,6 +13684,288 @@ Destination node id (string or non-negative integer).
 </tbody>
 </table>
 
+### MetaGraphCondition
+
+One condition on a graph, testing either a built-in attribute or a metadata
+key. Set exactly one of `field` / `metadataKey`, as for `MetaGraphSort`.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphcondition.field">field</strong></td>
+<td valign="top"><a href="#metagraphfield">MetaGraphField</a></td>
+<td>
+
+Built-in attribute to test.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphcondition.metadatakey">metadataKey</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Metadata key to test.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphcondition.where">where</strong></td>
+<td valign="top"><a href="#propcondition">PropCondition</a>!</td>
+<td>
+
+Condition applied to the value, using the same grammar as property
+filters elsewhere in the schema. Names, paths and metadata strings are
+tested as strings; counts and timestamps as integers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphcondition.matchesifabsent">matchesIfAbsent</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Overrides the result when the graph has no value for the target.
+
+Set this when absence should read as a default rather than a non-match —
+e.g. treating a graph with no `archived` key as not archived, so
+`archived == false` still selects it. Applies to `field` too, since a
+graph may have no name.
+
+Left unset, the condition itself decides, which is what you want for
+conditions already about absence (`isNone`, `ne`).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphcondition.casesensitive">caseSensitive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Compare strings case-sensitively (defaults to false, matching
+`NamespaceFilter`). Only affects string comparisons: numbers, booleans
+and the string-encoded temporal/decimal values are unaffected.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MetaGraphFilter
+
+Narrows a namespace's graph listing.
+
+Composes the same way as the graph/node/edge filters: leaves test one
+attribute or metadata key, and `and` / `or` / `not` combine them.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphfilter.condition">condition</strong></td>
+<td valign="top"><a href="#metagraphcondition">MetaGraphCondition</a></td>
+<td>
+
+Condition on a built-in attribute or a metadata key.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphfilter.and">and</strong></td>
+<td valign="top">[<a href="#metagraphfilter">MetaGraphFilter</a>!]</td>
+<td>
+
+Logical AND over nested filters.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphfilter.or">or</strong></td>
+<td valign="top">[<a href="#metagraphfilter">MetaGraphFilter</a>!]</td>
+<td>
+
+Logical OR over nested filters.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphfilter.not">not</strong></td>
+<td valign="top"><a href="#metagraphfilter">MetaGraphFilter</a></td>
+<td>
+
+Logical NOT over a nested filter.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MetaGraphSort
+
+One sort key for a graph listing. Set exactly one of `field` or
+`metadataKey`. Keys are applied in order, each breaking ties left by the
+previous one; graphs missing the sort value sort last.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphsort.field">field</strong></td>
+<td valign="top"><a href="#metagraphfield">MetaGraphField</a></td>
+<td>
+
+Sort on a built-in attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphsort.metadatakey">metadataKey</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Sort on the value of this metadata key.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphsort.valueorder">valueOrder</strong></td>
+<td valign="top">[<a href="#value">Value</a>!]</td>
+<td>
+
+Explicit ordering for the values of `metadataKey`, lowest first. Values
+not listed sort after every listed one, among themselves by their natural
+order. Use for keys holding a small vocabulary whose meaningful order
+isn't alphabetical.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="metagraphsort.reverse">reverse</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Reverse this key's direction (default ascending).
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### NamespaceFilter
+
+Narrows a namespace's sub-namespace listing. Sub-namespaces carry no metadata
+of their own, so only their path can be matched.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong id="namespacefilter.pathcontains">pathContains</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Substring match against the namespace's path.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="namespacefilter.casesensitive">caseSensitive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Match `pathContains` case-sensitively (defaults to false).
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### NamespaceSort
+
+One sort key for a sub-namespace listing.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong id="namespacesort.reverse">reverse</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Reverse the path ordering (default ascending).
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### NamespacedItemFilter
+
+Narrows a namespace's heterogeneous `items` listing. Each half applies to the
+matching kind of item; an item whose kind has no filter is kept. To list only
+one kind, query `graphs` or `children` instead.
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong id="namespaceditemfilter.graphs">graphs</strong></td>
+<td valign="top"><a href="#metagraphfilter">MetaGraphFilter</a></td>
+<td>
+
+Applied to the graphs in the collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="namespaceditemfilter.namespaces">namespaces</strong></td>
+<td valign="top"><a href="#namespacefilter">NamespaceFilter</a></td>
+<td>
+
+Applied to the sub-namespaces in the collection.
+
+</td>
+</tr>
+</tbody>
+</table>
+
 ### NodeAddition
 
 <table>
@@ -15636,6 +15996,71 @@ Persistent.
 <td>
 
 Event.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MetaGraphField
+
+A graph's built-in attributes. Both filtering and sorting address them
+through this enum, so a client that knows how a column maps onto a field can
+drive either from one declaration.
+
+<table>
+<thead>
+<tr>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>NAME</strong></td>
+<td>
+
+The graph's name.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>PATH</strong></td>
+<td>
+
+The graph's full path.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>CREATED</strong></td>
+<td>
+
+Creation timestamp.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>LAST_UPDATED</strong></td>
+<td>
+
+Last-updated timestamp.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>NODE_COUNT</strong></td>
+<td>
+
+Number of nodes.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>EDGE_COUNT</strong></td>
+<td>
+
+Number of edges.
 
 </td>
 </tr>

--- a/python/python/raphtory/graphql/__init__.pyi
+++ b/python/python/raphtory/graphql/__init__.pyi
@@ -359,25 +359,6 @@ class RaphtoryClient(object):
             None:
         """
 
-    def viewer_permissions(self) -> dict[str, Any]:
-        """
-        Return this token's own permission grants.
-
-        Reads only what the calling role has been granted, so it never discloses
-        other roles or graphs. Available to any authenticated caller (does not
-        require an admin token). Only available when the server was started with
-        a permissions store.
-
-        Returns:
-            dict[str, Any]: a mapping with keys ``roles`` (list of str),
-            ``graphs`` (list of ``{"path", "permission", "filtered"}``) and
-            ``namespaces`` (list of ``{"path", "permission"}``). ``roles`` is empty
-            when the token carries no role claim, in which case both lists are empty.
-            A token naming several roles gets their grants merged
-            most-permissive-wins, so an unfiltered grant from one role supersedes a
-            filtered grant from another on the same graph.
-        """
-
     def with_token(self, token: str) -> RaphtoryClient:
         """
         Return a new client identical to this one but authenticating with a

--- a/raphtory-graphql/src/auth.rs
+++ b/raphtory-graphql/src/auth.rs
@@ -401,7 +401,8 @@ fn roles_from_value(v: &serde_json::Value) -> Vec<String> {
     }
 }
 
-pub(crate) trait ContextValidation {
+pub trait ContextValidation {
+    fn is_read_only(&self) -> bool;
     fn require_jwt_write_access(&self) -> Result<(), AuthError>;
 }
 
@@ -434,28 +435,15 @@ pub(crate) trait ContextValidation {
 #[derive(Clone, Copy, Debug)]
 pub struct ReadOnly;
 
-/// Whether this context is marked [`ReadOnly`].
-pub(crate) fn is_read_only(ctx: &async_graphql::Context<'_>) -> bool {
+pub(crate) fn is_read_only(ctx: &Context<'_>) -> bool {
     ctx.data::<ReadOnly>().is_ok()
 }
 
-/// Check that the request carries a write-access JWT (`"access": "rw"`).
-/// For use in dynamic resolver ops that run under `query { ... }` and are
-/// therefore not covered by the `MutationAuth` extension.
-pub fn require_jwt_write_access_dynamic(
-    ctx: &async_graphql::dynamic::ResolverContext,
-) -> Result<(), async_graphql::Error> {
-    if ctx.data::<Access>().is_ok_and(|a| a == &Access::Rw) {
-        Ok(())
-    } else {
-        Err(gql_error_with_code(
-            "Access denied: write access required",
-            CODE_ACCESS_DENIED,
-        ))
+impl<'a> ContextValidation for Context<'a> {
+    /// Whether this context is marked [`ReadOnly`].
+    fn is_read_only(&self) -> bool {
+        self.data::<ReadOnly>().is_ok()
     }
-}
-
-impl<'a> ContextValidation for &Context<'a> {
     fn require_jwt_write_access(&self) -> Result<(), AuthError> {
         // A read-only context never writes, however much access its token carries.
         if self.data::<ReadOnly>().is_ok() {

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -639,7 +639,7 @@ impl Data {
 // ---------------------------------------------------------------------------
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum PermissionError {
+pub enum PermissionError {
     /// Graph exists but caller has no namespace visibility — hide graph existence.
     #[error("Graph does not exist")]
     GraphNotFound,
@@ -673,16 +673,13 @@ pub(crate) enum PermissionError {
 /// `GRAPH_NOT_FOUND` must be emitted for both a genuinely missing graph and a
 /// forbidden-but-hidden graph, so the two are byte-for-byte indistinguishable to
 /// an unauthorized caller.
-pub(crate) const CODE_ACCESS_DENIED: &str = "ACCESS_DENIED";
-pub(crate) const CODE_GRAPH_NOT_FOUND: &str = "GRAPH_NOT_FOUND";
+pub const CODE_ACCESS_DENIED: &str = "ACCESS_DENIED";
+pub const CODE_GRAPH_NOT_FOUND: &str = "GRAPH_NOT_FOUND";
 
 /// Build an `async_graphql::Error` carrying a `code` in its extensions. The
 /// human-readable message is preserved unchanged; only the structured code is
 /// added, so the client can branch on it without parsing message text.
-pub(crate) fn gql_error_with_code(
-    message: impl Into<String>,
-    code: &'static str,
-) -> async_graphql::Error {
+pub fn gql_error_with_code(message: impl Into<String>, code: &'static str) -> async_graphql::Error {
     async_graphql::Error::new(message.into()).extend_with(|_, ext| ext.set("code", code))
 }
 
@@ -690,7 +687,7 @@ impl PermissionError {
     /// The `extensions.code` this denial surfaces to the client. `GraphNotFound`
     /// deliberately shares the code a genuinely missing graph produces so a
     /// forbidden graph cannot be distinguished from a nonexistent one.
-    pub(crate) fn code(&self) -> &'static str {
+    pub fn code(&self) -> &'static str {
         match self {
             PermissionError::GraphNotFound => CODE_GRAPH_NOT_FOUND,
             PermissionError::IntrospectOnly { .. }
@@ -701,7 +698,7 @@ impl PermissionError {
     }
 
     /// Convert into an `async_graphql::Error` tagged with the matching `code`.
-    pub(crate) fn into_gql_error(self) -> async_graphql::Error {
+    pub fn into_gql_error(self) -> async_graphql::Error {
         let code = self.code();
         gql_error_with_code(self.to_string(), code)
     }
@@ -816,7 +813,7 @@ pub(crate) fn require_graph_write(
     policy: &Option<Arc<dyn AuthorizationPolicy>>,
     path: &str,
 ) -> async_graphql::Result<()> {
-    if crate::auth::is_read_only(ctx) {
+    if ctx.is_read_only() {
         return Err(gql_error_with_code(
             "Access denied: this context may not write",
             CODE_ACCESS_DENIED,

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -679,8 +679,11 @@ pub const CODE_GRAPH_NOT_FOUND: &str = "GRAPH_NOT_FOUND";
 /// Build an `async_graphql::Error` carrying a `code` in its extensions. The
 /// human-readable message is preserved unchanged; only the structured code is
 /// added, so the client can branch on it without parsing message text.
-pub fn gql_error_with_code(message: impl Into<String>, code: &'static str) -> async_graphql::Error {
-    async_graphql::Error::new(message.into()).extend_with(|_, ext| ext.set("code", code))
+pub fn gql_error_with_code(
+    error: impl Into<async_graphql::Error>,
+    code: &'static str,
+) -> async_graphql::Error {
+    error.into().extend_with(|_, ext| ext.set("code", code))
 }
 
 impl PermissionError {

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -1,10 +1,11 @@
 #![recursion_limit = "256"]
 
 pub use crate::{
-    auth::{require_jwt_write_access_dynamic, Access, Roles, TokenClaimValues},
+    auth::{Access, KeyResolver, ReadOnly, Roles, StaticKeyResolver, TokenClaimValues},
     model::graph::{filtering::GraphAccessFilter, property::Value},
     server::GraphServer,
 };
+
 use crate::{data::InsertionError, paths::PathValidationError};
 pub use raphtory::db::graph::views::{PropertyRedactedGraph, PropertyRedaction};
 use raphtory::errors::GraphError;
@@ -13,7 +14,6 @@ use std::sync::Arc;
 pub mod auth;
 pub mod auth_policy;
 
-pub use auth::{KeyResolver, ReadOnly, StaticKeyResolver};
 pub mod cache;
 pub mod cli;
 pub mod client;

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -10,7 +10,7 @@ pub use raphtory::db::graph::views::{PropertyRedactedGraph, PropertyRedaction};
 use raphtory::errors::GraphError;
 use std::sync::Arc;
 
-mod auth;
+pub mod auth;
 pub mod auth_policy;
 
 pub use auth::{KeyResolver, ReadOnly, StaticKeyResolver};

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -1,7 +1,9 @@
 #![recursion_limit = "256"]
 
 pub use crate::{
-    auth::{Access, KeyResolver, ReadOnly, Roles, StaticKeyResolver, TokenClaimValues, RolesMissing},
+    auth::{
+        Access, KeyResolver, ReadOnly, Roles, RolesMissing, StaticKeyResolver, TokenClaimValues,
+    },
     model::graph::{filtering::GraphAccessFilter, property::Value},
     server::GraphServer,
 };

--- a/raphtory-graphql/src/model/mod.rs
+++ b/raphtory-graphql/src/model/mod.rs
@@ -125,7 +125,7 @@ fn require_namespace_write(
     new_path: &str,
     operation: &str,
 ) -> Result<()> {
-    if crate::auth::is_read_only(ctx) {
+    if ctx.is_read_only() {
         return Err(gql_error_with_code(
             "Access denied: this context may not write",
             CODE_ACCESS_DENIED,

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -33,7 +33,7 @@ pub async fn blocking_compute<R: Send + 'static, F: FnOnce() -> R + Send + 'stat
     closure: F,
 ) -> R {
     let (send, recv) = oneshot::channel();
-    COMPUTE_POOL.spawn_fifo(move || {
+    COMPUTE_POOL.spawn(move || {
         let _ = send.send(closure()); // this only errors if no-one is listening anymore
     });
 

--- a/raphtory-server/src/main.rs
+++ b/raphtory-server/src/main.rs
@@ -1,7 +1,9 @@
 use std::io::Result as IoResult;
 
+// link in the auth plugin
+extern crate auth;
+
 #[tokio::main]
 async fn main() -> IoResult<()> {
-    auth::init();
     raphtory_graphql::cli::cli().await
 }

--- a/raphtory-server/tests/cli_parsing.rs
+++ b/raphtory-server/tests/cli_parsing.rs
@@ -1,13 +1,15 @@
 use std::{
     io::Write,
     process::{Command, Stdio},
-    time::Duration,
 };
 
 use raphtory_graphql::config::{app_config::AppConfig, cache_config::DEFAULT_CACHE_CAPACITY};
 use serde::Deserialize;
 use serde_json::Value;
 use tempfile::Builder;
+
+// link in the auth plugin
+extern crate auth;
 
 fn server_bin() -> std::path::PathBuf {
     std::env::var_os("NEXTEST_BIN_EXE_raphtory-server")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Core apis for managing auth and errors were private which meant that extensions had to reimplement them instead of using the existing implementations 

### Why are the changes needed?

Extensions implementing their own versions of these core functions risk diverging behaviour

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?


