### PR TITLE
add early stopping to dijkstra when all targets are covered

### DIFF
--- a/raphtory-benchmark/benches/algobench_medium.rs
+++ b/raphtory-benchmark/benches/algobench_medium.rs
@@ -216,12 +216,17 @@ pub fn graphgen_dijkstra(c: &mut Criterion) {
         5,
         10,
         medium_random_attachment_graph,
-        first_node_id,
-        |graph, source| {
+        |graph| {
+            (
+                first_node_id(graph),
+                graph.nodes().id().iter_values().last().unwrap(),
+            )
+        },
+        |graph, (source, dst)| {
             dijkstra_single_source_shortest_paths(
                 graph,
                 source.clone(),
-                vec![source.clone()],
+                vec![dst.clone()],
                 None,
                 Direction::BOTH,
             )

--- a/raphtory-tests/tests/algo_tests/pathing.rs
+++ b/raphtory-tests/tests/algo_tests/pathing.rs
@@ -422,6 +422,36 @@ mod dijkstra_tests {
             );
         });
     }
+
+    #[test]
+    fn test_dijkstra_no_weight_undirected_repeated_target() {
+        let edges = vec![
+            (0, "C", "A", vec![("weight", 4u64)]),
+            (1, "A", "B", vec![("weight", 4u64)]),
+            (3, "C", "D", vec![("weight", 3u64)]),
+        ];
+
+        let graph = Graph::new();
+
+        for (t, src, dst, props) in edges {
+            graph.add_edge(t, src, dst, props, None).unwrap();
+        }
+
+        let targets: Vec<&str> = vec!["D", "D", "D"];
+        let results =
+            dijkstra_single_source_shortest_paths(&graph, "A", targets, None, Direction::BOTH)
+                .unwrap();
+        assert_eq!(
+            results
+                .get_by_node("D")
+                .unwrap()
+                .path
+                .into_iter()
+                .map(|value| graph.node(value).unwrap().name())
+                .collect_vec(),
+            vec!["A", "C", "D"]
+        );
+    }
 }
 
 mod sssp_tests {

--- a/raphtory/src/algorithms/pathing/dijkstra.rs
+++ b/raphtory/src/algorithms/pathing/dijkstra.rs
@@ -125,11 +125,15 @@ pub fn dijkstra_single_source_shortest_paths<G: StaticGraphViewOps, T: AsNodeRef
         }
     }
 
+    let mut num_targets_remaining = 0usize;
     let mut target_nodes = vec![false; g.count_nodes()];
     for target in targets {
         if let Some(target_node) = g.node(target) {
             let pos = index.index(&target_node.node).unwrap();
-            target_nodes[pos] = true;
+            if !target_nodes[pos] {
+                target_nodes[pos] = true;
+                num_targets_remaining += 1;
+            }
         }
     }
 
@@ -185,6 +189,7 @@ pub fn dijkstra_single_source_shortest_paths<G: StaticGraphViewOps, T: AsNodeRef
     {
         let pos = index.index(&node_vid).unwrap();
         if target_nodes[pos] && !paths.contains_key(&node_vid) {
+            num_targets_remaining -= 1;
             let mut path = IndexSet::default();
             path.insert(node_vid);
             let mut current_node_id = node_vid;
@@ -194,6 +199,9 @@ pub fn dijkstra_single_source_shortest_paths<G: StaticGraphViewOps, T: AsNodeRef
             }
             path.reverse();
             paths.insert(node_vid, (cost.as_f64().unwrap(), path));
+        }
+        if num_targets_remaining == 0 {
+            break;
         }
         if !visited.insert(node_vid) {
             continue;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the stopping criterion in the `dijkstra_single_source_shortest_paths` algorithm.

### Why are the changes needed?

The `dijkstra_single_source_shortest_paths` algorithm was not stopping when all targets were covered but continued to explore the entire graph.

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

benchmark results and tests

### Are there any further changes required?


