### PR TITLE
Expose the auth surface an out-of-tree authorization plugin needs

### DIFF
--- a/raphtory-graphql/src/auth.rs
+++ b/raphtory-graphql/src/auth.rs
@@ -436,7 +436,7 @@ fn roles_from_value(v: &serde_json::Value) -> Vec<String> {
     }
 }
 
-pub(crate) trait ContextValidation {
+pub trait ContextValidation {
     fn require_jwt_write_access(&self) -> Result<(), AuthError>;
 }
 

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -677,16 +677,13 @@ pub(crate) enum PermissionError {
 /// `GRAPH_NOT_FOUND` must be emitted for both a genuinely missing graph and a
 /// forbidden-but-hidden graph, so the two are byte-for-byte indistinguishable to
 /// an unauthorized caller.
-pub(crate) const CODE_ACCESS_DENIED: &str = "ACCESS_DENIED";
-pub(crate) const CODE_GRAPH_NOT_FOUND: &str = "GRAPH_NOT_FOUND";
+pub const CODE_ACCESS_DENIED: &str = "ACCESS_DENIED";
+pub const CODE_GRAPH_NOT_FOUND: &str = "GRAPH_NOT_FOUND";
 
 /// Build an `async_graphql::Error` carrying a `code` in its extensions. The
 /// human-readable message is preserved unchanged; only the structured code is
 /// added, so the client can branch on it without parsing message text.
-pub(crate) fn gql_error_with_code(
-    message: impl Into<String>,
-    code: &'static str,
-) -> async_graphql::Error {
+pub fn gql_error_with_code(message: impl Into<String>, code: &'static str) -> async_graphql::Error {
     async_graphql::Error::new(message.into()).extend_with(|_, ext| ext.set("code", code))
 }
 

--- a/raphtory-graphql/src/lib.rs
+++ b/raphtory-graphql/src/lib.rs
@@ -10,7 +10,10 @@ pub use raphtory::db::graph::views::{PropertyRedactedGraph, PropertyRedaction};
 use raphtory::errors::GraphError;
 use std::sync::Arc;
 
-mod auth;
+/// Public so an out-of-tree authorization plugin (registered via
+/// [`plugin::schema::RegisterPlugin`]) can reach [`auth::ContextValidation`] from typed
+/// resolvers; [`require_jwt_write_access_dynamic`] covers only dynamic ones.
+pub mod auth;
 pub mod auth_policy;
 
 pub use auth::{KeyResolver, ReadOnly, StaticKeyResolver};

--- a/raphtory-graphql/src/model/graph/namespace.rs
+++ b/raphtory-graphql/src/model/graph/namespace.rs
@@ -17,7 +17,6 @@ use async_graphql::Context;
 use dynamic_graphql::{ResolvedObject, ResolvedObjectFields, Result};
 use itertools::Itertools;
 use std::{cmp::Ordering, path::PathBuf, sync::Arc};
-use tracing::error;
 use walkdir::WalkDir;
 
 /// A directory-like container for graphs and nested namespaces. Graphs are


### PR DESCRIPTION
## What changes were proposed in this pull request?

Four visibility changes, no behaviour: `pub mod auth`, `pub trait ContextValidation`,
`pub fn gql_error_with_code`, and the two `CODE_*` extension-code constants.

An authorization policy registered through `RegisterPlugin` lives outside this crate but guards
its resolvers, so it needs the same tools they use: `ContextValidation` for typed resolvers
(`require_jwt_write_access_dynamic` covers only dynamic ones), and the error helper with its code
constants so the plugin's denials carry the machine-readable codes the client already branches
on, rather than restating the strings and drifting.

## Why are the changes needed?

These were public on the branch #2731 was developed on and lost visibility on the way to db_v4.
The auth plugin in the private repository already depends on them; without this it cannot compile
against db_v4.

## Does this PR introduce any user-facing change? If yes is this documented?

No.

## How was this patch tested?

`cargo check --all-features` clean here; the private workspace that consumes the surface builds
against this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)