### PR TITLE
Aggregate is_deleted over an edge's layers, and reference filter set algebra independently

### DIFF
--- a/python/tests/test_base_install/test_filters/test_deletion_layer_semantics.py
+++ b/python/tests/test_base_install/test_filters/test_deletion_layer_semantics.py
@@ -1,0 +1,142 @@
+"""Where an edge's deletion is recorded, relative to where the edge lives.
+
+`delete_edge` records a deletion on one layer, creating that layer if the edge
+was never added to it — so an unlayered delete of a layered edge tombstones
+`_default` and leaves the original layer untouched. That state is deliberate (it
+is what lets an out-of-order stream record a deletion before its addition
+arrives), which makes "is this edge deleted?" a question about *aggregating*
+layers rather than about any single one.
+
+These tests pin that aggregation:
+
+* the `is_deleted` filter and `EdgeView.is_deleted` must answer identically —
+  the filter is the collection-level spelling of the method, not a different
+  predicate;
+* on a `PersistentGraph` the two predicates must partition, since there an edge
+  is either currently alive or currently deleted.
+
+`Graph` is covered too, where `is_valid`/`is_deleted` are independent facts
+about the history (an edge can have both an addition and a deletion) rather than
+a partition, so only the filter/method agreement is asserted.
+"""
+
+import pytest
+from raphtory import Graph, PersistentGraph, filter
+
+Edge = filter.Edge
+
+# (label, add layer, delete layer) — the three ways a deletion can sit relative
+# to the layer holding the edge. The last two are the ones that used to diverge.
+LAYOUTS = [
+    ("same layer", "work", "work"),
+    ("different layer", "work", "other"),
+    ("unlayered delete of a layered edge", "work", None),
+]
+
+GRAPH_TYPES = [Graph, PersistentGraph]
+
+
+def _build(cls, add_layer, delete_layer):
+    g = cls()
+    g.add_edge(10, "b", "c", layer=add_layer)
+    if delete_layer is None:
+        g.delete_edge(18, "b", "c")
+    else:
+        g.delete_edge(18, "b", "c", layer=delete_layer)
+    # An unrelated later edge, so the view's end is past the deletion and
+    # "currently deleted" is a meaningful question.
+    g.add_edge(25, "a", "d")
+    return g
+
+
+def _ids(collection):
+    return {e.id for e in collection}
+
+
+@pytest.mark.parametrize("cls", GRAPH_TYPES, ids=lambda c: c.__name__)
+@pytest.mark.parametrize(
+    "label,add_layer,delete_layer", LAYOUTS, ids=[c[0] for c in LAYOUTS]
+)
+def test_is_deleted_filter_agrees_with_the_method(cls, label, add_layer, delete_layer):
+    g = _build(cls, add_layer, delete_layer)
+    selected = _ids(g.edges[Edge.is_deleted()])
+    for edge in g.edges:
+        assert (edge.id in selected) == edge.is_deleted(), (
+            f"{label}: edges[is_deleted()] and is_deleted() disagree about {edge.id}: "
+            f"filter says {edge.id in selected}, method says {edge.is_deleted()}"
+        )
+
+
+@pytest.mark.parametrize("cls", GRAPH_TYPES, ids=lambda c: c.__name__)
+@pytest.mark.parametrize(
+    "label,add_layer,delete_layer", LAYOUTS, ids=[c[0] for c in LAYOUTS]
+)
+def test_is_valid_filter_agrees_with_the_method(cls, label, add_layer, delete_layer):
+    g = _build(cls, add_layer, delete_layer)
+    selected = _ids(g.edges[Edge.is_valid()])
+    for edge in g.edges:
+        assert (
+            edge.id in selected
+        ) == edge.is_valid(), (
+            f"{label}: edges[is_valid()] and is_valid() disagree about {edge.id}"
+        )
+
+
+@pytest.mark.parametrize(
+    "label,add_layer,delete_layer", LAYOUTS, ids=[c[0] for c in LAYOUTS]
+)
+def test_persistent_valid_and_deleted_partition(label, add_layer, delete_layer):
+    """On a persistent graph every edge is either currently alive or deleted."""
+    g = _build(PersistentGraph, add_layer, delete_layer)
+    valid = _ids(g.edges[Edge.is_valid()])
+    deleted = _ids(g.edges[Edge.is_deleted()])
+    every = _ids(g.edges)
+    assert (
+        valid & deleted == set()
+    ), f"{label}: {sorted(valid & deleted)} are both valid and deleted"
+    assert (
+        valid | deleted == every
+    ), f"{label}: {sorted(every - (valid | deleted))} are neither valid nor deleted"
+
+
+def test_edge_alive_on_another_layer_is_not_deleted():
+    """The case the aggregation exists for, asserted on its own.
+
+    The edge lives on `work` and is never deleted there; the unlayered delete
+    tombstones `_default`. Alive on one layer means not deleted, so neither the
+    method nor the filter may report it as deleted.
+    """
+    g = _build(PersistentGraph, "work", None)
+    bc = g.edge("b", "c")
+    # The state the assertions are about: the layers genuinely disagree.
+    assert sorted(bc.layer_names) == ["_default", "work"]
+    assert g.layer("work").edge("b", "c").is_valid()
+    assert g.layer("_default").edge("b", "c").is_deleted()
+
+    assert not bc.is_deleted()
+    assert bc.is_valid()
+    assert bc.id not in _ids(g.edges[Edge.is_deleted()])
+    assert bc.id in _ids(g.edges[Edge.is_valid()])
+
+
+def test_deletion_on_the_only_layer_is_deleted():
+    """The complement of the case above, so the fix cannot pass by never
+    reporting a deletion at all."""
+    g = _build(PersistentGraph, "work", "work")
+    bc = g.edge("b", "c")
+    assert bc.is_deleted()
+    assert not bc.is_valid()
+    assert bc.id in _ids(g.edges[Edge.is_deleted()])
+    assert bc.id not in _ids(g.edges[Edge.is_valid()])
+
+
+def test_layered_view_scopes_the_aggregation():
+    """Under `layer(...)` the aggregation is over that layer only, so the same
+    edge answers differently depending on which layer is in view."""
+    g = _build(PersistentGraph, "work", None)
+    assert g.layer("work").edge("b", "c").id not in _ids(
+        g.layer("work").edges[Edge.is_deleted()]
+    )
+    assert g.layer("_default").edge("b", "c").id in _ids(
+        g.layer("_default").edges[Edge.is_deleted()]
+    )

--- a/python/tests/test_base_install/test_filters/test_deletion_layer_semantics.py
+++ b/python/tests/test_base_install/test_filters/test_deletion_layer_semantics.py
@@ -140,3 +140,25 @@ def test_layered_view_scopes_the_aggregation():
     assert g.layer("_default").edge("b", "c").id in _ids(
         g.layer("_default").edges[Edge.is_deleted()]
     )
+
+
+def test_a_later_layer_restriction_does_not_rescope_the_filter():
+    """`filter(...)` then `.layer(...)` is not `.layer(...)` then `filter(...)`.
+
+    The filter answers against the view it was applied to. An edge alive on
+    another layer is not deleted, so it is already excluded, and restricting to
+    a layer afterwards only narrows what survived — it does not re-ask the
+    predicate within that layer. Applying the layer first genuinely changes the
+    view, and there the same edge is deleted.
+    """
+    g = PersistentGraph()
+    g.delete_edge(0, 1, 2, layer="1")
+    g.add_edge(0, 1, 2, layer="2")
+    edge_id = g.edge(1, 2).id
+
+    # Alive on "2", so not deleted — and a later `layer("1")` cannot bring it back.
+    assert edge_id not in _ids(g.filter(Edge.is_deleted()).edges)
+    assert list(g.filter(Edge.is_deleted()).layer("1").edges) == []
+
+    # The other order: layer "1" is the whole view, and there it is deleted.
+    assert edge_id in _ids(g.layer("1").filter(Edge.is_deleted()).edges)

--- a/python/tests/test_base_install/test_filters/test_edge_filter.py
+++ b/python/tests/test_base_install/test_filters/test_edge_filter.py
@@ -582,13 +582,42 @@ def test_filter_edges_is_valid():
     return check
 
 
-@with_variants(init_graph4)
+# `init_graph4` adds (3, 4) on layer `fire_nation` and then deletes it without
+# naming a layer, so the tombstone lands on `_default` while the edge stays alive
+# on `fire_nation`. The two graph models read that state differently, so the
+# variants are asserted separately.
+@with_variants(init_graph4, variants=["graph"])
 def test_filter_edges_is_deleted():
     def check(graph):
+        # On an event graph `is_deleted` says a deletion event exists, which it
+        # does for (3, 4) regardless of which layer recorded it.
         filter_expr = filter.Edge.is_deleted()
         result_ids = sorted(graph.after(2).filter(filter_expr).edges.id)
         expected_ids = sorted([(3, 4)])
         assert result_ids == expected_ids
+
+    return check
+
+
+@with_variants(init_graph4, variants=["persistent_graph"])
+def test_filter_edges_is_deleted_persistent():
+    def check(graph):
+        """On a persistent graph an edge alive on any layer is not deleted.
+
+        (3, 4) is still alive on `fire_nation`, so it is not deleted in the
+        unlayered view; the `_default` view, which holds the tombstone, does
+        report it. Both spellings are checked against `is_deleted()` so the
+        filter and the method cannot drift apart.
+        """
+        filter_expr = filter.Edge.is_deleted()
+        view = graph.after(2)
+
+        assert view.edge(3, 4).is_deleted() is False
+        assert sorted(view.filter(filter_expr).edges.id) == []
+
+        default_layer = view.layer("_default")
+        assert default_layer.edge(3, 4).is_deleted() is True
+        assert sorted(default_layer.filter(filter_expr).edges.id) == sorted([(3, 4)])
 
     return check
 

--- a/python/tests/test_base_install/test_filters/test_edges_collection_filter.py
+++ b/python/tests/test_base_install/test_filters/test_edges_collection_filter.py
@@ -84,6 +84,30 @@ def _singles(graph):
     return {name: _ids(graph.edges[expr]) for name, expr in _atoms().items()}
 
 
+def _assert_discriminating(graph, single, names):
+    """Reject reference sets that cannot tell a right answer from a wrong one.
+
+    The set-algebra expectations below are derived from single-filter results, so
+    a single filter that selects everything (or nothing) makes the derived
+    expectation degenerate: `EVERYTHING & X == X` is equally consistent with a
+    correct `and` and with one that dropped a term. That is not hypothetical —
+    on a build where a single view filter fails open, every `view & pred`
+    expectation collapses onto the predicate alone, so a broken combination
+    matches its expectation and the pins below would report it as fixed.
+
+    Asserting up front that each baseline is a proper subset keeps the pins
+    honest wherever this file is run, instead of only on a build where the
+    singles happen to be correct.
+    """
+    every = _ids(graph.edges)
+    for name in names:
+        assert single[name], f"baseline edges[{name}] selects nothing on this build"
+        assert single[name] != every, (
+            f"baseline edges[{name}] selects every edge on this build, so any "
+            f"expectation derived from it cannot discriminate"
+        )
+
+
 @with_variants(_init)
 def test_single_filters_match_graph_filter_and_chained_views():
     def check(graph):
@@ -259,6 +283,11 @@ def test_broken_combination_classes_are_still_broken():
     def check(graph):
         atoms, single = _atoms(), _singles(graph)
         every = _ids(graph.edges)
+        _assert_discriminating(
+            graph,
+            single,
+            ["window", "layer", "edge_prop", "node_prop", "node_name"],
+        )
         representatives = {
             "and drops a time view": (
                 atoms["window"] & atoms["edge_prop"],

--- a/python/tests/test_base_install/test_filters/test_edges_collection_filter.py
+++ b/python/tests/test_base_install/test_filters/test_edges_collection_filter.py
@@ -76,12 +76,85 @@ def _not_is_broken(a):
     return a in VIEWS or a in NODE_KIND
 
 
+def _not_composite_is_broken(a, b):
+    # `~(A & B)` and `~(A | B)`: negating a *composite* reaches the same wrappers
+    # through the negation, so `~(A & view)` degenerates to `~A` and loses the
+    # view entirely. Only a composite of two edge predicates survives.
+    return _kind(a) != "edge" or _kind(b) != "edge"
+
+
 def _ids(collection):
     return frozenset(e.id for e in collection)
 
 
+def _view_references(graph):
+    """Each view atom spelled as the equivalent chained view."""
+    return {
+        "layer": graph.layers(["work"]),
+        "layers2": graph.layers(["work", "friends"]),
+        "before": graph.before(10),
+        "after": graph.after(8),
+        "window": graph.window(3, 12),
+        "at": graph.at(10),
+        "latest": graph.latest(),
+        "snap_at": graph.snapshot_at(10),
+        "snap_latest": graph.snapshot_latest(),
+    }
+
+
+# What each non-view atom selects, evaluated directly over the collection. Node
+# filters keep the edges whose *both* endpoints pass, which is how a node filter
+# reduces onto an edge.
+def _node_scores(graph, threshold):
+    return {
+        node.name
+        for node in graph.nodes
+        if (node.properties.get("score") or 0) > threshold
+    }
+
+
+def _both_endpoints(graph, names):
+    return {
+        edge.id
+        for edge in graph.edges
+        if edge.src.name in names and edge.dst.name in names
+    }
+
+
+def _predicate_references(graph):
+    return {
+        "edge_prop": {
+            e.id for e in graph.edges if (e.properties.get("weight") or 0) > 5
+        },
+        "src": {e.id for e in graph.edges if e.src.name == "a"},
+        "dst": {e.id for e in graph.edges if e.dst.name == "c"},
+        "node_prop": _both_endpoints(graph, _node_scores(graph, 15)),
+        "node_name": _both_endpoints(graph, {"b", "c"}),
+        "is_valid": {e.id for e in graph.edges if e.is_valid()},
+        "is_deleted": {e.id for e in graph.edges if e.is_deleted()},
+        "is_active": {e.id for e in graph.edges if e.is_active()},
+        "self_loop": {e.id for e in graph.edges if e.src.name == e.dst.name},
+    }
+
+
 def _singles(graph):
-    return {name: _ids(graph.edges[expr]) for name, expr in _atoms().items()}
+    """What each atom selects, computed *without* the subscript under test.
+
+    Reading these back through `graph.edges[atom]` would make the expectations
+    below agree with the thing they are meant to check: where a single filter
+    fails open, `EVERYTHING & X == X`, so a combination that dropped a term
+    matches its expectation and the pins report a live bug as fixed. Views are
+    referenced through the equivalent chained view instead, and predicates are
+    evaluated over the collection directly.
+    """
+    views = _view_references(graph)
+    singles = {
+        name: frozenset(ids) for name, ids in _predicate_references(graph).items()
+    }
+    singles.update({name: _ids(view.edges) for name, view in views.items()})
+    missing = set(_atoms()) - set(singles)
+    assert not missing, f"no independent reference for {sorted(missing)}"
+    return singles
 
 
 def _assert_discriminating(graph, single, names):
@@ -157,6 +230,21 @@ def test_working_combinations_follow_set_algebra():
                 cases.append((f"{a} & {b}", atoms[a] & atoms[b], single[a] & single[b]))
             if not _or_is_broken(a, b):
                 cases.append((f"{a} | {b}", atoms[a] | atoms[b], single[a] | single[b]))
+            if not _not_composite_is_broken(a, b):
+                cases.append(
+                    (
+                        f"~({a} & {b})",
+                        ~(atoms[a] & atoms[b]),
+                        every - (single[a] & single[b]),
+                    )
+                )
+                cases.append(
+                    (
+                        f"~({a} | {b})",
+                        ~(atoms[a] | atoms[b]),
+                        every - (single[a] | single[b]),
+                    )
+                )
         for a in atoms:
             if not _not_is_broken(a):
                 cases.append((f"~{a}", ~atoms[a], every - single[a]))
@@ -308,6 +396,17 @@ def test_broken_combination_classes_are_still_broken():
             "not of a node filter is not the complement": (
                 ~atoms["node_name"],
                 every - single["node_name"],
+            ),
+            # Negating a composite that contains a view: the pairwise rules
+            # above only ever negate a single atom, so these shapes need their
+            # own representatives.
+            "not of an and containing a view loses the view": (
+                ~(atoms["edge_prop"] & atoms["layer"]),
+                every - (single["edge_prop"] & single["layer"]),
+            ),
+            "not of an or containing a view returns every edge": (
+                ~(atoms["edge_prop"] | atoms["layer"]),
+                every - (single["edge_prop"] | single["layer"]),
             ),
         }
         fixed = []

--- a/python/tests/test_base_install/test_filters/test_nodes_collection_filter.py
+++ b/python/tests/test_base_install/test_filters/test_nodes_collection_filter.py
@@ -70,7 +70,20 @@ def test_node_collection_combinations_follow_set_algebra():
             "before": Graph.before(12),
             "layer": Graph.layer("work"),
         }
-        single = {n: frozenset(graph.nodes[e].name) for n, e in atoms.items()}
+        # References computed without `nodes[...]`, which is the thing under
+        # test: views come from the equivalent chained view, predicates are
+        # evaluated over the collection. Reading them back through the subscript
+        # would make these expectations agree with it by construction.
+        single = {
+            "name": frozenset({"a", "b"}) & frozenset(graph.nodes.name),
+            "prop": frozenset(
+                n.name for n in graph.nodes if (n.properties.get("score") or 0) > 15
+            ),
+            "window": frozenset(graph.window(3, 12).nodes.name),
+            "before": frozenset(graph.before(12).nodes.name),
+            "layer": frozenset(graph.layer("work").nodes.name),
+        }
+        assert set(single) == set(atoms), "every atom needs an independent reference"
         every = frozenset(graph.nodes.name)
         cases = []
         for a, b in combinations(atoms, 2):

--- a/python/tests/test_base_install/test_graphql/test_filters/test_edge_filter_gql.py
+++ b/python/tests/test_base_install/test_graphql/test_filters/test_edge_filter_gql.py
@@ -153,8 +153,19 @@ def test_edges_filter_window_is_active(graph):
     run_graphql_test(query, expected_output, graph, sort_output=True)
 
 
-@pytest.mark.parametrize("graph", [EVENT_GRAPH, PERSISTENT_GRAPH])
-def test_edges_filter_window_is_deleted(graph):
+# `init_graph4` deletes (3, 4) without naming a layer, so the tombstone lands on
+# `_default` while the edge stays alive on `fire_nation`. An event graph reports
+# that a deletion exists; a persistent graph reports the edge as still alive,
+# because it is alive on a layer — so the two models expect different results.
+@pytest.mark.parametrize(
+    "graph,expected_edges",
+    [
+        (EVENT_GRAPH, [{"dst": {"name": "4"}, "src": {"name": "3"}}]),
+        (PERSISTENT_GRAPH, []),
+    ],
+    ids=["event", "persistent"],
+)
+def test_edges_filter_window_is_deleted(graph, expected_edges):
     query = """
     query {
       graph(path: "g") {
@@ -173,11 +184,5 @@ def test_edges_filter_window_is_deleted(graph):
       }
     }
     """
-    expected_output = {
-        "graph": {
-            "edges": {
-                "select": {"list": [{"dst": {"name": "4"}, "src": {"name": "3"}}]}
-            }
-        }
-    }
+    expected_output = {"graph": {"edges": {"select": {"list": expected_edges}}}}
     run_graphql_test(query, expected_output, graph)

--- a/raphtory/src/db/graph/views/is_deleted_graph.rs
+++ b/raphtory/src/db/graph/views/is_deleted_graph.rs
@@ -5,20 +5,17 @@ use crate::{
                 InheritEdgePropertySchemaOps, InheritNodePropertySchemaOps, InheritPropertiesOps,
             },
             view::internal::{
-                EdgeTimeSemanticsOps, Immutable, InheritEdgeFilterOps, InheritEdgeHistoryFilter,
-                InheritExplodedEdgeFilterOps, InheritLayerOps, InheritListOps, InheritMaterialize,
-                InheritNodeFilterOps, InheritNodeHistoryFilter, InheritStorageOps,
-                InheritTimeSemantics, InternalEdgeLayerFilterOps, Static,
+                EdgeTimeSemanticsOps, Immutable, InheritEdgeHistoryFilter,
+                InheritEdgeLayerFilterOps, InheritExplodedEdgeFilterOps, InheritLayerOps,
+                InheritListOps, InheritMaterialize, InheritNodeFilterOps, InheritNodeHistoryFilter,
+                InheritStorageOps, InheritTimeSemantics, InternalEdgeFilterOps, Static,
             },
         },
         graph::views::layer_graph::LayeredGraph,
     },
     prelude::GraphViewOps,
 };
-use raphtory_api::{
-    core::entities::{LayerId, LayerIds},
-    inherit::Base,
-};
+use raphtory_api::{core::entities::LayerIds, inherit::Base};
 use raphtory_storage::{core_ops::InheritCoreGraphOps, graph::edges::edge_ref::EdgeEntryRef};
 
 #[derive(Copy, Clone, Debug)]
@@ -59,22 +56,32 @@ impl<'graph, G: GraphViewOps<'graph>> InheritNodeFilterOps for IsDeletedGraph<G>
 
 impl<'graph, G: GraphViewOps<'graph>> InheritTimeSemantics for IsDeletedGraph<G> {}
 
-impl<'graph, G: GraphViewOps<'graph>> InheritEdgeFilterOps for IsDeletedGraph<G> {}
-
 impl<'graph, G: GraphViewOps<'graph>> InheritExplodedEdgeFilterOps for IsDeletedGraph<G> {}
 
-impl<'graph, G: GraphViewOps<'graph>> InternalEdgeLayerFilterOps for IsDeletedGraph<G> {
-    fn internal_edge_layer_filtered(&self) -> bool {
+impl<'graph, G: GraphViewOps<'graph>> InheritEdgeLayerFilterOps for IsDeletedGraph<G> {}
+
+/// An edge is deleted only when *no* layer of the current view still holds it
+/// alive, which is what `EdgeView::is_deleted` reports.
+///
+/// This has to be the whole-edge filter rather than the per-layer one: an edge
+/// passes a layer filter when *any* of its layers passes, so testing layers
+/// individually would answer "some layer has a deletion" instead. The two
+/// readings diverge as soon as an edge's layers disagree — a deletion recorded
+/// on a layer the edge was never added to (which `delete_edge` does by default,
+/// tombstoning `_default`) would then report an edge as deleted while it is
+/// still alive on another layer, and while `is_deleted()` says it is not.
+impl<'graph, G: GraphViewOps<'graph>> InternalEdgeFilterOps for IsDeletedGraph<G> {
+    fn internal_edge_filtered(&self) -> bool {
         true
     }
 
-    fn internal_layer_filter_edge_list_trusted(&self) -> bool {
+    fn internal_edge_list_trusted(&self) -> bool {
         false
     }
 
-    fn internal_filter_edge_layer(&self, edge: EdgeEntryRef, layer: LayerId) -> bool {
+    fn internal_filter_edge(&self, edge: EdgeEntryRef, layer_ids: &LayerIds) -> bool {
         let time_semantics = self.graph.edge_time_semantics();
-        time_semantics.edge_is_deleted(edge, LayeredGraph::new(&self.graph, LayerIds::One(layer)))
-            && self.graph.internal_filter_edge_layer(edge, layer)
+        time_semantics.edge_is_deleted(edge, LayeredGraph::new(&self.graph, layer_ids.clone()))
+            && self.graph.internal_filter_edge(edge, layer_ids)
     }
 }

--- a/raphtory/src/db/graph/views/is_deleted_graph.rs
+++ b/raphtory/src/db/graph/views/is_deleted_graph.rs
@@ -1,17 +1,14 @@
 use crate::{
-    db::{
-        api::{
-            properties::internal::{
-                InheritEdgePropertySchemaOps, InheritNodePropertySchemaOps, InheritPropertiesOps,
-            },
-            view::internal::{
-                EdgeTimeSemanticsOps, Immutable, InheritEdgeHistoryFilter,
-                InheritEdgeLayerFilterOps, InheritExplodedEdgeFilterOps, InheritLayerOps,
-                InheritListOps, InheritMaterialize, InheritNodeFilterOps, InheritNodeHistoryFilter,
-                InheritStorageOps, InheritTimeSemantics, InternalEdgeFilterOps, Static,
-            },
+    db::api::{
+        properties::internal::{
+            InheritEdgePropertySchemaOps, InheritNodePropertySchemaOps, InheritPropertiesOps,
         },
-        graph::views::layer_graph::LayeredGraph,
+        view::internal::{
+            EdgeTimeSemanticsOps, Immutable, InheritEdgeHistoryFilter, InheritEdgeLayerFilterOps,
+            InheritExplodedEdgeFilterOps, InheritLayerOps, InheritListOps, InheritMaterialize,
+            InheritNodeFilterOps, InheritNodeHistoryFilter, InheritStorageOps,
+            InheritTimeSemantics, InternalEdgeFilterOps, Static,
+        },
     },
     prelude::GraphViewOps,
 };
@@ -70,6 +67,11 @@ impl<'graph, G: GraphViewOps<'graph>> InheritEdgeLayerFilterOps for IsDeletedGra
 /// on a layer the edge was never added to (which `delete_edge` does by default,
 /// tombstoning `_default`) would then report an edge as deleted while it is
 /// still alive on another layer, and while `is_deleted()` says it is not.
+///
+/// For the same reason the deletion test ignores the layer ids it is handed:
+/// they scope the caller's question, and answering within a narrower scope
+/// would give that same partial reading. Only the delegated filter below can
+/// use them.
 impl<'graph, G: GraphViewOps<'graph>> InternalEdgeFilterOps for IsDeletedGraph<G> {
     fn internal_edge_filtered(&self) -> bool {
         true
@@ -81,7 +83,7 @@ impl<'graph, G: GraphViewOps<'graph>> InternalEdgeFilterOps for IsDeletedGraph<G
 
     fn internal_filter_edge(&self, edge: EdgeEntryRef, layer_ids: &LayerIds) -> bool {
         let time_semantics = self.graph.edge_time_semantics();
-        time_semantics.edge_is_deleted(edge, LayeredGraph::new(&self.graph, layer_ids.clone()))
+        time_semantics.edge_is_deleted(edge, &self.graph)
             && self.graph.internal_filter_edge(edge, layer_ids)
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Split out of #2767: the `is_deleted` fix and the test hardening that does not depend on the filter-lowering work, so they can land while the composite lowering is redesigned.

**1. `is_deleted` aggregates over an edge's layers** (Pometry/pometry-storage#378)

`IsDeletedGraph` implemented the predicate as a *per-layer* filter, and an edge passes a layer filter when **any** of its layers passes — so `edges[is_deleted()]` answered "some layer has a deletion" while `EdgeView::is_deleted` answers "no layer still holds this edge alive". The two diverge as soon as an edge's layers disagree, which the default delete path produces on its own: `delete_edge(t, src, dst)` with no layer always tombstones `_default`, leaving a layered edge alive on its own layer and deleted on another. On a `PersistentGraph` that also broke the `valid`/`deleted` partition — the same edge appeared in both. It now implements the whole-edge filter, which receives the view's full layer set.

The state itself is deliberate — recording a deletion on a layer an edge was never added to is what lets an out-of-order stream see a deletion before its addition — so the fix is in how the readers aggregate, not in rejecting the write. `ValidGraph` and `IsActiveGraph` stay per-layer, which is correct for them: "alive on some layer" and "active on some layer" are the intended readings.

**2. Set-algebra expectations no longer come from the path under test**

The edge- and node-collection suites derived their expected sets by reading single filters back through the same subscript they were checking. Where a single filter fails open, `EVERYTHING & X == X`, so a combination that silently dropped a term matched its own expectation. References now come from the equivalent chained view for view atoms and from direct evaluation for predicates, a degenerate baseline (a single filter selecting everything or nothing) is rejected up front, and the negated-composite shapes `~(A & view)` / `~(A | view)` are covered explicitly — they were reported on Pometry/pometry-storage#371 as a cell the pairwise grid cannot reach.

The combination classes that are broken on `db_v4` stay pinned as broken, by a discriminating representative each; those pins fail with instructions when a fix lands.

### Why are the changes needed?

The `is_deleted` divergence made either answer unsafe to rely on, since the filter and the method are two spellings of one question. The oracle change is what let the remaining filter-composition bugs be measured honestly rather than masked.

### Does this PR introduce any user-facing change? If yes is this documented?

One answer changes:

    # PersistentGraph, edge added on layer "work" then deleted with no layer named
    g.edges[Edge.is_deleted()]        -> []            (was [the edge])

On an event graph `is_deleted` still reports that a deletion event exists, regardless of which layer recorded it; the two models expect different results and the tests are split accordingly.

### How was this patch tested?

* New `test_deletion_layer_semantics.py`: the deletion's layer relative to the edge's layers, crossed over the three layouts and both graph models.
* `test_edge_filter.py` / `test_edge_filter_gql.py`: `is_deleted` expectations split by graph model.
* Collection suites: independent references, degenerate-baseline guard, negated-composite rows.
* Full Python suite 3355 passed / 17 skipped / 9 xfailed; filter suite 585 passed; `cargo test -p raphtory --lib` 83 passed; `cargo check --features python` and `cargo +nightly fmt` clean.

### Are there any further changes required?

The composite filter lowering (#371 classes 1–5) is being redesigned in #2767 around proper time-semantics composition and will land separately.
