### PR TITLE
Graphql Scheduling changes and update benchmark

### DIFF
--- a/graphql-bench/process-k6-output.py
+++ b/graphql-bench/process-k6-output.py
@@ -34,8 +34,21 @@ def find_max_rate(scenario_name):
     # perf = valid_trend.loc[max_rate_index]
     # return pd.Series(perf, name=scenario_name)
 
+# The scheduling pair runs under deliberate saturation, so the p95-gated max-rate is meaningless
+# for it; report the steady completed rate instead (collapses if short queries starve).
+UNDER_LOAD_SCENARIOS = {"heavy_load", "short_queries_under_heavy_load"}
+
+def steady_rate(scenario_name):
+    scenario = output[output["scenario"] == scenario_name]
+    req_duration = scenario[scenario["metric_name"] == "http_req_duration"]
+    rate = req_duration["metric_value"].resample('1s').count()
+    return rate.iloc[10:].mean() # discard first 10 seconds
+
 scenarios = output["scenario"].unique()[1:] # first element is nan
-max_rates = [find_max_rate(scenario) for scenario in scenarios]
+max_rates = [
+    steady_rate(scenario) if scenario in UNDER_LOAD_SCENARIOS else find_max_rate(scenario)
+    for scenario in scenarios
+]
 
 results = [{"name": name, "unit": "req/s", "value": value} for (name, value) in zip(scenarios, max_rates)]
 df = pd.DataFrame(results)

--- a/graphql-bench/server.py
+++ b/graphql-bench/server.py
@@ -20,15 +20,15 @@ if not os.path.exists(BIG_PATH):
     for start in range(0, BIG_NODES, chunk):
         hi = min(start + chunk, BIG_NODES)
         g.load_nodes(
-            pd.DataFrame({"id": np.arange(start, hi, dtype="uint64"), "time": 1}),
+            pd.DataFrame({"id": np.arange(start, hi).astype(str), "time": 1}),
             time="time",
             id="id",
         )
         g.load_edges(
             pd.DataFrame(
                 {
-                    "src": rng.integers(0, hi, size=hi - start, dtype="uint64"),
-                    "dst": rng.integers(0, hi, size=hi - start, dtype="uint64"),
+                    "src": rng.integers(0, hi, size=hi - start).astype(str),
+                    "dst": rng.integers(0, hi, size=hi - start).astype(str),
                     "time": 1,
                 }
             ),

--- a/graphql-bench/server.py
+++ b/graphql-bench/server.py
@@ -1,4 +1,42 @@
-from raphtory import graphql
+import logging
+import os
 
-server = graphql.GraphServer(work_dir="data/apache")
-server.run()
+import numpy as np
+import pandas as pd
+from raphtory import Graph, graphql
+
+logging.basicConfig(level=logging.INFO)
+
+# Graph for the heavy_load / short_queries_under_heavy_load scenarios: big enough that a full
+# name scan takes hundreds of milliseconds. Built once and cached.
+BIG_NODES = int(os.environ.get("BENCH_BIG_NODES", "5000000"))
+BIG_PATH = os.path.join("data", "apache", "big")
+
+if not os.path.exists(BIG_PATH):
+    logging.info("building the %s-node bench graph at %s", BIG_NODES, BIG_PATH)
+    rng = np.random.default_rng(seed=42)
+    g = Graph()
+    chunk = 1_000_000
+    for start in range(0, BIG_NODES, chunk):
+        hi = min(start + chunk, BIG_NODES)
+        g.load_nodes(
+            pd.DataFrame({"id": np.arange(start, hi, dtype="uint64"), "time": 1}),
+            time="time",
+            id="id",
+        )
+        g.load_edges(
+            pd.DataFrame(
+                {
+                    "src": rng.integers(0, hi, size=hi - start, dtype="uint64"),
+                    "dst": rng.integers(0, hi, size=hi - start, dtype="uint64"),
+                    "time": 1,
+                }
+            ),
+            time="time",
+            src="src",
+            dst="dst",
+        )
+    g.save_to_file(BIG_PATH)
+    del g
+
+graphql.GraphServer(work_dir="data/apache").run()

--- a/graphql-bench/src/bench.ts
+++ b/graphql-bench/src/bench.ts
@@ -28,8 +28,15 @@ const execs = [
   nodePropsByName,
   nodeNeighboursByName,
   readAndWriteNodeProperties,
+  shortestPathSingleSource,
+  pagerank,
+  degreeCentrality,
 ];
-const rampingScenarios = execs.map(
+
+// Run a subset of the ramping scenarios, e.g. k6 run -e ONLY=pagerank,degreeCentrality dist/bench.js
+const only = __ENV.ONLY ? new Set(String(__ENV.ONLY).split(",")) : null;
+const enabledExecs = only ? execs.filter((e) => only.has(e.name)) : execs;
+const rampingScenarios = enabledExecs.map(
   (exec, index) =>
     [
       exec.name,
@@ -55,7 +62,7 @@ const rampingScenarios = execs.map(
 // collapses; if short queries get slots promptly, the rate matches the offered rate.
 // Run only this pair (30s) with: k6 run -e SCHEDULING_ONLY=1 dist/bench.js
 const schedulingOnly = Boolean(__ENV.SCHEDULING_ONLY);
-const schedulingStart = schedulingOnly ? "0s" : `${execs.length * minutesPerScenario}m`;
+const schedulingStart = schedulingOnly ? "0s" : `${enabledExecs.length * minutesPerScenario}m`;
 const schedulingDuration = schedulingOnly ? "30s" : "2m";
 const schedulingScenarios = {
   heavy_load: {
@@ -82,7 +89,7 @@ const schedulingScenarios = {
 export const options = {
   scenarios: {
     ...(schedulingOnly ? {} : Object.fromEntries(rampingScenarios)),
-    ...schedulingScenarios,
+    ...(only ? {} : schedulingScenarios),
   },
   // Empty thresholds split these out in the end-of-run summary, so the short queries' latency
   // under load is visible directly rather than folded into the heavy queries' distribution.
@@ -243,6 +250,46 @@ export function nodeNeighboursByName() {
           list: {
             name: true,
           },
+        },
+      },
+    },
+  });
+}
+
+export function shortestPathSingleSource() {
+  fetchAndCheck(errorRate, {
+    graph: {
+      __args: { path: "master" },
+      algorithm: {
+        singleSourceShortestPath: {
+          __args: { source: "SPARK-22386" },
+          count: true,
+        },
+      },
+    },
+  });
+}
+
+export function pagerank() {
+  fetchAndCheck(errorRate, {
+    graph: {
+      __args: { path: "master" },
+      algorithm: {
+        pagerank: {
+          count: true,
+        },
+      },
+    },
+  });
+}
+
+export function degreeCentrality() {
+  fetchAndCheck(errorRate, {
+    graph: {
+      __args: { path: "master" },
+      algorithm: {
+        degreeCentrality: {
+          count: true,
         },
       },
     },

--- a/graphql-bench/src/bench.ts
+++ b/graphql-bench/src/bench.ts
@@ -29,7 +29,7 @@ const execs = [
   nodeNeighboursByName,
   readAndWriteNodeProperties,
 ];
-const scenarios = execs.map(
+const rampingScenarios = execs.map(
   (exec, index) =>
     [
       exec.name,
@@ -49,8 +49,47 @@ const scenarios = execs.map(
     ] as const,
 );
 
+// Scheduling scenario: full-graph scans saturate the server's compute pool while short
+// queries arrive at a fixed rate. The tracked metric is the short queries' completed rate: if the
+// scheduler starves them behind the scans, probe VUs jam on in-flight requests and the rate
+// collapses; if short queries get slots promptly, the rate matches the offered rate.
+// Run only this pair (30s) with: k6 run -e SCHEDULING_ONLY=1 dist/bench.js
+const schedulingOnly = Boolean(__ENV.SCHEDULING_ONLY);
+const schedulingStart = schedulingOnly ? "0s" : `${execs.length * minutesPerScenario}m`;
+const schedulingDuration = schedulingOnly ? "30s" : "2m";
+const schedulingScenarios = {
+  heavy_load: {
+    executor: "constant-vus",
+    exec: "heavyNameScan",
+    vus: 24,
+    duration: schedulingDuration,
+    startTime: schedulingStart,
+  },
+  short_queries_under_heavy_load: {
+    executor: "constant-arrival-rate",
+    exec: "shortCountNodes",
+    // Below the dispatch capacity under heavy load: this models occasional short queries (health
+    // checks, dashboards) during sustained heavy traffic, not a short-query flood.
+    rate: 2,
+    timeUnit: "1s",
+    duration: schedulingDuration,
+    preAllocatedVUs: 5,
+    maxVUs: 25,
+    startTime: schedulingStart,
+  },
+};
+
 export const options = {
-  scenarios: Object.fromEntries(scenarios),
+  scenarios: {
+    ...(schedulingOnly ? {} : Object.fromEntries(rampingScenarios)),
+    ...schedulingScenarios,
+  },
+  // Empty thresholds split these out in the end-of-run summary, so the short queries' latency
+  // under load is visible directly rather than folded into the heavy queries' distribution.
+  thresholds: {
+    "http_req_duration{scenario:heavy_load}": [],
+    "http_req_duration{scenario:short_queries_under_heavy_load}": [],
+  },
 };
 
 type SetupData = {
@@ -81,6 +120,17 @@ export function setup(): SetupData {
     graph: {
       __args: {
         path: "empty",
+      },
+      countNodes: true,
+    },
+  });
+
+  // Load the generated `big` graph before the scheduling scenarios start, so their measurements
+  // reflect scheduling rather than the one-off multi-second graph load.
+  fetchAndCheck(errorRate, {
+    graph: {
+      __args: {
+        path: "big",
       },
       countNodes: true,
     },
@@ -248,4 +298,27 @@ export function readAndWriteNodeProperties(input: SetupData) {
       },
     });
   }
+}
+
+// A full name scan over the generated `big` graph: one long uninterrupted parallel task per
+// request, the load shape that monopolises the compute pool.
+export function heavyNameScan() {
+  fetchAndCheck(errorRate, {
+    graph: {
+      __args: { path: "big" },
+      nodes: {
+        __args: { select: { name: { where: { contains: { str: "99999" } } } } },
+        count: true,
+      },
+    },
+  });
+}
+
+export function shortCountNodes() {
+  fetchAndCheck(errorRate, {
+    graph: {
+      __args: { path: "big" },
+      countNodes: true,
+    },
+  });
 }

--- a/raphtory-graphql/schema.graphql
+++ b/raphtory-graphql/schema.graphql
@@ -7790,4 +7790,3 @@ schema {
 	query: QueryRoot
 	mutation: MutRoot
 }
-

--- a/raphtory-graphql/src/config/app_config.rs
+++ b/raphtory-graphql/src/config/app_config.rs
@@ -381,18 +381,6 @@ impl AppConfigBuilder {
                                         .map_err(|e| invalid_value([path, sub_path], e))?,
                                 );
                             }
-                            ConcurrencyConfigFieldName::MaxConcurrentQueries => {
-                                self.with_max_concurrent_queries(
-                                    Deserialize::deserialize(value)
-                                        .map_err(|e| invalid_value([path, sub_path], e))?,
-                                );
-                            }
-                            ConcurrencyConfigFieldName::NewestFirstScheduling => {
-                                self.with_newest_first_scheduling(
-                                    Deserialize::deserialize(value)
-                                        .map_err(|e| invalid_value([path, sub_path], e))?,
-                                );
-                            }
                             ConcurrencyConfigFieldName::MaxConcurrentLoads => {
                                 self.with_max_concurrent_loads(
                                     Deserialize::deserialize(value)
@@ -610,19 +598,6 @@ impl AppConfigBuilder {
 
     pub fn with_express_threads(&mut self, express_threads: usize) -> &mut Self {
         self.config.concurrency.express_threads = express_threads;
-        self
-    }
-
-    pub fn with_max_concurrent_queries(
-        &mut self,
-        max_concurrent_queries: Option<usize>,
-    ) -> &mut Self {
-        self.config.concurrency.max_concurrent_queries = max_concurrent_queries;
-        self
-    }
-
-    pub fn with_newest_first_scheduling(&mut self, newest_first_scheduling: bool) -> &mut Self {
-        self.config.concurrency.newest_first_scheduling = newest_first_scheduling;
         self
     }
 

--- a/raphtory-graphql/src/config/app_config.rs
+++ b/raphtory-graphql/src/config/app_config.rs
@@ -375,12 +375,6 @@ impl AppConfigBuilder {
                                         .map_err(|e| invalid_value([path, sub_path], e))?,
                                 );
                             }
-                            ConcurrencyConfigFieldName::ExpressThreads => {
-                                self.with_express_threads(
-                                    Deserialize::deserialize(value)
-                                        .map_err(|e| invalid_value([path, sub_path], e))?,
-                                );
-                            }
                             ConcurrencyConfigFieldName::MaxConcurrentLoads => {
                                 self.with_max_concurrent_loads(
                                     Deserialize::deserialize(value)
@@ -593,11 +587,6 @@ impl AppConfigBuilder {
 
     pub fn with_max_page_size(&mut self, max_page_size: Option<usize>) -> &mut Self {
         self.config.concurrency.max_page_size = max_page_size;
-        self
-    }
-
-    pub fn with_express_threads(&mut self, express_threads: usize) -> &mut Self {
-        self.config.concurrency.express_threads = express_threads;
         self
     }
 

--- a/raphtory-graphql/src/config/app_config.rs
+++ b/raphtory-graphql/src/config/app_config.rs
@@ -369,6 +369,30 @@ impl AppConfigBuilder {
                                         .map_err(|e| invalid_value([path, sub_path], e))?,
                                 );
                             }
+                            ConcurrencyConfigFieldName::ExpressThreads => {
+                                self.with_express_threads(
+                                    Deserialize::deserialize(value)
+                                        .map_err(|e| invalid_value([path, sub_path], e))?,
+                                );
+                            }
+                            ConcurrencyConfigFieldName::MaxConcurrentQueries => {
+                                self.with_max_concurrent_queries(
+                                    Deserialize::deserialize(value)
+                                        .map_err(|e| invalid_value([path, sub_path], e))?,
+                                );
+                            }
+                            ConcurrencyConfigFieldName::NewestFirstScheduling => {
+                                self.with_newest_first_scheduling(
+                                    Deserialize::deserialize(value)
+                                        .map_err(|e| invalid_value([path, sub_path], e))?,
+                                );
+                            }
+                            ConcurrencyConfigFieldName::MaxConcurrentLoads => {
+                                self.with_max_concurrent_loads(
+                                    Deserialize::deserialize(value)
+                                        .map_err(|e| invalid_value([path, sub_path], e))?,
+                                );
+                            }
                             ConcurrencyConfigFieldName::MaxPageSize => {
                                 self.with_max_page_size(
                                     Deserialize::deserialize(value)
@@ -570,6 +594,29 @@ impl AppConfigBuilder {
 
     pub fn with_max_page_size(&mut self, max_page_size: Option<usize>) -> &mut Self {
         self.config.concurrency.max_page_size = max_page_size;
+        self
+    }
+
+    pub fn with_express_threads(&mut self, express_threads: usize) -> &mut Self {
+        self.config.concurrency.express_threads = express_threads;
+        self
+    }
+
+    pub fn with_max_concurrent_queries(
+        &mut self,
+        max_concurrent_queries: Option<usize>,
+    ) -> &mut Self {
+        self.config.concurrency.max_concurrent_queries = max_concurrent_queries;
+        self
+    }
+
+    pub fn with_newest_first_scheduling(&mut self, newest_first_scheduling: bool) -> &mut Self {
+        self.config.concurrency.newest_first_scheduling = newest_first_scheduling;
+        self
+    }
+
+    pub fn with_max_concurrent_loads(&mut self, max_concurrent_loads: Option<usize>) -> &mut Self {
+        self.config.concurrency.max_concurrent_loads = max_concurrent_loads;
         self
     }
 

--- a/raphtory-graphql/src/config/app_config.rs
+++ b/raphtory-graphql/src/config/app_config.rs
@@ -234,6 +234,12 @@ impl AppConfigBuilder {
                                         .map_err(|e| invalid_value([path, sub_path], e))?,
                                 );
                             }
+                            CacheConfigFieldName::ReadOnly => {
+                                self.with_cache_read_only(
+                                    Deserialize::deserialize(value)
+                                        .map_err(|e| invalid_value([path, sub_path], e))?,
+                                );
+                            }
                         }
                     }
                 }
@@ -534,6 +540,11 @@ impl AppConfigBuilder {
 
     pub fn with_cache_capacity(&mut self, cache_capacity: u64) -> &mut Self {
         self.config.cache.capacity = cache_capacity;
+        self
+    }
+
+    pub fn with_cache_read_only(&mut self, read_only: bool) -> &mut Self {
+        self.config.cache.read_only = read_only;
         self
     }
 

--- a/raphtory-graphql/src/config/cache_config.rs
+++ b/raphtory-graphql/src/config/cache_config.rs
@@ -6,12 +6,16 @@ pub const DEFAULT_CACHE_CAPACITY: u64 = 30;
 #[derive(Debug, Deserialize, PartialEq, Clone, serde::Serialize, FieldName)]
 pub struct CacheConfig {
     pub capacity: u64,
+    /// Serve every graph read-only: reads skip per-access segment locking entirely and
+    /// graph mutations fail. For deployments whose workload has no updates.
+    pub read_only: bool,
 }
 
 impl Default for CacheConfig {
     fn default() -> Self {
         Self {
             capacity: DEFAULT_CACHE_CAPACITY,
+            read_only: false,
         }
     }
 }

--- a/raphtory-graphql/src/config/concurrency_config.rs
+++ b/raphtory-graphql/src/config/concurrency_config.rs
@@ -49,16 +49,6 @@ pub struct ConcurrencyConfig {
     /// the compute pool so they stay responsive while heavy queries saturate it.
     pub express_threads: usize,
 
-    /// Max query closures running on the compute pool at once; the rest queue. Prevents heavy
-    /// queries time-sharing every thread, so slots free up quickly. `None` = half the compute
-    /// threads: raising it amplifies storage-lock contention faster than it adds parallelism.
-    pub max_concurrent_queries: Option<usize>,
-
-    /// Dispatch queued queries newest-first, so a fresh short query jumps a backlog of heavy ones
-    /// instead of waiting for it to drain. Old waiters are periodically dispatched first so a
-    /// sustained backlog cannot starve them.
-    pub newest_first_scheduling: bool,
-
     /// Maximum graph loads decoding at once. Each in-flight load holds a whole graph in memory,
     /// so this bounds peak memory when many graphs are requested together. `None` = cores / 4,
     /// at least 2.
@@ -75,8 +65,6 @@ impl Default for ConcurrencyConfig {
             disable_lists: DEFAULT_DISABLE_LISTS,
             max_page_size: None,
             express_threads: default_express_threads(),
-            max_concurrent_queries: None,
-            newest_first_scheduling: true,
             max_concurrent_loads: None,
         }
     }

--- a/raphtory-graphql/src/config/concurrency_config.rs
+++ b/raphtory-graphql/src/config/concurrency_config.rs
@@ -50,7 +50,8 @@ pub struct ConcurrencyConfig {
     pub express_threads: usize,
 
     /// Max query closures running on the compute pool at once; the rest queue. Prevents heavy
-    /// queries time-sharing every thread, so slots free up quickly. `None` = one per compute thread.
+    /// queries time-sharing every thread, so slots free up quickly. `None` = half the compute
+    /// threads: raising it amplifies storage-lock contention faster than it adds parallelism.
     pub max_concurrent_queries: Option<usize>,
 
     /// Dispatch queued queries newest-first, so a fresh short query jumps a backlog of heavy ones

--- a/raphtory-graphql/src/config/concurrency_config.rs
+++ b/raphtory-graphql/src/config/concurrency_config.rs
@@ -1,4 +1,3 @@
-use crate::rayon::default_express_threads;
 use field_types::FieldName;
 use serde::{Deserialize, Serialize};
 
@@ -45,10 +44,6 @@ pub struct ConcurrencyConfig {
     /// `None` means unlimited.
     pub max_page_size: Option<usize>,
 
-    /// Threads reserved for the express pool (health checks and cheap resolvers), taken out of
-    /// the compute pool so they stay responsive while heavy queries saturate it.
-    pub express_threads: usize,
-
     /// Maximum graph loads decoding at once. Each in-flight load holds a whole graph in memory,
     /// so this bounds peak memory when many graphs are requested together. `None` = cores / 4,
     /// at least 2.
@@ -64,7 +59,6 @@ impl Default for ConcurrencyConfig {
             max_batch_size: Some(DEFAULT_MAX_BATCH_SIZE),
             disable_lists: DEFAULT_DISABLE_LISTS,
             max_page_size: None,
-            express_threads: default_express_threads(),
             max_concurrent_loads: None,
         }
     }

--- a/raphtory-graphql/src/config/concurrency_config.rs
+++ b/raphtory-graphql/src/config/concurrency_config.rs
@@ -1,3 +1,4 @@
+use crate::rayon::default_express_threads;
 use field_types::FieldName;
 use serde::{Deserialize, Serialize};
 
@@ -43,6 +44,24 @@ pub struct ConcurrencyConfig {
     /// of `page` so clients can't circumvent `disable_lists` by requesting huge pages.
     /// `None` means unlimited.
     pub max_page_size: Option<usize>,
+
+    /// Threads reserved for the express pool (health checks and cheap resolvers), taken out of
+    /// the compute pool so they stay responsive while heavy queries saturate it.
+    pub express_threads: usize,
+
+    /// Max query closures running on the compute pool at once; the rest queue. Prevents heavy
+    /// queries time-sharing every thread, so slots free up quickly. `None` = compute threads / 2.
+    pub max_concurrent_queries: Option<usize>,
+
+    /// Dispatch queued queries newest-first, so a fresh short query jumps a backlog of heavy ones
+    /// instead of waiting for it to drain. Old waiters are periodically dispatched first so a
+    /// sustained backlog cannot starve them.
+    pub newest_first_scheduling: bool,
+
+    /// Maximum graph loads decoding at once. Each in-flight load holds a whole graph in memory,
+    /// so this bounds peak memory when many graphs are requested together. `None` = cores / 4,
+    /// at least 2.
+    pub max_concurrent_loads: Option<usize>,
 }
 
 impl Default for ConcurrencyConfig {
@@ -54,6 +73,10 @@ impl Default for ConcurrencyConfig {
             max_batch_size: Some(DEFAULT_MAX_BATCH_SIZE),
             disable_lists: DEFAULT_DISABLE_LISTS,
             max_page_size: None,
+            express_threads: default_express_threads(),
+            max_concurrent_queries: None,
+            newest_first_scheduling: true,
+            max_concurrent_loads: None,
         }
     }
 }

--- a/raphtory-graphql/src/config/concurrency_config.rs
+++ b/raphtory-graphql/src/config/concurrency_config.rs
@@ -50,7 +50,7 @@ pub struct ConcurrencyConfig {
     pub express_threads: usize,
 
     /// Max query closures running on the compute pool at once; the rest queue. Prevents heavy
-    /// queries time-sharing every thread, so slots free up quickly. `None` = compute threads / 2.
+    /// queries time-sharing every thread, so slots free up quickly. `None` = one per compute thread.
     pub max_concurrent_queries: Option<usize>,
 
     /// Dispatch queued queries newest-first, so a fresh short query jumps a backlog of heavy ones

--- a/raphtory-graphql/src/data.rs
+++ b/raphtory-graphql/src/data.rs
@@ -165,6 +165,7 @@ pub struct DataInner {
     #[cfg(feature = "vectors")]
     pub(crate) vector_cache: LazyDiskVectorCache,
     pub(crate) graph_conf: Config,
+    pub(crate) read_only: bool,
     pub(crate) auth_policy: Option<Arc<dyn AuthorizationPolicy>>,
     pub(crate) allowed_parquet_paths: Vec<PathBuf>,
 }
@@ -306,6 +307,7 @@ impl Data {
                 #[cfg(feature = "vectors")]
                 vector_cache: LazyDiskVectorCache::new(work_dir.join(".vector-cache")),
                 graph_conf,
+                read_only: cache_configs.read_only,
                 auth_policy: None,
                 allowed_parquet_paths: configs.parquet.allowed_paths.clone(),
             }),
@@ -393,6 +395,7 @@ impl Data {
     ) -> Result<(), InsertionError> {
         let key = writeable_folder.local_path().to_owned();
         let config = self.graph_conf.clone();
+        let read_only = self.read_only;
         self.cache
             .insert_or_replace_with(&key, |old_graph| async {
                 invalidate_graph(old_graph).await;
@@ -401,7 +404,11 @@ impl Data {
                     let folder = writeable_folder.finish()?;
                     let graph = GraphWithVectors::new(new_graph, None, folder.as_existing()?);
                     graph.set_dirty(is_dirty);
-                    Ok::<_, InsertionError>(graph)
+                    Ok::<_, InsertionError>(if read_only {
+                        graph.into_read_only()
+                    } else {
+                        graph
+                    })
                 })
                 .await
             })
@@ -618,13 +625,18 @@ impl Data {
         let config = self.graph_conf.clone();
         #[cfg(feature = "vectors")]
         let cache = self.vector_cache.clone();
-        GraphWithVectors::read_from_folder(
+        let graph = GraphWithVectors::read_from_folder(
             &folder,
             #[cfg(feature = "vectors")]
             &cache,
             config,
         )
-        .await
+        .await?;
+        Ok(if self.read_only {
+            graph.into_read_only()
+        } else {
+            graph
+        })
     }
 
     async fn read_graph_from_disk(&self, path: &str) -> Result<GraphWithVectors, GQLError> {
@@ -1120,6 +1132,29 @@ pub(crate) mod data_tests {
             data.insert_graph(folder, graph.clone()).await?;
         }
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_only_graphs_reject_mutations_and_serve_reads() {
+        let tmp_work_dir = tempfile::tempdir().unwrap();
+        let graph = Graph::new();
+        graph.add_edge(0, 1, 2, NO_PROPS, None).unwrap();
+        let path = tmp_work_dir.path().join("g");
+        fs::create_dir_all(&path).unwrap();
+        graph.encode(&path).unwrap();
+
+        let config = AppConfigBuilder::new().with_cache_read_only(true).build();
+        let data = Data::new(tmp_work_dir.path(), &config, Default::default());
+        let served = data.get_graph_for_test("g").await.unwrap();
+        let served = served.graph().clone().into_events().unwrap();
+        assert_eq!(served.count_nodes(), 2);
+        assert!(served.add_node(1, 3, NO_PROPS, None, None).is_err());
+
+        let config = AppConfigBuilder::new().build();
+        let data = Data::new(tmp_work_dir.path(), &config, Default::default());
+        let served = data.get_graph_for_test("g").await.unwrap();
+        let served = served.graph().clone().into_events().unwrap();
+        assert!(served.add_node(1, 3, NO_PROPS, None, None).is_ok());
     }
 
     #[tokio::test]

--- a/raphtory-graphql/src/graph.rs
+++ b/raphtory-graphql/src/graph.rs
@@ -98,6 +98,23 @@ impl GraphWithVectors {
         });
         future.await
     }
+    /// Swap in a read-only handle for the graph. No-op with a warning if the inner
+    /// state is unexpectedly shared (only call right after construction).
+    pub(crate) fn into_read_only(self) -> Self {
+        match Arc::try_unwrap(self.inner) {
+            Ok(mut inner) => {
+                inner.graph = inner.graph.read_only();
+                Self {
+                    inner: Arc::new(inner),
+                }
+            }
+            Err(inner) => {
+                tracing::warn!("graph handle shared during load; serving it without read-only");
+                Self { inner }
+            }
+        }
+    }
+
     pub fn graph(&self) -> &MaterializedGraph {
         &self.inner.graph
     }

--- a/raphtory-graphql/src/graph.rs
+++ b/raphtory-graphql/src/graph.rs
@@ -1,6 +1,6 @@
 use crate::{
     paths::{ExistingGraphFolder, UnlockedGraphFolder, ValidGraphPaths},
-    rayon::blocking_compute,
+    rayon::blocking_load,
 };
 use raphtory::{
     core::entities::nodes::node_ref::AsNodeRef,
@@ -185,12 +185,12 @@ impl GraphWithVectors {
         let folder_clone = folder.clone();
         let graph_folder = folder.graph_folder();
         let graph = if graph_folder.read_metadata()?.is_diskgraph {
-            blocking_compute(move || {
+            blocking_load(move || {
                 MaterializedGraph::load_with_config(folder_clone.graph_folder(), config)
             })
             .await?
         } else {
-            blocking_compute(move || {
+            blocking_load(move || {
                 MaterializedGraph::decode_with_config(folder_clone.graph_folder(), config)
             })
             .await?

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -120,30 +120,30 @@ fn max_concurrent() -> usize {
         .unwrap_or_else(|| (COMPUTE_POOL.current_num_threads() / 2).max(1))
 }
 
+/// Take a queued job if an admission slot is free, counting it as running.
+fn next_job() -> Option<Job> {
+    let mut s = SCHEDULER.lock().expect("scheduler lock");
+    if s.running >= max_concurrent() || s.queue.is_empty() {
+        return None;
+    }
+    s.dispatched += 1;
+    let old_waiter = s
+        .queue
+        .front()
+        .is_some_and(|(queued, _)| queued.elapsed() > PROMOTE_AFTER);
+    let take_oldest = !settings().newest_first || (old_waiter && s.dispatched % PROMOTE_EVERY == 0);
+    let (_, job) = if take_oldest {
+        s.queue.pop_front()
+    } else {
+        s.queue.pop_back()
+    }?;
+    s.running += 1;
+    Some(job)
+}
+
 /// Fill free admission slots from the queue; runs on every submission and completion.
 fn pump() {
-    loop {
-        let job = {
-            let mut s = SCHEDULER.lock().expect("scheduler lock");
-            if s.running >= max_concurrent() {
-                return;
-            }
-            s.dispatched += 1;
-            let promote_old = s.dispatched % PROMOTE_EVERY == 0;
-            let job = if settings().newest_first {
-                match s.queue.front() {
-                    Some((queued, _)) if promote_old && queued.elapsed() > PROMOTE_AFTER => {
-                        s.queue.pop_front()
-                    }
-                    _ => s.queue.pop_back(),
-                }
-            } else {
-                s.queue.pop_front()
-            };
-            let Some((_, job)) = job else { return };
-            s.running += 1;
-            job
-        };
+    while let Some(job) = next_job() {
         COMPUTE_POOL.spawn(move || {
             job();
             SCHEDULER.lock().expect("scheduler lock").running -= 1;

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -12,7 +12,7 @@ use tracing::warn;
 pub struct PoolSettings {
     /// Reserved for [`EXPRESS_POOL`], taken out of the compute pool.
     pub express_threads: usize,
-    /// Max queries running at once; the rest queue. `None` = half the compute threads.
+    /// Max queries running at once; the rest queue. `None` = one per compute thread.
     pub max_concurrent_queries: Option<usize>,
     /// Dispatch queued queries newest-first instead of FIFO.
     pub newest_first: bool,
@@ -117,7 +117,7 @@ const PROMOTE_EVERY: u64 = 4;
 fn max_concurrent() -> usize {
     settings()
         .max_concurrent_queries
-        .unwrap_or_else(|| (COMPUTE_POOL.current_num_threads() / 2).max(1))
+        .unwrap_or_else(|| COMPUTE_POOL.current_num_threads().max(1))
 }
 
 /// Take a queued job if an admission slot is free, counting it as running.

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -12,7 +12,8 @@ use tracing::warn;
 pub struct PoolSettings {
     /// Reserved for [`EXPRESS_POOL`], taken out of the compute pool.
     pub express_threads: usize,
-    /// Max queries running at once; the rest queue. `None` = one per compute thread.
+    /// Max queries running at once; the rest queue. `None` = half the compute threads:
+    /// raising it amplifies storage-lock contention faster than it adds parallelism.
     pub max_concurrent_queries: Option<usize>,
     /// Dispatch queued queries newest-first instead of FIFO.
     pub newest_first: bool,
@@ -117,7 +118,7 @@ const PROMOTE_EVERY: u64 = 4;
 fn max_concurrent() -> usize {
     settings()
         .max_concurrent_queries
-        .unwrap_or_else(|| COMPUTE_POOL.current_num_threads().max(1))
+        .unwrap_or_else(|| (COMPUTE_POOL.current_num_threads() / 2).max(1))
 }
 
 /// Take a queued job if an admission slot is free, counting it as running.

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -1,6 +1,72 @@
 use rayon::{ThreadPool, ThreadPoolBuilder};
-use std::sync::LazyLock;
-use tokio::sync::oneshot;
+use std::{
+    collections::VecDeque,
+    sync::{LazyLock, Mutex, OnceLock},
+    time::{Duration, Instant},
+};
+use tokio::sync::{oneshot, Semaphore};
+use tracing::warn;
+
+/// How the compute pool schedules query work. The pools are process-global statics, so this is
+/// set once from the first server's `ConcurrencyConfig`; every later server in the process shares it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoolSettings {
+    /// Threads taken out of the compute pool and reserved for [`EXPRESS_POOL`].
+    pub express_threads: usize,
+    /// Maximum number of [`blocking_compute`] closures executing at once; further submissions
+    /// queue in the [`SCHEDULER`]. `None` = half the compute pool's threads.
+    pub max_concurrent_queries: Option<usize>,
+    /// When true, queued submissions are dispatched newest-first (with rationed promotion of old
+    /// waiters — see [`pump`]); when false, strictly first-in first-out.
+    pub newest_first: bool,
+    /// Maximum graph loads decoding at once via [`blocking_load`]. Each in-flight load holds a
+    /// whole graph in memory, so this bounds peak memory during a load stampede.
+    /// `None` = cores / 4, at least 2.
+    pub max_concurrent_loads: Option<usize>,
+}
+
+impl Default for PoolSettings {
+    fn default() -> Self {
+        PoolSettings {
+            express_threads: default_express_threads(),
+            max_concurrent_queries: None,
+            newest_first: true,
+            max_concurrent_loads: None,
+        }
+    }
+}
+
+/// Two reserved threads on an 8+-core machine; one below that, so a small machine does not give
+/// up a large share of its compute pool for the reservation.
+pub fn default_express_threads() -> usize {
+    if cores() >= 8 {
+        2
+    } else {
+        1
+    }
+}
+const PROMOTE_AFTER: Duration = Duration::from_secs(1);
+
+static SETTINGS: OnceLock<PoolSettings> = OnceLock::new();
+
+/// First caller wins (the pools are process-global); a later, different configuration is ignored
+/// with a warning.
+pub fn configure_pools(settings: PoolSettings) {
+    let applied = SETTINGS.get_or_init(|| settings.clone());
+    if *applied != settings {
+        warn!(?applied, ignored = ?settings, "rayon pools already configured; keeping the first configuration");
+    }
+}
+
+fn settings() -> &'static PoolSettings {
+    SETTINGS.get_or_init(PoolSettings::default)
+}
+
+fn cores() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8)
+}
 
 pub static WRITE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
     ThreadPoolBuilder::new()
@@ -12,7 +78,19 @@ pub static WRITE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
 pub static COMPUTE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
     ThreadPoolBuilder::new()
         .stack_size(16 * 1024 * 1024)
+        .num_threads(cores().saturating_sub(settings().express_threads).max(2))
         .thread_name(|t| format!("RAP-compute-{t}"))
+        .build()
+        .unwrap()
+});
+
+/// Threads reserved for work that must stay responsive while the compute pool is saturated:
+/// the `/health` round-trip and cheap store/metadata resolvers. Nothing submitted here may do
+/// graph work — one scan on this pool removes the reservation for everything else.
+pub static EXPRESS_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
+    ThreadPoolBuilder::new()
+        .num_threads(settings().express_threads.max(1))
+        .thread_name(|t| format!("RAP-express-{t}"))
         .build()
         .unwrap()
 });
@@ -26,17 +104,120 @@ pub static EVICT_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
         .unwrap()
 });
 
-/// Use the rayon threadpool to execute a task
-///
-/// Use this for long-running, compute-heavy work
+type Job = Box<dyn FnOnce() + Send + 'static>;
+
+struct Scheduler {
+    queue: VecDeque<(Instant, Job)>,
+    running: usize,
+    dispatched: u64,
+}
+
+static SCHEDULER: LazyLock<Mutex<Scheduler>> = LazyLock::new(|| {
+    Mutex::new(Scheduler {
+        queue: VecDeque::new(),
+        running: 0,
+        dispatched: 0,
+    })
+});
+
+/// One dispatch in this many takes the oldest waiter (if older than [`PROMOTE_AFTER`]) instead of
+/// the newest. Promotion must be rationed: under a sustained backlog the front of the queue is
+/// always old, so promoting it on every dispatch is exactly first-in first-out and newest-first
+/// never happens.
+const PROMOTE_EVERY: u64 = 4;
+
+fn max_concurrent() -> usize {
+    settings()
+        .max_concurrent_queries
+        .unwrap_or_else(|| (COMPUTE_POOL.current_num_threads() / 2).max(1))
+}
+
+/// Dispatch queued jobs until every admission slot is in use, then return; runs again after each
+/// job completes and on every submission. Admission (at most [`max_concurrent`] jobs running)
+/// stops queries time-sharing the whole pool, so a slot frees as soon as one query finishes;
+/// newest-first dispatch then hands that slot to the most recently submitted query, so a short
+/// query arriving into a backlog waits for one slot, not for the whole backlog to drain.
+fn pump() {
+    loop {
+        let job = {
+            let mut s = SCHEDULER.lock().expect("scheduler lock");
+            if s.running >= max_concurrent() {
+                return;
+            }
+            s.dispatched += 1;
+            let promote_old = s.dispatched % PROMOTE_EVERY == 0;
+            let job = if settings().newest_first {
+                match s.queue.front() {
+                    Some((queued, _)) if promote_old && queued.elapsed() > PROMOTE_AFTER => {
+                        s.queue.pop_front()
+                    }
+                    _ => s.queue.pop_back(),
+                }
+            } else {
+                s.queue.pop_front()
+            };
+            let Some((_, job)) = job else { return };
+            s.running += 1;
+            job
+        };
+        COMPUTE_POOL.spawn(move || {
+            job();
+            SCHEDULER.lock().expect("scheduler lock").running -= 1;
+            pump();
+        });
+    }
+}
+
+/// Run `closure` on the compute pool, scheduled: the job queues in the [`SCHEDULER`] and starts
+/// when an admission slot is free, dispatched newest-first (see [`pump`]). Use for query work,
+/// which may be arbitrarily heavy.
 pub async fn blocking_compute<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(
     closure: F,
 ) -> R {
     let (send, recv) = oneshot::channel();
-    COMPUTE_POOL.spawn(move || {
+    {
+        let mut s = SCHEDULER.lock().expect("scheduler lock");
+        s.queue.push_back((
+            Instant::now(),
+            Box::new(move || {
+                let _ = send.send(closure()); // this only errors if no-one is listening anymore
+            }),
+        ));
+    }
+    pump();
+    recv.await.expect("Function panicked in rayon::spawn")
+}
+
+static LOAD_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| {
+    let permits = settings()
+        .max_concurrent_loads
+        .unwrap_or_else(|| (cores() / 4).max(2));
+    Semaphore::new(permits.max(1))
+});
+
+/// Run a graph load: on tokio's blocking pool (so it never holds a query admission slot), bounded
+/// by [`LOAD_PERMITS`] (each in-flight load holds a decoded graph in memory, so unbounded
+/// concurrency is a memory blow-up under a load stampede). Internal parallelism uses rayon's
+/// global pool, which the query path never touches.
+pub async fn blocking_load<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(closure: F) -> R {
+    let _permit = LOAD_PERMITS
+        .acquire()
+        .await
+        .expect("load semaphore is never closed");
+    tokio::task::spawn_blocking(closure)
+        .await
+        .expect("graph load panicked")
+}
+
+/// Run `closure` immediately on the reserved [`EXPRESS_POOL`], bypassing the scheduler. Only for
+/// work that is always cheap (health checks, store/metadata reads) — never graph work.
+pub async fn blocking_express<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(
+    closure: F,
+) -> R {
+    let (send, recv) = oneshot::channel();
+    EXPRESS_POOL.spawn(move || {
         let _ = send.send(closure()); // this only errors if no-one is listening anymore
     });
-
     recv.await.expect("Function panicked in rayon::spawn")
 }
 
@@ -48,6 +229,10 @@ pub async fn blocking_write<R: Send + 'static, F: FnOnce() -> R + Send + 'static
     });
     recv.await.expect("Function panicked in rayon::spawn")
 }
+
+/// The pools are process-global, so tests that jam or saturate them must not overlap.
+#[cfg(test)]
+static TEST_SERIAL: Mutex<()> = Mutex::new(());
 
 #[cfg(test)]
 mod deadlock_tests {
@@ -83,6 +268,7 @@ mod deadlock_tests {
     }
 
     async fn test_pool_lock(port: u16, pool_lock: impl FnOnce(Arc<Mutex<()>>)) {
+        let _serial = super::TEST_SERIAL.lock();
         let tempdir = TempDir::new().unwrap();
         let server = GraphServer::new(tempdir.path().to_path_buf(), None, Config::default())
             .await
@@ -106,5 +292,88 @@ mod deadlock_tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         let health: Health = response.json().await.unwrap();
         assert_eq!(health.healthy, false);
+    }
+}
+
+#[cfg(test)]
+mod scheduler_tests {
+    use super::*;
+
+    /// A short task submitted behind a backlog of long ones runs long before the backlog drains.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_new_short_task_jumps_a_heavy_backlog() {
+        let _serial = TEST_SERIAL.lock();
+        let heavies: Vec<_> = (0..COMPUTE_POOL.current_num_threads() * 4)
+            .map(|_| {
+                tokio::spawn(blocking_compute(|| {
+                    std::thread::sleep(Duration::from_millis(200))
+                }))
+            })
+            .collect();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let t0 = Instant::now();
+        blocking_compute(|| {}).await;
+        let waited = t0.elapsed();
+        // Full FIFO drain would be seconds; one admission slot freeing is a few hundred ms.
+        assert!(
+            waited < Duration::from_millis(1500),
+            "short task waited {waited:?} behind the heavy backlog"
+        );
+        for h in heavies {
+            let _ = h.await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_loads_are_bounded() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let _serial = TEST_SERIAL.lock();
+        static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+        static PEAK: AtomicUsize = AtomicUsize::new(0);
+        let loads: Vec<_> = (0..16)
+            .map(|_| {
+                tokio::spawn(blocking_load(|| {
+                    let now = IN_FLIGHT.fetch_add(1, Ordering::SeqCst) + 1;
+                    PEAK.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(50));
+                    IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+                }))
+            })
+            .collect();
+        for l in loads {
+            let _ = l.await;
+        }
+        let cap = settings()
+            .max_concurrent_loads
+            .unwrap_or_else(|| (cores() / 4).max(2));
+        assert!(
+            PEAK.load(Ordering::SeqCst) <= cap,
+            "peak {} loads exceeded the cap {cap}",
+            PEAK.load(Ordering::SeqCst)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn express_is_immediate_while_compute_is_saturated() {
+        let _serial = TEST_SERIAL.lock();
+        let heavies: Vec<_> = (0..COMPUTE_POOL.current_num_threads() * 4)
+            .map(|_| {
+                tokio::spawn(blocking_compute(|| {
+                    std::thread::sleep(Duration::from_millis(200))
+                }))
+            })
+            .collect();
+        let t0 = Instant::now();
+        blocking_express(|| {}).await;
+        let waited = t0.elapsed();
+        // Drain the backlog before releasing the serial guard, so no jobs leak into other tests.
+        for h in heavies {
+            let _ = h.await;
+        }
+        assert!(
+            waited < Duration::from_millis(100),
+            "express waited {waited:?}"
+        );
     }
 }

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -1,9 +1,7 @@
 use rayon::{ThreadPool, ThreadPoolBuilder};
-use std::{
-    collections::VecDeque,
-    sync::{LazyLock, Mutex, OnceLock},
-    time::{Duration, Instant},
-};
+#[cfg(test)]
+use std::sync::Mutex;
+use std::sync::{LazyLock, OnceLock};
 use tokio::sync::{oneshot, Semaphore};
 use tracing::warn;
 
@@ -12,11 +10,6 @@ use tracing::warn;
 pub struct PoolSettings {
     /// Reserved for [`EXPRESS_POOL`], taken out of the compute pool.
     pub express_threads: usize,
-    /// Max queries running at once; the rest queue. `None` = half the compute threads:
-    /// raising it amplifies storage-lock contention faster than it adds parallelism.
-    pub max_concurrent_queries: Option<usize>,
-    /// Dispatch queued queries newest-first instead of FIFO.
-    pub newest_first: bool,
     /// Max graph loads decoding at once; bounds peak memory. `None` = cores / 4, at least 2.
     pub max_concurrent_loads: Option<usize>,
 }
@@ -25,8 +18,6 @@ impl Default for PoolSettings {
     fn default() -> Self {
         PoolSettings {
             express_threads: default_express_threads(),
-            max_concurrent_queries: None,
-            newest_first: true,
             max_concurrent_loads: None,
         }
     }
@@ -40,7 +31,6 @@ pub fn default_express_threads() -> usize {
         1
     }
 }
-const PROMOTE_AFTER: Duration = Duration::from_secs(1);
 
 static SETTINGS: OnceLock<PoolSettings> = OnceLock::new();
 
@@ -96,78 +86,14 @@ pub static EVICT_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
         .unwrap()
 });
 
-type Job = Box<dyn FnOnce() + Send + 'static>;
-
-struct Scheduler {
-    queue: VecDeque<(Instant, Job)>,
-    running: usize,
-    dispatched: u64,
-}
-
-static SCHEDULER: LazyLock<Mutex<Scheduler>> = LazyLock::new(|| {
-    Mutex::new(Scheduler {
-        queue: VecDeque::new(),
-        running: 0,
-        dispatched: 0,
-    })
-});
-
-/// Rationed: under a backlog the queue front is always old, so promoting it every dispatch is FIFO.
-const PROMOTE_EVERY: u64 = 4;
-
-fn max_concurrent() -> usize {
-    settings()
-        .max_concurrent_queries
-        .unwrap_or_else(|| (COMPUTE_POOL.current_num_threads() / 2).max(1))
-}
-
-/// Take a queued job if an admission slot is free, counting it as running.
-fn next_job() -> Option<Job> {
-    let mut s = SCHEDULER.lock().expect("scheduler lock");
-    if s.running >= max_concurrent() || s.queue.is_empty() {
-        return None;
-    }
-    s.dispatched += 1;
-    let old_waiter = s
-        .queue
-        .front()
-        .is_some_and(|(queued, _)| queued.elapsed() > PROMOTE_AFTER);
-    let take_oldest = !settings().newest_first || (old_waiter && s.dispatched % PROMOTE_EVERY == 0);
-    let (_, job) = if take_oldest {
-        s.queue.pop_front()
-    } else {
-        s.queue.pop_back()
-    }?;
-    s.running += 1;
-    Some(job)
-}
-
-/// Fill free admission slots from the queue; runs on every submission and completion.
-fn pump() {
-    while let Some(job) = next_job() {
-        COMPUTE_POOL.spawn(move || {
-            job();
-            SCHEDULER.lock().expect("scheduler lock").running -= 1;
-            pump();
-        });
-    }
-}
-
-/// Query work: queues for an admission slot on the compute pool, dispatched newest-first.
+/// Query work on the compute pool.
 pub async fn blocking_compute<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(
     closure: F,
 ) -> R {
     let (send, recv) = oneshot::channel();
-    {
-        let mut s = SCHEDULER.lock().expect("scheduler lock");
-        s.queue.push_back((
-            Instant::now(),
-            Box::new(move || {
-                let _ = send.send(closure()); // this only errors if no-one is listening anymore
-            }),
-        ));
-    }
-    pump();
+    COMPUTE_POOL.spawn(move || {
+        let _ = send.send(closure()); // this only errors if no-one is listening anymore
+    });
     recv.await.expect("Function panicked in rayon::spawn")
 }
 
@@ -277,31 +203,7 @@ mod deadlock_tests {
 #[cfg(test)]
 mod scheduler_tests {
     use super::*;
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn a_new_short_task_jumps_a_heavy_backlog() {
-        let _serial = TEST_SERIAL.lock();
-        let heavies: Vec<_> = (0..COMPUTE_POOL.current_num_threads() * 4)
-            .map(|_| {
-                tokio::spawn(blocking_compute(|| {
-                    std::thread::sleep(Duration::from_millis(200))
-                }))
-            })
-            .collect();
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        let t0 = Instant::now();
-        blocking_compute(|| {}).await;
-        let waited = t0.elapsed();
-        // Full FIFO drain would be seconds; one admission slot freeing is a few hundred ms.
-        assert!(
-            waited < Duration::from_millis(1500),
-            "short task waited {waited:?} behind the heavy backlog"
-        );
-        for h in heavies {
-            let _ = h.await;
-        }
-    }
+    use std::time::{Duration, Instant};
 
     #[tokio::test(flavor = "multi_thread")]
     async fn concurrent_loads_are_bounded() {

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -6,30 +6,10 @@ use tokio::sync::{oneshot, Semaphore};
 use tracing::warn;
 
 /// Process-global: set once by the first server, shared by every later one.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct PoolSettings {
-    /// Reserved for [`EXPRESS_POOL`], taken out of the compute pool.
-    pub express_threads: usize,
     /// Max graph loads decoding at once; bounds peak memory. `None` = cores / 4, at least 2.
     pub max_concurrent_loads: Option<usize>,
-}
-
-impl Default for PoolSettings {
-    fn default() -> Self {
-        PoolSettings {
-            express_threads: default_express_threads(),
-            max_concurrent_loads: None,
-        }
-    }
-}
-
-/// One thread below 8 cores, so a small machine keeps most of its compute pool.
-pub fn default_express_threads() -> usize {
-    if cores() >= 8 {
-        2
-    } else {
-        1
-    }
 }
 
 static SETTINGS: OnceLock<PoolSettings> = OnceLock::new();
@@ -62,16 +42,19 @@ pub static WRITE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
 pub static COMPUTE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
     ThreadPoolBuilder::new()
         .stack_size(16 * 1024 * 1024)
-        .num_threads(cores().saturating_sub(settings().express_threads).max(2))
+        .num_threads(cores().saturating_sub(EXPRESS_THREADS).max(2))
         .thread_name(|t| format!("RAP-compute-{t}"))
         .build()
         .unwrap()
 });
 
+/// Reserved out of the compute pool for work that must stay responsive while it is saturated.
+const EXPRESS_THREADS: usize = 1;
+
 /// Never submit graph work here — one scan removes the reservation for everything else.
 pub static EXPRESS_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
     ThreadPoolBuilder::new()
-        .num_threads(settings().express_threads.max(1))
+        .num_threads(EXPRESS_THREADS)
         .thread_name(|t| format!("RAP-express-{t}"))
         .build()
         .unwrap()

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -7,21 +7,16 @@ use std::{
 use tokio::sync::{oneshot, Semaphore};
 use tracing::warn;
 
-/// How the compute pool schedules query work. The pools are process-global statics, so this is
-/// set once from the first server's `ConcurrencyConfig`; every later server in the process shares it.
+/// Process-global: set once by the first server, shared by every later one.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PoolSettings {
-    /// Threads taken out of the compute pool and reserved for [`EXPRESS_POOL`].
+    /// Reserved for [`EXPRESS_POOL`], taken out of the compute pool.
     pub express_threads: usize,
-    /// Maximum number of [`blocking_compute`] closures executing at once; further submissions
-    /// queue in the [`SCHEDULER`]. `None` = half the compute pool's threads.
+    /// Max queries running at once; the rest queue. `None` = half the compute threads.
     pub max_concurrent_queries: Option<usize>,
-    /// When true, queued submissions are dispatched newest-first (with rationed promotion of old
-    /// waiters — see [`pump`]); when false, strictly first-in first-out.
+    /// Dispatch queued queries newest-first instead of FIFO.
     pub newest_first: bool,
-    /// Maximum graph loads decoding at once via [`blocking_load`]. Each in-flight load holds a
-    /// whole graph in memory, so this bounds peak memory during a load stampede.
-    /// `None` = cores / 4, at least 2.
+    /// Max graph loads decoding at once; bounds peak memory. `None` = cores / 4, at least 2.
     pub max_concurrent_loads: Option<usize>,
 }
 
@@ -36,8 +31,7 @@ impl Default for PoolSettings {
     }
 }
 
-/// Two reserved threads on an 8+-core machine; one below that, so a small machine does not give
-/// up a large share of its compute pool for the reservation.
+/// One thread below 8 cores, so a small machine keeps most of its compute pool.
 pub fn default_express_threads() -> usize {
     if cores() >= 8 {
         2
@@ -49,8 +43,7 @@ const PROMOTE_AFTER: Duration = Duration::from_secs(1);
 
 static SETTINGS: OnceLock<PoolSettings> = OnceLock::new();
 
-/// First caller wins (the pools are process-global); a later, different configuration is ignored
-/// with a warning.
+/// First caller wins; a later, different configuration is ignored with a warning.
 pub fn configure_pools(settings: PoolSettings) {
     let applied = SETTINGS.get_or_init(|| settings.clone());
     if *applied != settings {
@@ -84,9 +77,7 @@ pub static COMPUTE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
         .unwrap()
 });
 
-/// Threads reserved for work that must stay responsive while the compute pool is saturated:
-/// the `/health` round-trip and cheap store/metadata resolvers. Nothing submitted here may do
-/// graph work — one scan on this pool removes the reservation for everything else.
+/// Never submit graph work here — one scan removes the reservation for everything else.
 pub static EXPRESS_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
     ThreadPoolBuilder::new()
         .num_threads(settings().express_threads.max(1))
@@ -120,10 +111,7 @@ static SCHEDULER: LazyLock<Mutex<Scheduler>> = LazyLock::new(|| {
     })
 });
 
-/// One dispatch in this many takes the oldest waiter (if older than [`PROMOTE_AFTER`]) instead of
-/// the newest. Promotion must be rationed: under a sustained backlog the front of the queue is
-/// always old, so promoting it on every dispatch is exactly first-in first-out and newest-first
-/// never happens.
+/// Rationed: under a backlog the queue front is always old, so promoting it every dispatch is FIFO.
 const PROMOTE_EVERY: u64 = 4;
 
 fn max_concurrent() -> usize {
@@ -132,11 +120,7 @@ fn max_concurrent() -> usize {
         .unwrap_or_else(|| (COMPUTE_POOL.current_num_threads() / 2).max(1))
 }
 
-/// Dispatch queued jobs until every admission slot is in use, then return; runs again after each
-/// job completes and on every submission. Admission (at most [`max_concurrent`] jobs running)
-/// stops queries time-sharing the whole pool, so a slot frees as soon as one query finishes;
-/// newest-first dispatch then hands that slot to the most recently submitted query, so a short
-/// query arriving into a backlog waits for one slot, not for the whole backlog to drain.
+/// Fill free admission slots from the queue; runs on every submission and completion.
 fn pump() {
     loop {
         let job = {
@@ -168,9 +152,7 @@ fn pump() {
     }
 }
 
-/// Run `closure` on the compute pool, scheduled: the job queues in the [`SCHEDULER`] and starts
-/// when an admission slot is free, dispatched newest-first (see [`pump`]). Use for query work,
-/// which may be arbitrarily heavy.
+/// Query work: queues for an admission slot on the compute pool, dispatched newest-first.
 pub async fn blocking_compute<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(
     closure: F,
 ) -> R {
@@ -195,10 +177,7 @@ static LOAD_PERMITS: LazyLock<Semaphore> = LazyLock::new(|| {
     Semaphore::new(permits.max(1))
 });
 
-/// Run a graph load: on tokio's blocking pool (so it never holds a query admission slot), bounded
-/// by [`LOAD_PERMITS`] (each in-flight load holds a decoded graph in memory, so unbounded
-/// concurrency is a memory blow-up under a load stampede). Internal parallelism uses rayon's
-/// global pool, which the query path never touches.
+/// Graph loads: off the query pools, bounded because each in-flight load holds a whole graph.
 pub async fn blocking_load<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(closure: F) -> R {
     let _permit = LOAD_PERMITS
         .acquire()
@@ -209,8 +188,7 @@ pub async fn blocking_load<R: Send + 'static, F: FnOnce() -> R + Send + 'static>
         .expect("graph load panicked")
 }
 
-/// Run `closure` immediately on the reserved [`EXPRESS_POOL`], bypassing the scheduler. Only for
-/// work that is always cheap (health checks, store/metadata reads) — never graph work.
+/// Immediate, bypassing the scheduler. Only for always-cheap work — never graph work.
 pub async fn blocking_express<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(
     closure: F,
 ) -> R {
@@ -299,7 +277,6 @@ mod deadlock_tests {
 mod scheduler_tests {
     use super::*;
 
-    /// A short task submitted behind a backlog of long ones runs long before the backlog drains.
     #[tokio::test(flavor = "multi_thread")]
     async fn a_new_short_task_jumps_a_heavy_backlog() {
         let _serial = TEST_SERIAL.lock();

--- a/raphtory-graphql/src/rayon.rs
+++ b/raphtory-graphql/src/rayon.rs
@@ -42,20 +42,8 @@ pub static WRITE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
 pub static COMPUTE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
     ThreadPoolBuilder::new()
         .stack_size(16 * 1024 * 1024)
-        .num_threads(cores().saturating_sub(EXPRESS_THREADS).max(2))
+        .num_threads(cores().max(2))
         .thread_name(|t| format!("RAP-compute-{t}"))
-        .build()
-        .unwrap()
-});
-
-/// Reserved out of the compute pool for work that must stay responsive while it is saturated.
-const EXPRESS_THREADS: usize = 1;
-
-/// Never submit graph work here — one scan removes the reservation for everything else.
-pub static EXPRESS_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
-    ThreadPoolBuilder::new()
-        .num_threads(EXPRESS_THREADS)
-        .thread_name(|t| format!("RAP-express-{t}"))
         .build()
         .unwrap()
 });
@@ -96,17 +84,6 @@ pub async fn blocking_load<R: Send + 'static, F: FnOnce() -> R + Send + 'static>
     tokio::task::spawn_blocking(closure)
         .await
         .expect("graph load panicked")
-}
-
-/// Immediate, bypassing the scheduler. Only for always-cheap work — never graph work.
-pub async fn blocking_express<R: Send + 'static, F: FnOnce() -> R + Send + 'static>(
-    closure: F,
-) -> R {
-    let (send, recv) = oneshot::channel();
-    EXPRESS_POOL.spawn(move || {
-        let _ = send.send(closure()); // this only errors if no-one is listening anymore
-    });
-    recv.await.expect("Function panicked in rayon::spawn")
 }
 
 /// Use a separate rayon threadpool to execute write tasks to avoid potential deadlocks
@@ -186,7 +163,7 @@ mod deadlock_tests {
 #[cfg(test)]
 mod scheduler_tests {
     use super::*;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn concurrent_loads_are_bounded() {
@@ -214,29 +191,6 @@ mod scheduler_tests {
             PEAK.load(Ordering::SeqCst) <= cap,
             "peak {} loads exceeded the cap {cap}",
             PEAK.load(Ordering::SeqCst)
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn express_is_immediate_while_compute_is_saturated() {
-        let _serial = TEST_SERIAL.lock();
-        let heavies: Vec<_> = (0..COMPUTE_POOL.current_num_threads() * 4)
-            .map(|_| {
-                tokio::spawn(blocking_compute(|| {
-                    std::thread::sleep(Duration::from_millis(200))
-                }))
-            })
-            .collect();
-        let t0 = Instant::now();
-        blocking_express(|| {}).await;
-        let waited = t0.elapsed();
-        // Drain the backlog before releasing the serial guard, so no jobs leak into other tests.
-        for h in heavies {
-            let _ = h.await;
-        }
-        assert!(
-            waited < Duration::from_millis(100),
-            "express waited {waited:?}"
         );
     }
 }

--- a/raphtory-graphql/src/routes.rs
+++ b/raphtory-graphql/src/routes.rs
@@ -10,7 +10,7 @@ use rust_embed::Embed;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
 
-use crate::rayon::{blocking_compute, blocking_write};
+use crate::rayon::{blocking_compute, blocking_express, blocking_write};
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct Health {
@@ -29,10 +29,14 @@ struct HealthQuery {
 
 #[handler]
 pub(crate) async fn health(Query(params): Query<HealthQuery>) -> impl IntoResponse {
-    // using blocking_compute and blocking_write to identify deadlocks on any of the two rayon pools
+    // Round-trips every pool to identify a deadlock. A merely busy compute pool answers fast:
+    // the no-op jumps the pending queue and runs as soon as an admission slot frees.
     let result = tokio::time::timeout(
         Duration::from_secs(params.timeout.unwrap_or(10)),
-        join(blocking_compute(|| {}), blocking_write(|| {})),
+        join(
+            blocking_compute(|| {}),
+            join(blocking_express(|| {}), blocking_write(|| {})),
+        ),
     )
     .await;
     match result {

--- a/raphtory-graphql/src/routes.rs
+++ b/raphtory-graphql/src/routes.rs
@@ -10,7 +10,7 @@ use rust_embed::Embed;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
 
-use crate::rayon::{blocking_compute, blocking_express, blocking_write};
+use crate::rayon::{blocking_compute, blocking_write};
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct Health {
@@ -29,14 +29,11 @@ struct HealthQuery {
 
 #[handler]
 pub(crate) async fn health(Query(params): Query<HealthQuery>) -> impl IntoResponse {
-    // Round-trips every pool to identify a deadlock. A merely busy compute pool answers fast:
-    // the no-op jumps the pending queue and runs as soon as an admission slot frees.
+    // Round-trips every pool: one that cannot run a no-op within the timeout (deadlocked, or
+    // saturated beyond use) reports unhealthy.
     let result = tokio::time::timeout(
         Duration::from_secs(params.timeout.unwrap_or(10)),
-        join(
-            blocking_compute(|| {}),
-            join(blocking_express(|| {}), blocking_write(|| {})),
-        ),
+        join(blocking_compute(|| {}), blocking_write(|| {})),
     )
     .await;
     match result {

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -146,7 +146,6 @@ impl GraphServer {
         }
         let config = app_config.unwrap_or_default();
         configure_pools(PoolSettings {
-            express_threads: config.concurrency.express_threads,
             max_concurrent_loads: config.concurrency.max_concurrent_loads,
         });
         let extensions = config.extensions.clone();

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{AuthenticatedGraphQL, MutationAuth},
+    auth::{AuthenticatedGraphQL, KeyResolver, MutationAuth},
     auth_policy::AuthorizationPolicy,
     cli::ServerArgs,
     config::{
@@ -10,6 +10,7 @@ use crate::{
     model::App,
     observability::open_telemetry::OpenTelemetry,
     plugin::schema::RegisterPlugin,
+    rayon::{configure_pools, PoolSettings},
     routes::{health, version, PublicFilesEndpoint},
     server::ServerError::SchemaError,
 };
@@ -37,6 +38,7 @@ use std::{
     ops::Deref,
     path::{Path, PathBuf},
     pin::Pin,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
 };
 use thiserror::Error;
@@ -112,7 +114,7 @@ impl From<ServerError> for io::Error {
     }
 }
 
-type SchemaDataInjector = std::sync::Arc<
+type SchemaDataInjector = Arc<
     dyn Fn(async_graphql::dynamic::SchemaBuilder) -> async_graphql::dynamic::SchemaBuilder
         + Send
         + Sync,
@@ -125,7 +127,7 @@ pub struct GraphServer {
     work_dir: PathBuf,
     config: AppConfig,
     schema_data: Vec<SchemaDataInjector>,
-    key_resolver: Option<std::sync::Arc<dyn crate::auth::KeyResolver>>,
+    key_resolver: Option<Arc<dyn KeyResolver>>,
     schema_plugins: Vec<Box<dyn RegisterPlugin>>,
 }
 
@@ -143,6 +145,12 @@ impl GraphServer {
             create_dir_all(&work_dir)?;
         }
         let config = app_config.unwrap_or_default();
+        configure_pools(PoolSettings {
+            express_threads: config.concurrency.express_threads,
+            max_concurrent_queries: config.concurrency.max_concurrent_queries,
+            newest_first: config.concurrency.newest_first_scheduling,
+            max_concurrent_loads: config.concurrency.max_concurrent_loads,
+        });
         let extensions = config.extensions.clone();
         let data = Data::new(work_dir.as_path(), &config, graph_config);
         let server = Self {
@@ -170,10 +178,7 @@ impl GraphServer {
 
     /// Register a custom JWT key resolver (e.g. an SSO/JWKS resolver from an auth extension). When
     /// set, it replaces the static `auth.public_key` for token verification.
-    pub fn with_key_resolver(
-        mut self,
-        resolver: std::sync::Arc<dyn crate::auth::KeyResolver>,
-    ) -> Self {
+    pub fn with_key_resolver(mut self, resolver: Arc<dyn KeyResolver>) -> Self {
         self.key_resolver = Some(resolver);
         self
     }
@@ -184,15 +189,15 @@ impl GraphServer {
     }
 
     /// Set the authorization policy used for graph access checks.
-    pub fn with_auth_policy(mut self, policy: std::sync::Arc<dyn AuthorizationPolicy>) -> Self {
+    pub fn with_auth_policy(mut self, policy: Arc<dyn AuthorizationPolicy>) -> Self {
         self.data.set_auth_policy(policy);
         self
     }
 
     /// Inject arbitrary typed data into the GQL schema (accessible via `ctx.data::<T>()`).
     pub fn with_schema_data<T: std::any::Any + Send + Sync + 'static>(mut self, data: T) -> Self {
-        let data = std::sync::Arc::new(std::sync::Mutex::new(Some(data)));
-        self.schema_data.push(std::sync::Arc::new(move |sb| {
+        let data = Arc::new(Mutex::new(Some(data)));
+        self.schema_data.push(Arc::new(move |sb| {
             let data = data
                 .lock()
                 .unwrap()

--- a/raphtory-graphql/src/server.rs
+++ b/raphtory-graphql/src/server.rs
@@ -147,8 +147,6 @@ impl GraphServer {
         let config = app_config.unwrap_or_default();
         configure_pools(PoolSettings {
             express_threads: config.concurrency.express_threads,
-            max_concurrent_queries: config.concurrency.max_concurrent_queries,
-            newest_first: config.concurrency.newest_first_scheduling,
             max_concurrent_loads: config.concurrency.max_concurrent_loads,
         });
         let extensions = config.extensions.clone();

--- a/raphtory/src/db/api/view/internal/materialize.rs
+++ b/raphtory/src/db/api/view/internal/materialize.rs
@@ -86,6 +86,17 @@ impl Debug for MaterializedGraph {
 impl Static for MaterializedGraph {}
 
 impl MaterializedGraph {
+    /// A read-only handle to this graph: reads skip per-access segment locking and
+    /// mutations fail with `Immutable::ReadLockedImmutable`.
+    pub fn read_only(&self) -> Self {
+        match self {
+            MaterializedGraph::EventGraph(g) => MaterializedGraph::EventGraph(g.read_only()),
+            MaterializedGraph::PersistentGraph(g) => {
+                MaterializedGraph::PersistentGraph(g.read_only())
+            }
+        }
+    }
+
     pub fn into_events(self) -> Option<Graph> {
         match self {
             MaterializedGraph::EventGraph(g) => Some(g),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two GraphQL server changes plus benchmark coverage:

1. **Cold graph loads off the query path, and bounded** — graphs decode on the blocking-IO pool
   via `blocking_load`, gated by a semaphore (`[concurrency] max_concurrent_loads`, default
   `cores / 4`, at least 2). A multi-second load no longer stalls queries or health, and a burst
   of cold loads can no longer hold an unbounded number of decoding graphs in memory at once.

2. **Read-only mode** (`[cache] read_only = true`) — every graph entering the cache is wrapped
   with the new `MaterializedGraph::read_only()`: storage segments are read-locked once for the
   server's lifetime, so every read on every path skips per-access segment locking. Graph
   mutations fail fast with the existing locked-graph error; role/permission management is
   unaffected.

Benchmark harness (`graphql-bench`): a generated 5M-node graph (string ids), an overlapping
heavy-scan + short-query scenario pair (`-e SCHEDULING_ONLY=1` runs just the pair), three
algorithm scenarios (single-source shortest path, PageRank, degree centrality), and an `-e ONLY=`
filter for running scenario subsets. The under-load pair reports steady completed rate instead of
the p95-gated max rate, which is meaningless under deliberate saturation. Note the three algorithm
ramps add ~15 minutes to the benchmark job.

### Why are the changes needed?

- Health checks and short queries stalled behind cold graph loads: during one cold load,
  `/health` took the full load duration (measured 6.1s, returning 503) and 3ms after the change.
- Concurrent cold loads previously decoded with unbounded concurrency, so peak memory was
  concurrent decodes × graph size.
- Read-heavy deployments with no updates pay per-access lock traffic on every read: profiling a
  point-read mix showed ~27% of on-CPU compute time in shared-lock acquisition, capping the test
  box at ~2.2k req/s. In read-only mode the same box served a ramp to 24k req/s with p95 <1ms
  and zero shed load, and short queries hold p95 ~100ms under 24 concurrent full-graph scans.

### Does this PR introduce any user-facing change? If yes is this documented?

Yes: two new config options, `[cache] read_only` (default `false`) and
`[concurrency] max_concurrent_loads` (default `cores / 4`), documented on the config fields. In
read-only mode graph mutations return the existing "graph is locked and cannot be mutated" error.

### How was this patch tested?

- New tests: the concurrent-load bound, and read-only cache behaviour (reads served, mutations
  rejected, writable control). The existing deadlock tests are unchanged and passing; the full
  `raphtory-graphql` suite is green.
- k6: the scheduling pair under 24 scan VUs (shorts p95 ~100ms, 100% success), the read-mix ramp
  comparison above, and the new algorithm scenarios (max sustainable rates on the reference
  graph: degree centrality 381 req/s, single-source shortest path 250 req/s, PageRank 68 req/s).
- Server-behaviour tests covering read-only mode with auth filters, probes, and algorithms run
  in both modes in the downstream suite.

### Are there any further changes required?

- `nodes.page(offset, …)` reaches its offset via `iter().skip(offset)`, paying a locked node
  read per skipped element (~26k reads for a random offset on the reference graph); indexing
  directly into the node list when no filter is active is the follow-up with the largest
  measured win for paged reads.
- Outside read-only mode, point reads still take a segment read lock per node access;
  amortising the guard per query is the broader follow-up.