### PR TITLE
Reworking the label propagation algorithm

### DIFF
--- a/raphtory-graphql/src/model/algorithms/resolvers.rs
+++ b/raphtory-graphql/src/model/algorithms/resolvers.rs
@@ -321,12 +321,29 @@ impl GqlAlgorithms {
     pub async fn label_propagation(
         &self,
         #[graphql(desc = "Number of iterations to run. Defaults to 20.")] iter_count: Option<usize>,
+        #[graphql(desc = "Seed for the tie-break draw. If unset, seeded from the OS.")]
+        seed: Option<u64>,
         #[graphql(desc = "Number of threads to use. Defaults to all available.")] threads: Option<
             usize,
         >,
+        #[graphql(
+            desc = "Relative-improvement threshold used to track convergence. Defaults to 3e-4."
+        )]
+        rel_tol: Option<f64>,
+        #[graphql(desc = "Stop after this many iterations without progress. Defaults to 10.")]
+        patience: Option<usize>,
     ) -> GqlNodeState {
         self.run(move |graph| {
-            label_propagation(&graph, iter_count.unwrap_or(20), None, threads).into()
+            label_propagation(
+                &graph,
+                iter_count.unwrap_or(20),
+                seed,
+                threads,
+                None,
+                rel_tol,
+                patience,
+            )
+            .into()
         })
         .await
     }

--- a/raphtory-graphql/src/model/graph/vector_selection.rs
+++ b/raphtory-graphql/src/model/graph/vector_selection.rs
@@ -181,3 +181,12 @@ impl GqlVectorSelection {
         self.0.get_vectorised_graph().embed_text(text).await
     }
 }
+
+#[cfg(not(feature = "vectors"))]
+#[derive(ResolvedObject)]
+#[graphql(name = "VectorSelection")]
+pub struct GqlVectorSelection;
+
+#[cfg(not(feature = "vectors"))]
+#[ResolvedObjectFields]
+impl GqlVectorSelection {}

--- a/raphtory-graphql/src/model/graph/vector_selection.rs
+++ b/raphtory-graphql/src/model/graph/vector_selection.rs
@@ -181,12 +181,3 @@ impl GqlVectorSelection {
         self.0.get_vectorised_graph().embed_text(text).await
     }
 }
-
-#[cfg(not(feature = "vectors"))]
-#[derive(ResolvedObject)]
-#[graphql(name = "VectorSelection")]
-pub struct GqlVectorSelection;
-
-#[cfg(not(feature = "vectors"))]
-#[ResolvedObjectFields]
-impl GqlVectorSelection {}

--- a/raphtory-tests/tests/algo_tests/community_detection.rs
+++ b/raphtory-tests/tests/algo_tests/community_detection.rs
@@ -49,7 +49,7 @@ fn lpa_test() {
     test_storage!(&graph, |graph| {
         let seed = Some([5; 32]);
         let result =
-            label_propagation(graph, 20, seed, None).to_hashmap(|value| value.community_id);
+            label_propagation(graph, 20, seed, None, None).to_hashmap(|value| value.community_id);
         println!("{:?}", result);
         let result = group_by_value(&result);
 

--- a/raphtory-tests/tests/algo_tests/community_detection.rs
+++ b/raphtory-tests/tests/algo_tests/community_detection.rs
@@ -1,6 +1,6 @@
 use raphtory::{
     algorithms::community_detection::{
-        label_propagation::label_propagation,
+        label_propagation::{label_propagation, label_propagation_fast},
         louvain::louvain,
         modularity::{ComID, ModularityFunction, ModularityUnDir, Partition},
     },
@@ -66,6 +66,69 @@ fn lpa_test() {
         ];
         for hashset in expected {
             assert!(result.contains(&hashset));
+        }
+    });
+}
+
+/// `label_propagation_fast` must agree with `label_propagation` node for node. It only runs the
+/// seeded case, so both are given an explicit `init_state`: the identity map, which reproduces the
+/// unseeded start, and a partial map, which exercises the `NO_LABEL` front advancing from a couple
+/// of seeds. Both are deterministic given `seed`, including across thread counts.
+#[test]
+fn lpa_fast_matches_lpa() {
+    let graph: Graph = Graph::new();
+    let edges = vec![
+        (1, "R1", "R2"),
+        (1, "R1", "R3"),
+        (1, "R2", "R3"),
+        (1, "R3", "G"),
+        (1, "G", "B1"),
+        (1, "G", "B3"),
+        (1, "B1", "B2"),
+        (1, "B2", "B3"),
+        (1, "B2", "B4"),
+        (1, "B3", "B4"),
+        (1, "B3", "B5"),
+        (1, "B4", "B5"),
+    ];
+    for (ts, src, dst) in edges {
+        graph.add_edge(ts, src, dst, NO_PROPS, None).unwrap();
+    }
+    test_storage!(&graph, |graph| {
+        let identity: HashMap<usize, usize> =
+            graph.nodes().iter().map(|n| (n.node.0, n.node.0)).collect();
+        let partial: HashMap<usize, usize> = ["R1", "B5"]
+            .iter()
+            .enumerate()
+            .map(|(label, name)| (graph.node(*name).unwrap().node.0, label))
+            .collect();
+
+        for init_state in [identity, partial] {
+            for seed in [8u64, 42] {
+                for threads in [None, Some(4)] {
+                    let expected = label_propagation(
+                        graph,
+                        20,
+                        Some(seed),
+                        threads,
+                        Some(init_state.clone()),
+                        None,
+                        None,
+                    )
+                    .to_hashmap(|value| value.community_id);
+                    let actual = label_propagation_fast(
+                        graph,
+                        20,
+                        Some(seed),
+                        threads,
+                        init_state.clone(),
+                        None,
+                        None,
+                    )
+                    .to_hashmap(|value| value.community_id);
+                    assert_eq!(expected, actual, "seed={seed} threads={threads:?}");
+                }
+            }
         }
     });
 }

--- a/raphtory-tests/tests/algo_tests/community_detection.rs
+++ b/raphtory-tests/tests/algo_tests/community_detection.rs
@@ -171,7 +171,7 @@ fn test_louvain_deterministic() {
     random_attachment(&graph, 10_000, 5, Some([7; 32]));
 
     test_storage!(&graph, |graph| {
-        let seed = Some(8);
+        let seed = Some(42);
         let first = louvain::<ModularityUnDir, _>(graph, 1.0, None, None, seed);
 
         for _ in 0..100 {

--- a/raphtory-tests/tests/algo_tests/community_detection.rs
+++ b/raphtory-tests/tests/algo_tests/community_detection.rs
@@ -47,7 +47,7 @@ fn lpa_test() {
         graph.add_edge(ts, src, dst, NO_PROPS, None).unwrap();
     }
     test_storage!(&graph, |graph| {
-        let seed = Some([5; 32]);
+        let seed = Some(5);
         let result = label_propagation(graph, 20, seed, None, None, None, None)
             .to_hashmap(|value| value.community_id);
         println!("{:?}", result);

--- a/raphtory-tests/tests/algo_tests/community_detection.rs
+++ b/raphtory-tests/tests/algo_tests/community_detection.rs
@@ -48,8 +48,8 @@ fn lpa_test() {
     }
     test_storage!(&graph, |graph| {
         let seed = Some([5; 32]);
-        let result =
-            label_propagation(graph, 20, seed, None, None).to_hashmap(|value| value.community_id);
+        let result = label_propagation(graph, 20, seed, None, None, None, None)
+            .to_hashmap(|value| value.community_id);
         println!("{:?}", result);
         let result = group_by_value(&result);
 

--- a/raphtory-tests/tests/algo_tests/community_detection.rs
+++ b/raphtory-tests/tests/algo_tests/community_detection.rs
@@ -47,7 +47,7 @@ fn lpa_test() {
         graph.add_edge(ts, src, dst, NO_PROPS, None).unwrap();
     }
     test_storage!(&graph, |graph| {
-        let seed = Some(6); // NB: different seeds affect the partition reached
+        let seed = Some(8); // NB: different seeds affect the partition reached
         let result = label_propagation(graph, 20, seed, None, None, None, None)
             .to_hashmap(|value| value.community_id);
         println!("{:?}", result);
@@ -171,7 +171,7 @@ fn test_louvain_deterministic() {
     random_attachment(&graph, 10_000, 5, Some([7; 32]));
 
     test_storage!(&graph, |graph| {
-        let seed = Some(42);
+        let seed = Some(8);
         let first = louvain::<ModularityUnDir, _>(graph, 1.0, None, None, seed);
 
         for _ in 0..100 {

--- a/raphtory-tests/tests/algo_tests/community_detection.rs
+++ b/raphtory-tests/tests/algo_tests/community_detection.rs
@@ -47,7 +47,7 @@ fn lpa_test() {
         graph.add_edge(ts, src, dst, NO_PROPS, None).unwrap();
     }
     test_storage!(&graph, |graph| {
-        let seed = Some(5);
+        let seed = Some(6); // NB: different seeds affect the partition reached
         let result = label_propagation(graph, 20, seed, None, None, None, None)
             .to_hashmap(|value| value.community_id);
         println!("{:?}", result);

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -139,17 +139,20 @@ where
     // `patience` iterations since the improvement was no better than `rel_tol`.
     let rel_tol = rel_tol.unwrap_or(3e-4);
     let patience = patience.unwrap_or(10);
-    // (best, stale): Check is Fn + called once/iter single-threaded, so the Mutex is uncontended
-    let convergence_state = Arc::new(Mutex::new((usize::MAX, 0usize)));
+    // (best, stale, n_iter): Check is Fn + called once/iter single-threaded, so the Mutex is uncontended
+    let convergence_state = Arc::new(Mutex::new((usize::MAX, 0usize, 0usize)));
     let step4 = Job::Check(Box::new(move |state: &GlobalState<ComputeStateVec>| {
         let diff = state.read(&global_diff);
-        let (best, stale) = &mut *convergence_state.lock().unwrap();
+        let (best, stale, n_iter) = &mut *convergence_state.lock().unwrap();
+        *n_iter += 1;
         // check for improvement
         let improved = (diff as f64) < (*best as f64) * (1.0 - rel_tol);
         *best = (*best).min(diff);
         *stale = if improved { 0 } else { *stale + 1 };
         // Stop once fully converged (diff == 0) or the changed-node count has plateaued.
         if diff == 0 || *stale >= patience {
+            let pct = 100.0 * diff as f64 / num_nodes as f64;
+            println!("label_propagation: stopped after {n_iter} iters; diff={diff} ({pct:.2}%)");
             Step::Done
         } else {
             Step::Continue

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -16,12 +16,18 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
 pub struct LabelPropState {
     #[serde(skip)]
     nbors: HashMap<usize, usize>,
     pub community_id: usize,
+    #[serde(skip)]
+    is_changed: bool, // derive(Default) initializes to false
 }
 
 /// Computes components using a label propagation algorithm
@@ -52,6 +58,10 @@ where
     let global_diff = accumulators::sum::<usize>(2);
     ctx.global_agg_reset(global_diff);
 
+    let num_nodes = g.count_nodes();
+    let active: Arc<Vec<AtomicBool>> =
+        Arc::new((0..num_nodes).map(|_| AtomicBool::new(false)).collect());
+
     let step1 = ATask::new(move |s| {
         let id = s.node.index();
         let state: &mut LabelPropState = s.get_mut();
@@ -59,10 +69,29 @@ where
             .as_ref()
             .and_then(|map| map.get(&id).copied())
             .unwrap_or(id);
+        state.is_changed = true; // the actual initialization
         Step::Continue
     });
 
+    let active_step2 = Arc::clone(&active);
     let step2 = ATask::new(move |s: &mut EvalNodeView<_, LabelPropState>| {
+        if s.prev().is_changed {
+            for nbor in s.neighbours() {
+                active_step2[nbor.state_pos].store(true, Ordering::Relaxed);
+            }
+        }
+        Step::Continue
+    });
+
+    let active_step3 = Arc::clone(&active);
+    let step3 = ATask::new(move |s: &mut EvalNodeView<_, LabelPropState>| {
+        // Gate: consume this node's activation flag atomically.
+        if !active_step3[s.state_pos].swap(false, Ordering::AcqRel) {
+            s.get_mut().is_changed = false;
+            // NB: this leaves community_id unchanged
+            return Step::Continue;
+        }
+
         let prev_id = s.prev().community_id;
         let nbor_iter = s.neighbours();
         let state: &mut LabelPropState = s.get_mut();
@@ -82,13 +111,14 @@ where
         {
             state.community_id = label;
         }
-        if state.community_id != prev_id {
+        state.is_changed = state.community_id != prev_id;
+        if state.is_changed {
             s.global_update(&global_diff, 1);
         }
         Step::Continue
     });
 
-    let step3 = Job::Check(Box::new(move |state: &GlobalState<ComputeStateVec>| {
+    let step4 = Job::Check(Box::new(move |state: &GlobalState<ComputeStateVec>| {
         if state.read(&global_diff) > 0 {
             Step::Continue
         } else {
@@ -99,7 +129,7 @@ where
     let mut runner: TaskRunner<G, _> = TaskRunner::new(ctx);
     runner.run(
         vec![Job::new(step1)],
-        vec![Job::new(step2), step3],
+        vec![Job::read_only(step2), Job::new(step3), step4],
         None,
         |_, _, _, local, index| {
             TypedNodeState::new(GenericNodeState::new_from_eval_with_index(

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -32,6 +32,7 @@ pub struct LabelPropState {
 /// - `iter_count` - Number of iterations
 /// - `seed` - (Optional) Array of 32 bytes of u8 which is set as the rng seed
 /// - `threads` - (Optional) Number of threads to use
+/// - `init_state` - (Optional) HashMap of node index to community ID for warm-starting the algorithm
 ///
 /// # Returns
 ///
@@ -42,6 +43,7 @@ pub fn label_propagation<G>(
     iter_count: usize,
     _seed: Option<[u8; 32]>,
     threads: Option<usize>,
+    init_state: Option<HashMap<usize, usize>>,
 ) -> TypedNodeState<'static, LabelPropState, G>
 where
     G: StaticGraphViewOps,
@@ -53,7 +55,10 @@ where
     let step1 = ATask::new(move |s| {
         let id = s.node.index();
         let state: &mut LabelPropState = s.get_mut();
-        state.community_id = id;
+        state.community_id = init_state
+            .as_ref()
+            .and_then(|map| map.get(&id).copied())
+            .unwrap_or(id);
         Step::Continue
     });
 

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -17,6 +17,7 @@ use crate::{
 use rand::Rng;
 use raphtory_api::core::utils::hashing::calculate_hash;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 use std::{
     collections::HashMap,
     sync::{
@@ -199,7 +200,7 @@ where
         if diff == 0 || *stale >= patience {
             let pct = 100.0 * diff as f64 / num_nodes as f64;
             // println!("label_propagation: stopped after {n_iter} iters; diff={diff} ({pct:.2}%)");
-            println!(
+            debug!(
                 "label_propagation: stopped after {n_iter} iters; \
                  diff={diff} ({pct:.2}%); seed={tie_seed}"
             );

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -15,10 +15,12 @@ use crate::{
     prelude::*,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
@@ -26,6 +28,7 @@ pub struct LabelPropState {
     #[serde(skip)]
     nbors: HashMap<usize, usize>,
     pub community_id: usize,
+    pub alternate_id: Option<usize>, // set to previous value when community_id has changed; None once settled
     #[serde(skip)]
     is_changed: bool, // derive(Default) initializes to false
 }
@@ -39,10 +42,14 @@ pub struct LabelPropState {
 /// - `seed` - (Optional) Array of 32 bytes of u8 which is set as the rng seed
 /// - `threads` - (Optional) Number of threads to use
 /// - `init_state` - (Optional) HashMap of node index to community ID for warm-starting the algorithm
+/// - `rel_tol` - (Optional) Relative-improvement threshold to track convergence. An iteration counts
+///   as progress only if its changed-node count drops below `best * (1 - rel_tol)`. Defaults to 3e-4.
+/// - `patience` - (Optional) Stop after this many consecutive iterations without progress. Defaults to 10.
 ///
 /// # Returns
 ///
-/// A vector of hashsets each containing nodes
+/// A `TypedNodeState` mapping each node to its `LabelPropState`: its `community_id`, plus
+/// `alternate_id` (the previous label it swaps with while oscillating, or `None` once converged).
 ///
 pub fn label_propagation<G>(
     g: &G,
@@ -50,6 +57,8 @@ pub fn label_propagation<G>(
     _seed: Option<[u8; 32]>,
     threads: Option<usize>,
     init_state: Option<HashMap<usize, usize>>,
+    rel_tol: Option<f64>,
+    patience: Option<usize>,
 ) -> TypedNodeState<'static, LabelPropState, G>
 where
     G: StaticGraphViewOps,
@@ -87,8 +96,10 @@ where
     let step3 = ATask::new(move |s: &mut EvalNodeView<_, LabelPropState>| {
         // Gate: consume this node's activation flag atomically.
         if !active_step3[s.state_pos].swap(false, Ordering::AcqRel) {
-            s.get_mut().is_changed = false;
-            // NB: this leaves community_id unchanged
+            let state = s.get_mut();
+            state.is_changed = false;
+            state.alternate_id = None; // clear any stale value from a prior iter
+                                       // NB: state.community_id unchanged
             return Step::Continue;
         }
 
@@ -99,9 +110,11 @@ where
         // get labels from neighbors
         for nbor in nbor_iter {
             let nbor_id = nbor.prev().community_id;
+            // below could be written instead as:
+            // *state.nbors.entry(nbor_id).or_insert(0) += 1;
             state
                 .nbors
-                .insert(nbor_id, *state.nbors.get(&nbor_id).unwrap_or(&(0)) + 1);
+                .insert(nbor_id, *state.nbors.get(&nbor_id).unwrap_or(&0) + 1);
         }
         // get max label (use usize ID to resolve tie)
         if let Some((&label, _)) = state
@@ -113,16 +126,33 @@ where
         }
         state.is_changed = state.community_id != prev_id;
         if state.is_changed {
+            state.alternate_id = Some(prev_id);
             s.global_update(&global_diff, 1);
+        } else {
+            state.alternate_id = None;
         }
         Step::Continue
     });
 
+    // Synchronous LPA never reaches global_diff == 0 on graphs with locally-bipartite pockets
+    // (results in ~period-2 oscillations), so the stopping criterion we use is to wait for
+    // `patience` iterations since the improvement was no better than `rel_tol`.
+    let rel_tol = rel_tol.unwrap_or(3e-4);
+    let patience = patience.unwrap_or(10);
+    // (best, stale): Check is Fn + called once/iter single-threaded, so the Mutex is uncontended
+    let convergence_state = Arc::new(Mutex::new((usize::MAX, 0usize)));
     let step4 = Job::Check(Box::new(move |state: &GlobalState<ComputeStateVec>| {
-        if state.read(&global_diff) > 0 {
-            Step::Continue
-        } else {
+        let diff = state.read(&global_diff);
+        let (best, stale) = &mut *convergence_state.lock().unwrap();
+        // check for improvement
+        let improved = (diff as f64) < (*best as f64) * (1.0 - rel_tol);
+        *best = (*best).min(diff);
+        *stale = if improved { 0 } else { *stale + 1 };
+        // Stop once fully converged (diff == 0) or the changed-node count has plateaued.
+        if diff == 0 || *stale >= patience {
             Step::Done
+        } else {
+            Step::Continue
         }
     }));
 

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -23,6 +23,13 @@ use std::{
     },
 };
 
+/// Label carried by a node that has not (yet) been assigned a community.
+///
+/// Only used when `init_state` is supplied for unseeded nodes.
+/// Safe as a sentinel because `usize::MAX` is already the codebase's "not a node"
+/// marker (see `VID::is_initialised`), so it can never collide with a node index.
+const NO_LABEL: usize = usize::MAX;
+
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
 pub struct LabelPropState {
     #[serde(skip)]
@@ -41,7 +48,10 @@ pub struct LabelPropState {
 /// - `iter_count` - Number of iterations
 /// - `seed` - (Optional) Array of 32 bytes of u8 which is set as the rng seed
 /// - `threads` - (Optional) Number of threads to use
-/// - `init_state` - (Optional) HashMap of node index to community ID for warm-starting the algorithm
+/// - `init_state` - (Optional) HashMap of node VID to community ID. When absent, every node starts
+///   in its own community. When present, only the nodes it names are labelled and active; the rest
+///   start unlabelled and may acquire a label from their neighbours. A map covering every node
+///   reproduces a previous warm-start behaviour exactly.
 /// - `rel_tol` - (Optional) Relative-improvement threshold to track convergence. An iteration counts
 ///   as progress only if its changed-node count drops below `best * (1 - rel_tol)`. Defaults to 3e-4.
 /// - `patience` - (Optional) Stop after this many consecutive iterations without progress. Defaults to 10.
@@ -49,8 +59,8 @@ pub struct LabelPropState {
 /// # Returns
 ///
 /// A `TypedNodeState` mapping each node to its `LabelPropState`: its `community_id`, plus
-/// `alternate_id` (the previous label it swaps with while oscillating, or `None` once converged).
-///
+/// `alternate_id` (the previous label it swaps with while oscillating; `None` once converged, and
+/// also `None` until the node has been labeled a whole iteration.
 pub fn label_propagation<G>(
     g: &G,
     iter_count: usize,
@@ -74,11 +84,19 @@ where
     let step1 = ATask::new(move |s| {
         let id = s.node.index();
         let state: &mut LabelPropState = s.get_mut();
-        state.community_id = init_state
-            .as_ref()
-            .and_then(|map| map.get(&id).copied())
-            .unwrap_or(id);
-        state.is_changed = true; // the actual initialization
+        match init_state.as_ref() {
+            // Unseeded
+            None => {
+                state.community_id = id;
+                state.is_changed = true; // the actual initialization
+            }
+            // Seeded: only nodes named in the map get a label, and only they start live.
+            Some(map) => {
+                let seed = map.get(&id).copied();
+                state.community_id = seed.unwrap_or(NO_LABEL);
+                state.is_changed = seed.is_some();
+            }
+        }
         Step::Continue
     });
 
@@ -106,10 +124,18 @@ where
         let prev_id = s.prev().community_id;
         let nbor_iter = s.neighbours();
         let state: &mut LabelPropState = s.get_mut();
-        state.nbors = HashMap::from([(prev_id, 1)]);
+        // each node votes for its own label but only if it's initialised
+        state.nbors = if prev_id != NO_LABEL {
+            HashMap::from([(prev_id, 1)])
+        } else {
+            HashMap::new()
+        };
         // get labels from neighbors
         for nbor in nbor_iter {
             let nbor_id = nbor.prev().community_id;
+            if nbor_id == NO_LABEL {
+                continue; // unlabelled neihbours don't cast a vote
+            }
             // below could be written instead as:
             // *state.nbors.entry(nbor_id).or_insert(0) += 1;
             state
@@ -126,7 +152,7 @@ where
         }
         state.is_changed = state.community_id != prev_id;
         if state.is_changed {
-            state.alternate_id = Some(prev_id);
+            state.alternate_id = (prev_id != NO_LABEL).then_some(prev_id);
             s.global_update(&global_diff, 1);
         } else {
             state.alternate_id = None;

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -94,8 +94,9 @@ where
     let active: Arc<Vec<AtomicBool>> =
         Arc::new((0..num_nodes).map(|_| AtomicBool::new(false)).collect());
 
-    // An unseeded run draws fresh entropy, as `fast_rp`, `louvain` and the graph generators all do.
+    // Unseeded runs draw random number
     let tie_seed: u64 = seed.unwrap_or_else(|| rand::rng().random());
+
     let step1 = ATask::new(move |s| {
         let id = s.node.index();
         let state: &mut LabelPropState = s.get_mut();

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -14,6 +14,8 @@ use crate::{
     },
     prelude::*,
 };
+use rand::Rng;
+use raphtory_api::core::utils::hashing::calculate_hash;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -40,13 +42,24 @@ pub struct LabelPropState {
     is_changed: bool, // derive(Default) initializes to false
 }
 
+/// Deterministic pseudorandom rank for `label` as seen by `node`, used only to break vote-count
+/// ties in `step3`.
+///
+/// `node` is the VID and the super-step is not mixed in, so a node's preference order is stable
+/// across iterations: a standing tie resolves the same way each time and adds no churn to
+/// `global_diff`.
+fn tie_rank(seed: u64, node: usize, label: usize) -> u64 {
+    calculate_hash(&(seed, node, label))
+}
+
 /// Computes components using a label propagation algorithm
 ///
 /// # Arguments
 ///
 /// - `g` - A reference to the graph
 /// - `iter_count` - Number of iterations
-/// - `seed` - (Optional) Array of 32 bytes of u8 which is set as the rng seed
+/// - `seed` - (Optional) Seeds the tie-break draw. The value used is printed in the stopping summary
+///   and can be passed back here to reproduce a run.
 /// - `threads` - (Optional) Number of threads to use
 /// - `init_state` - (Optional) HashMap of node VID to community ID. When absent, every node starts
 ///   in its own community. When present, only the nodes it names are labelled and active; the rest
@@ -64,7 +77,7 @@ pub struct LabelPropState {
 pub fn label_propagation<G>(
     g: &G,
     iter_count: usize,
-    _seed: Option<[u8; 32]>,
+    seed: Option<u64>,
     threads: Option<usize>,
     init_state: Option<HashMap<usize, usize>>,
     rel_tol: Option<f64>,
@@ -81,6 +94,8 @@ where
     let active: Arc<Vec<AtomicBool>> =
         Arc::new((0..num_nodes).map(|_| AtomicBool::new(false)).collect());
 
+    // An unseeded run draws fresh entropy, as `fast_rp`, `louvain` and the graph generators all do.
+    let tie_seed: u64 = seed.unwrap_or_else(|| rand::rng().random());
     let step1 = ATask::new(move |s| {
         let id = s.node.index();
         let state: &mut LabelPropState = s.get_mut();
@@ -121,6 +136,7 @@ where
             return Step::Continue;
         }
 
+        let id = s.node.index();
         let prev_id = s.prev().community_id;
         let nbor_iter = s.neighbours();
         let state: &mut LabelPropState = s.get_mut();
@@ -142,11 +158,14 @@ where
                 .nbors
                 .insert(nbor_id, *state.nbors.get(&nbor_id).unwrap_or(&0) + 1);
         }
-        // get max label (use usize ID to resolve tie)
         if let Some((&label, _)) = state
             .nbors
             .iter()
-            .max_by(|(k1, v1), (k2, v2)| v1.cmp(v2).then(k1.cmp(k2)))
+            // REMOVED: get max label (use usize ID to resolve tie)
+            // .max_by(|(k1, v1), (k2, v2)| v1.cmp(v2).then(k1.cmp(k2)))
+            // NEW BEHAVIOUR: a tie is settled by pseudorandom rank, which draws the winner uniformly
+            // from all the top-tied labels.
+            .max_by_key(|&(&label, &count)| (count, tie_rank(tie_seed, id, label)))
         {
             state.community_id = label;
         }
@@ -178,7 +197,11 @@ where
         // Stop once fully converged (diff == 0) or the changed-node count has plateaued.
         if diff == 0 || *stale >= patience {
             let pct = 100.0 * diff as f64 / num_nodes as f64;
-            println!("label_propagation: stopped after {n_iter} iters; diff={diff} ({pct:.2}%)");
+            // println!("label_propagation: stopped after {n_iter} iters; diff={diff} ({pct:.2}%)");
+            println!(
+                "label_propagation: stopped after {n_iter} iters; \
+                 diff={diff} ({pct:.2}%); seed={tie_seed}"
+            );
             Step::Done
         } else {
             Step::Continue

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -16,15 +16,17 @@ use crate::{
 };
 use rand::Rng;
 use raphtory_api::core::utils::hashing::calculate_hash;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 use std::{
+    cell::RefCell,
     collections::HashMap,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
     },
 };
+use tracing::debug;
 
 /// Label carried by a node that has not (yet) been assigned a community.
 ///
@@ -33,14 +35,18 @@ use std::{
 /// marker (see `VID::is_initialised`), so it can never collide with a node index.
 const NO_LABEL: usize = usize::MAX;
 
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
 pub struct LabelPropState {
-    #[serde(skip)]
-    nbors: HashMap<usize, usize>,
     pub community_id: usize,
     pub alternate_id: Option<usize>, // set to previous value when community_id has changed; None once settled
     #[serde(skip)]
     is_changed: bool, // derive(Default) initializes to false
+}
+
+// Per-thread scratch tally for `step3` vote counts. Keeping them out of `LabelPropState` spares
+// the runner a deep `HashMap` clone per node per superstep.
+thread_local! {
+    static LABEL_COUNTS: RefCell<FxHashMap<usize, usize>> = RefCell::new(FxHashMap::default());
 }
 
 /// Deterministic pseudorandom rank for `label` as seen by `node`, used only to break vote-count
@@ -139,41 +145,40 @@ where
         }
 
         let id = s.node.index();
-        let prev_id = s.prev().community_id;
-        let nbor_iter = s.neighbours();
-        let state: &mut LabelPropState = s.get_mut();
-        // each node votes for its own label but only if it's initialised
-        state.nbors = if prev_id != NO_LABEL {
-            HashMap::from([(prev_id, 1)])
-        } else {
-            HashMap::new()
-        };
-        // get labels from neighbors
-        for nbor in nbor_iter {
-            let nbor_id = nbor.prev().community_id;
-            if nbor_id == NO_LABEL {
-                continue; // unlabelled neihbours don't cast a vote
+        let prev_label = s.prev().community_id;
+        let winner_label = LABEL_COUNTS.with(|counts| {
+            let mut counts = counts.borrow_mut();
+            counts.clear();
+            if prev_label != NO_LABEL {
+                // initialised nodes vote for their own label
+                counts.insert(prev_label, 1);
             }
-            // below could be written instead as:
-            // *state.nbors.entry(nbor_id).or_insert(0) += 1;
-            state
-                .nbors
-                .insert(nbor_id, *state.nbors.get(&nbor_id).unwrap_or(&0) + 1);
-        }
-        if let Some((&label, _)) = state
-            .nbors
-            .iter()
-            // REMOVED: get max label (use usize ID to resolve tie)
-            // .max_by(|(k1, v1), (k2, v2)| v1.cmp(v2).then(k1.cmp(k2)))
-            // NEW BEHAVIOUR: a tie is settled by pseudorandom rank, which draws the winner uniformly
-            // from all the top-tied labels.
-            .max_by_key(|&(&label, &count)| (count, tie_rank(tie_seed, id, label)))
-        {
+            for nbor in s.neighbours() {
+                let nbor_label = nbor.prev().community_id;
+                if nbor_label == NO_LABEL {
+                    continue; // unlabelled neighbours don't cast a vote
+                }
+                let count = counts.entry(nbor_label).or_insert(0);
+                *count += 1;
+            }
+            counts
+                .iter()
+                // REMOVED: get max label (use usize ID to resolve tie)
+                // .max_by(|(k1, v1), (k2, v2)| v1.cmp(v2).then(k1.cmp(k2)))
+                // NEW BEHAVIOUR: a tie is settled by pseudorandom rank, which draws the winner uniformly
+                // from all the top-tied labels.
+                .max_by_key(|&(&label, &count)| (count, tie_rank(tie_seed, id, label)))
+                .map(|(&label, _)| label)
+        });
+
+        let state: &mut LabelPropState = s.get_mut();
+        // No votes at all (unlabelled node, no labelled neighbours) leaves community_id standing.
+        if let Some(label) = winner_label {
             state.community_id = label;
         }
-        state.is_changed = state.community_id != prev_id;
+        state.is_changed = state.community_id != prev_label;
         if state.is_changed {
-            state.alternate_id = (prev_id != NO_LABEL).then_some(prev_id);
+            state.alternate_id = (prev_label != NO_LABEL).then_some(prev_label);
             s.global_update(&global_diff, 1);
         } else {
             state.alternate_id = None;

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -2,27 +2,30 @@ use crate::{
     core::state::{accumulator_id::accumulators, compute_state::ComputeStateVec},
     db::{
         api::{
-            state::{GenericNodeState, TypedNodeState},
-            view::StaticGraphViewOps,
+            state::{GenericNodeState, Index, TypedNodeState},
+            view::{internal::filtered_node::FilteredNodeStorageOps, StaticGraphViewOps},
         },
         task::{
             context::{Context, GlobalState},
+            custom_pool,
             node::eval_node::EvalNodeView,
             task::{ATask, Job, Step},
             task_runner::TaskRunner,
+            POOL,
         },
     },
     prelude::*,
 };
 use rand::Rng;
-use raphtory_api::core::utils::hashing::calculate_hash;
+use raphtory_api::core::{entities::VID, utils::hashing::calculate_hash, Direction};
+use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
     collections::HashMap,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
     },
 };
@@ -34,6 +37,12 @@ use tracing::debug;
 /// Safe as a sentinel because `usize::MAX` is already the codebase's "not a node"
 /// marker (see `VID::is_initialised`), so it can never collide with a node index.
 const NO_LABEL: usize = usize::MAX;
+
+/// Default relative-improvement threshold for the plateau stopping criterion.
+const DEFAULT_REL_TOL: f64 = 3e-4;
+
+/// Default number of consecutive iterations without progress before stopping.
+const DEFAULT_PATIENCE: usize = 10;
 
 #[derive(Copy, Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
 pub struct LabelPropState {
@@ -104,6 +113,8 @@ where
 
     // Unseeded runs draw random number
     let tie_seed: u64 = seed.unwrap_or_else(|| rand::rng().random());
+    let rel_tol = rel_tol.unwrap_or(DEFAULT_REL_TOL);
+    let patience = patience.unwrap_or(DEFAULT_PATIENCE);
 
     let step1 = ATask::new(move |s| {
         let id = s.node.index();
@@ -207,8 +218,7 @@ where
     // Synchronous LPA never reaches global_diff == 0 on graphs with locally-bipartite pockets
     // (results in ~period-2 oscillations), so the stopping criterion we use is to wait for
     // `patience` iterations since the improvement was no better than `rel_tol`.
-    let rel_tol = rel_tol.unwrap_or(3e-4);
-    let patience = patience.unwrap_or(10);
+
     // (best, stale, n_iter): Check is Fn + called once/iter single-threaded, so the Mutex is uncontended
     let convergence_state = Arc::new(Mutex::new((usize::MAX, 0usize, 0usize)));
     let step4 = Job::Check(Box::new(move |state: &GlobalState<ComputeStateVec>| {
@@ -251,4 +261,236 @@ where
         None,
         None,
     )
+}
+
+/// Seeded label propagation over flat label arrays, bypassing the task framework.
+///
+/// Same result as [`label_propagation`] called with the same arguments and a `Some(init_state)`:
+/// same activation gating, same tie-break, same plateau stopping criterion. It differs only in
+/// how it gets there, which is where the speed comes from:
+///
+/// - votes are tallied in a flat array indexed by a compacted label, so resetting the tally
+///   between nodes is proportional to the node's degree rather than to the high-water capacity
+///   of a hash map;
+/// - the adjacency is read through a [`GraphStorage::lock`]ed view of the storage, taken once,
+///   so traversing a node's neighbours does not re-acquire a segment lock per node;
+/// - a node that changes its label activates its neighbours directly, which removes the separate
+///   full pass over the graph that the task version needs to build the next frontier.
+///
+/// Unlike [`label_propagation`] this only runs the seeded case: `init_state` is mandatory.
+///
+/// # Arguments
+///
+/// See [`label_propagation`]; the arguments mean the same thing, except that `init_state` is
+/// required. The label values themselves are unconstrained — they are compacted internally, so
+/// the tally is sized by the number of *distinct* labels, not by the largest one.
+///
+/// # Returns
+///
+/// A `TypedNodeState` mapping each node to its `LabelPropState`, exactly as [`label_propagation`].
+pub fn label_propagation_fast<G>(
+    g: &G,
+    iter_count: usize,
+    seed: Option<u64>,
+    threads: Option<usize>,
+    init_state: HashMap<usize, usize>,
+    rel_tol: Option<f64>,
+    patience: Option<usize>,
+) -> TypedNodeState<'static, LabelPropState, G>
+where
+    G: StaticGraphViewOps,
+{
+    let index = Index::for_graph(g.clone());
+    let n = index.len();
+
+    // Unseeded runs draw random number
+    let tie_seed: u64 = seed.unwrap_or_else(|| rand::rng().random());
+    let rel_tol = rel_tol.unwrap_or(DEFAULT_REL_TOL);
+    let patience = patience.unwrap_or(DEFAULT_PATIENCE);
+
+    // Compact the caller's labels into `0..labels.len()`. Only labels named in `init_state` are
+    // ever in circulation (an unlabelled node can only copy a neighbour's), so this is the whole
+    // label space, and the vote tally below is sized by it rather than by the label values.
+    let labels: Vec<usize> = {
+        let mut labels: Vec<usize> = init_state.values().copied().collect();
+        labels.sort_unstable();
+        labels.dedup(); // only removes consecutive
+        labels
+    };
+    let slot_of: FxHashMap<usize, usize> = labels
+        .iter()
+        .enumerate()
+        .map(|(slot, &label)| (label, slot))
+        .collect();
+
+    // One lock for the whole run: `core_node` on a locked storage is an indexed read
+    let locked = g.core_graph().lock();
+    let layer_ids = g.layer_ids();
+    // Neighbours as flat index positions, matching `NodeViewOps::neighbours` (both directions,
+    // deduplicated, view filters applied).
+    let collect_nbors = |vid: VID, out: &mut Vec<usize>| {
+        out.clear();
+        let node = locked.core_node(vid);
+        out.extend(
+            node.as_ref()
+                .filtered_neighbours_iter(g, layer_ids, Direction::BOTH)
+                .map(|nbor| index.index(&nbor).expect("neighbour VID not in index")),
+        );
+    };
+
+    // Labels, held as slots and indexed by flat position. `cur` starts as a copy of `prev` so that
+    // an `iter_count` of 0 still reports the seeding.
+    let mut prev: Vec<AtomicUsize> = (0..n).map(|_| AtomicUsize::new(NO_LABEL)).collect();
+    index.par_iter().for_each(|(pos, vid)| {
+        if let Some(slot) = init_state.get(&vid.index()).and_then(|l| slot_of.get(l)) {
+            prev[pos].store(*slot, Ordering::Relaxed);
+        }
+    });
+    let mut cur: Vec<AtomicUsize> = prev
+        .iter()
+        .map(|slot| AtomicUsize::new(slot.load(Ordering::Relaxed)))
+        .collect();
+
+    // The frontier for the first sweep: the neighbours of the seeded nodes.
+    let mut active_cur: Vec<AtomicBool> = (0..n).map(|_| AtomicBool::new(false)).collect();
+    let mut active_next: Vec<AtomicBool> = (0..n).map(|_| AtomicBool::new(false)).collect();
+    index
+        .par_iter()
+        .for_each_init(Vec::new, |nbors, (pos, vid)| {
+            if prev[pos].load(Ordering::Relaxed) != NO_LABEL {
+                collect_nbors(vid, nbors); // collects into nbors
+                for &nbor in nbors.iter() {
+                    active_cur[nbor].store(true, Ordering::Relaxed);
+                }
+            }
+        });
+
+    let sweep = |prev: &[AtomicUsize],
+                 cur: &[AtomicUsize],
+                 active_cur: &[AtomicBool],
+                 active_next: &[AtomicBool]| {
+        let changed = AtomicUsize::new(0); // a counter
+        index.par_iter().for_each_init(
+            || (vec![0u32; labels.len()], Vec::new(), Vec::new()),
+            |(counts, touched, nbors), (pos, vid)| {
+                let prev_slot = prev[pos].load(Ordering::Relaxed);
+                // Gate: consume this node's activation flag atomically. A node that does not run
+                // still has to carry its label over, which the task version gets for free from the
+                // runner copying `prev` into `cur` between supersteps.
+                if !active_cur[pos].swap(false, Ordering::AcqRel) {
+                    cur[pos].store(prev_slot, Ordering::Relaxed);
+                    return;
+                }
+
+                collect_nbors(vid, nbors);
+                let node_key = calculate_hash(&(tie_seed, vid.index())); // tie_rank's 1st arg
+                let mut best_slot = prev_slot;
+                let mut best_count = 0u32;
+                let mut best_rank = 0u64;
+                if prev_slot != NO_LABEL {
+                    // initialised nodes vote for their own label
+                    counts[prev_slot] = 1;
+                    touched.push(prev_slot);
+                    best_count = 1;
+                    best_rank = tie_rank(node_key, labels[prev_slot]);
+                }
+                for &nbor in nbors.iter() {
+                    let nbor_slot = prev[nbor].load(Ordering::Relaxed);
+                    if nbor_slot == NO_LABEL {
+                        continue; // unlabelled neighbours don't cast a vote
+                    }
+                    let count = &mut counts[nbor_slot];
+                    *count += 1;
+                    let count = *count;
+                    // if count increased from 0 -> 1 we keep track of activated nbors
+                    if count == 1 {
+                        touched.push(nbor_slot);
+                    }
+
+                    if nbor_slot == best_slot {
+                        best_count = count;
+                    } else if count >= best_count {
+                        let rank = tie_rank(node_key, labels[nbor_slot]);
+                        if (count, rank) > (best_count, best_rank) {
+                            best_slot = nbor_slot;
+                            best_count = count;
+                            best_rank = rank;
+                        }
+                    }
+                }
+                // Reset
+                for &slot in touched.iter() {
+                    counts[slot] = 0;
+                }
+                touched.clear();
+
+                // `best_slot` is still `prev_slot` when no voting happened, so an unlabelled node
+                // with no labelled neighbours keeps its label, as in the task version.
+                cur[pos].store(best_slot, Ordering::Relaxed);
+                if best_slot != prev_slot {
+                    changed.fetch_add(1, Ordering::Relaxed);
+                    // The frontier
+                    for &nbor in nbors.iter() {
+                        active_next[nbor].store(true, Ordering::Relaxed);
+                    }
+                }
+            },
+        );
+        changed.into_inner()
+    };
+
+    // Synchronous LPA never reaches global_diff == 0 on graphs with locally-bipartite pockets
+    // (results in ~period-2 oscillations), so the stopping criterion we use is to wait for
+    // `patience` iterations since the improvement was no better than `rel_tol`.
+    let pool: Arc<rayon::ThreadPool> = threads.map(custom_pool).unwrap_or_else(|| POOL.clone());
+    pool.install(|| {
+        let mut best = usize::MAX;
+        let mut stale = 0usize;
+        for n_iter in 1..=iter_count {
+            let diff = sweep(&prev, &cur, &active_cur, &active_next);
+            // `prev` now holds the labels this sweep produced, `cur` the ones it started from.
+            std::mem::swap(&mut prev, &mut cur);
+            std::mem::swap(&mut active_cur, &mut active_next);
+
+            // check for improvement
+            let improved = (diff as f64) < (best as f64) * (1.0 - rel_tol);
+            best = best.min(diff);
+            stale = if improved { 0 } else { stale + 1 };
+            // Stop once fully converged (diff == 0) or the changed-node count has plateaued.
+            if diff == 0 || stale >= patience {
+                let pct = 100.0 * diff as f64 / n as f64;
+                debug!(
+                    "label_propagation_fast: stopped after {n_iter} iters; \
+                     diff={diff} ({pct:.2}%); seed={tie_seed}"
+                );
+                break;
+            }
+        }
+    });
+
+    // `cur` still holds the labels from before the last sweep, which is what `alternate_id` and
+    // `is_changed` report on.
+    let values: Vec<LabelPropState> = (0..n)
+        .into_par_iter()
+        .map(|pos| {
+            let slot = prev[pos].load(Ordering::Relaxed);
+            let was = cur[pos].load(Ordering::Relaxed);
+            LabelPropState {
+                community_id: if slot == NO_LABEL {
+                    NO_LABEL
+                } else {
+                    labels[slot]
+                },
+                alternate_id: (slot != was && was != NO_LABEL).then(|| labels[was]),
+                is_changed: slot != was,
+            }
+        })
+        .collect();
+
+    TypedNodeState::new(GenericNodeState::new_from_eval_with_index(
+        g.clone(),
+        values,
+        index,
+        None,
+    ))
 }

--- a/raphtory/src/algorithms/community_detection/label_propagation.rs
+++ b/raphtory/src/algorithms/community_detection/label_propagation.rs
@@ -49,14 +49,15 @@ thread_local! {
     static LABEL_COUNTS: RefCell<FxHashMap<usize, usize>> = RefCell::new(FxHashMap::default());
 }
 
-/// Deterministic pseudorandom rank for `label` as seen by `node`, used only to break vote-count
-/// ties in `step3`.
-///
-/// `node` is the VID and the super-step is not mixed in, so a node's preference order is stable
-/// across iterations: a standing tie resolves the same way each time and adds no churn to
-/// `global_diff`.
-fn tie_rank(seed: u64, node: usize, label: usize) -> u64 {
-    calculate_hash(&(seed, node, label))
+/// Deterministic pseudorandom rank for `label` as seen by a node whose `node_key` is
+/// `calculate_hash(&(seed, node))`, used only to break vote-count ties in `step3`.
+/// Splitting the mix in two lets `step3` hoist the per-node half out of its per-label loop.
+#[inline]
+fn tie_rank(node_key: u64, label: usize) -> u64 {
+    let mut x = node_key ^ (label as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^ (x >> 31)
 }
 
 /// Computes components using a label propagation algorithm
@@ -144,14 +145,20 @@ where
             return Step::Continue;
         }
 
-        let id = s.node.index();
+        let node_key = calculate_hash(&(tie_seed, s.node.index())); // tie_rank's 1st arg
         let prev_label = s.prev().community_id;
         let winner_label = LABEL_COUNTS.with(|counts| {
             let mut counts = counts.borrow_mut();
             counts.clear();
+
+            let mut best_label = prev_label;
+            let mut best_count = 0;
+            let mut best_rank = 0u64;
             if prev_label != NO_LABEL {
                 // initialised nodes vote for their own label
                 counts.insert(prev_label, 1);
+                best_count = 1;
+                best_rank = tie_rank(node_key, prev_label);
             }
             for nbor in s.neighbours() {
                 let nbor_label = nbor.prev().community_id;
@@ -160,15 +167,26 @@ where
                 }
                 let count = counts.entry(nbor_label).or_insert(0);
                 *count += 1;
+                let count = *count;
+
+                if nbor_label == best_label {
+                    best_count = count;
+                } else if count >= best_count {
+                    let rank = tie_rank(node_key, nbor_label);
+                    if (count, rank) > (best_count, best_rank) {
+                        best_label = nbor_label;
+                        best_count = count;
+                        best_rank = rank;
+                    }
+                    // TODO: delete
+                    // REMOVED: get max label (use usize ID to resolve tie)
+                    // .max_by(|(k1, v1), (k2, v2)| v1.cmp(v2).then(k1.cmp(k2)))
+                    // REMOVED: a tie settled by pseudorandom rank of (tie_seed) id and label
+                    // .max_by_key(|&(&label, &count)| (count, tie_rank(tie_seed, id, label)))
+                }
             }
-            counts
-                .iter()
-                // REMOVED: get max label (use usize ID to resolve tie)
-                // .max_by(|(k1, v1), (k2, v2)| v1.cmp(v2).then(k1.cmp(k2)))
-                // NEW BEHAVIOUR: a tie is settled by pseudorandom rank, which draws the winner uniformly
-                // from all the top-tied labels.
-                .max_by_key(|&(&label, &count)| (count, tie_rank(tie_seed, id, label)))
-                .map(|(&label, _)| label)
+            // `best_label` is still NO_LABEL only when no voting happened
+            (best_label != NO_LABEL).then_some(best_label)
         });
 
         let state: &mut LabelPropState = s.get_mut();

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -64,10 +64,10 @@ use crate::{
         graph::nodes::Nodes,
     },
     errors::GraphError,
-    prelude::{Graph, NodeStateOps, PropUnwrap},
+    prelude::{Graph, GraphViewOps, NodeStateOps, PropUnwrap},
     python::{
         filter::filter_expr::PyFilterExpr,
-        graph::{node::PyNode, node_state::PyOutputNodeState, views::graph_view::PyGraphView},
+        graph::{node::PyNode, views::graph_view::PyGraphView},
         utils::PyNodeRef,
     },
 };
@@ -792,12 +792,15 @@ pub fn betweenness_centrality(
 ///     graph (GraphView): A reference to the graph
 ///     iter_count (int): Number of iterations. Defaults to 20.
 ///     seed (bytes, optional): Array of 32 bytes of u8 which is set as the rng seed
-///     init_state (OutputNodeState, optional): Node state from a previous run used as the initial community assignment
+///     init_state (dict[NodeInput, int], optional): initial community assignment. Nodes omitted from the map start unlabelled and take a label from their neighbours.
 ///     rel_tol (float, optional): Relative-improvement threshold for the plateau stop. An iteration counts as progress only if its changed-node count drops below best * (1 - rel_tol). Defaults to 3e-4.
 ///     patience (int, optional): Stop after this many consecutive iterations without progress. Defaults to 10.
 ///
 /// Returns:
 ///     OutputNodeState: NodeState mapping nodes to community id
+///
+/// Raises:
+///     ValueError: If a key of `init_state` is not a node in `graph`.
 ///
 #[pyfunction]
 #[pyo3[signature = (graph, iter_count=20, seed=None, init_state=None, rel_tol=None, patience=None)]]
@@ -805,25 +808,30 @@ pub fn label_propagation(
     graph: &PyGraphView,
     iter_count: usize,
     seed: Option<[u8; 32]>,
-    init_state: Option<&PyOutputNodeState>,
+    init_state: Option<HashMap<PyNodeRef, usize>>,
     rel_tol: Option<f64>,
     patience: Option<usize>,
-) -> OutputTypedNodeState<'static, DynamicGraph> {
-    let init_map: Option<HashMap<usize, usize>> = init_state.map(|state| {
-        state
-            .inner
-            .iter()
-            .filter_map(|(node, prop_map)| {
-                let cid = prop_map
-                    .get("community_id")
-                    .and_then(|v| v.as_ref())
-                    .and_then(|p| (&p.0).as_f64())
-                    .map(|v| v as usize)?;
-                Some((node.node.0, cid))
-            })
-            .collect()
-    });
-    label_propagation_rs(
+) -> PyResult<OutputTypedNodeState<'static, DynamicGraph>> {
+    let init_map: Option<HashMap<usize, usize>> = match init_state {
+        None => None,
+        Some(seeds) => {
+            let mut resolved = HashMap::with_capacity(seeds.len());
+            for (node, label) in seeds {
+                match graph.graph.node(&node) {
+                    Some(n) => {
+                        resolved.insert(n.node.0, label);
+                    }
+                    None => {
+                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                            "{node:?} is not a node in the graph"
+                        )))
+                    }
+                }
+            }
+            Some(resolved)
+        }
+    };
+    let result = label_propagation_rs(
         &graph.graph,
         iter_count,
         seed,
@@ -831,12 +839,8 @@ pub fn label_propagation(
         init_map,
         rel_tol,
         patience,
-    )
-    .to_output_nodestate()
-    // match  {
-    //Ok(result) => Ok(result),
-    //Err(err_msg) => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(err_msg)),
-    // }
+    );
+    Ok(result.to_output_nodestate())
 }
 
 /// Determines which nodes are in the k-core for a given value of k

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -807,7 +807,7 @@ pub fn betweenness_centrality(
 pub fn label_propagation(
     graph: &PyGraphView,
     iter_count: usize,
-    seed: Option<[u8; 32]>,
+    seed: Option<u64>,
     init_state: Option<HashMap<PyNodeRef, usize>>,
     rel_tol: Option<f64>,
     patience: Option<usize>,

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -72,7 +72,6 @@ use crate::{
     },
 };
 use pyo3::{prelude::*, types::PyList};
-use std::collections::HashMap;
 use rand::{prelude::StdRng, SeedableRng};
 use raphtory_api::core::{
     entities::{properties::prop::Prop, LayerIds},
@@ -80,6 +79,7 @@ use raphtory_api::core::{
     Direction,
 };
 use raphtory_storage::core_ops::CoreGraphOps;
+use std::collections::HashMap;
 
 /// Helper function to parse single-vertex or multi-vertex parameters to a Vec of vertices
 fn process_node_param(param: &Bound<PyAny>) -> PyResult<Vec<PyNodeRef>> {
@@ -793,17 +793,21 @@ pub fn betweenness_centrality(
 ///     iter_count (int): Number of iterations. Defaults to 20.
 ///     seed (bytes, optional): Array of 32 bytes of u8 which is set as the rng seed
 ///     init_state (OutputNodeState, optional): Node state from a previous run used as the initial community assignment
+///     rel_tol (float, optional): Relative-improvement threshold for the plateau stop. An iteration counts as progress only if its changed-node count drops below best * (1 - rel_tol). Defaults to 3e-4.
+///     patience (int, optional): Stop after this many consecutive iterations without progress. Defaults to 10.
 ///
 /// Returns:
 ///     OutputNodeState: NodeState mapping nodes to community id
 ///
 #[pyfunction]
-#[pyo3[signature = (graph, iter_count=20, seed=None, init_state=None)]]
+#[pyo3[signature = (graph, iter_count=20, seed=None, init_state=None, rel_tol=None, patience=None)]]
 pub fn label_propagation(
     graph: &PyGraphView,
     iter_count: usize,
     seed: Option<[u8; 32]>,
     init_state: Option<&PyOutputNodeState>,
+    rel_tol: Option<f64>,
+    patience: Option<usize>,
 ) -> OutputTypedNodeState<'static, DynamicGraph> {
     let init_map: Option<HashMap<usize, usize>> = init_state.map(|state| {
         state
@@ -819,7 +823,16 @@ pub fn label_propagation(
             })
             .collect()
     });
-    label_propagation_rs(&graph.graph, iter_count, seed, None, init_map).to_output_nodestate()
+    label_propagation_rs(
+        &graph.graph,
+        iter_count,
+        seed,
+        None,
+        init_map,
+        rel_tol,
+        patience,
+    )
+    .to_output_nodestate()
     // match  {
     //Ok(result) => Ok(result),
     //Err(err_msg) => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(err_msg)),

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -813,7 +813,8 @@ pub fn label_propagation(
                 let cid = prop_map
                     .get("community_id")
                     .and_then(|v| v.as_ref())
-                    .map(|p| p.0.clone().unwrap_u64() as usize)?;
+                    .and_then(|p| (&p.0).as_f64())
+                    .map(|v| v as usize)?;
                 Some((node.node.0, cid))
             })
             .collect()

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -10,8 +10,12 @@ use crate::{
             pagerank::page_rank,
         },
         community_detection::{
-            label_propagation::label_propagation as label_propagation_rs,
-            louvain::louvain as louvain_rs, modularity::ModularityUnDir,
+            label_propagation::{
+                label_propagation as label_propagation_rs,
+                label_propagation_fast as label_propagation_fast_rs,
+            },
+            louvain::louvain as louvain_rs,
+            modularity::ModularityUnDir,
         },
         components,
         cores::k_core::k_core_set,
@@ -786,12 +790,34 @@ pub fn betweenness_centrality(
     betweenness_rs(&graph.graph, k, normalized).to_output_nodestate()
 }
 
+/// Helper: resolve a caller-supplied community assignment to the node indices the label propagation
+/// algorithms expect.
+fn resolve_label_prop_init_state(
+    graph: &PyGraphView,
+    seeds: HashMap<PyNodeRef, usize>,
+) -> PyResult<HashMap<usize, usize>> {
+    let mut resolved = HashMap::with_capacity(seeds.len());
+    for (node, label) in seeds {
+        match graph.graph.node(&node) {
+            Some(n) => {
+                resolved.insert(n.node.0, label);
+            }
+            None => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "{node:?} is not a node in the graph"
+                )))
+            }
+        }
+    }
+    Ok(resolved)
+}
+
 /// Computes components using a label propagation algorithm
 ///
 /// Arguments:
 ///     graph (GraphView): A reference to the graph
 ///     iter_count (int): Number of iterations. Defaults to 20.
-///     seed (bytes, optional): Array of 32 bytes of u8 which is set as the rng seed
+///     seed (int, optional): Seeds the tie-break draw. Pass the value back to reproduce a run.
 ///     init_state (dict[NodeInput, int], optional): initial community assignment. Nodes omitted from the map start unlabelled and take a label from their neighbours.
 ///     rel_tol (float, optional): Relative-improvement threshold for the plateau stop. An iteration counts as progress only if its changed-node count drops below best * (1 - rel_tol). Defaults to 3e-4.
 ///     patience (int, optional): Stop after this many consecutive iterations without progress. Defaults to 10.
@@ -812,26 +838,52 @@ pub fn label_propagation(
     rel_tol: Option<f64>,
     patience: Option<usize>,
 ) -> PyResult<OutputTypedNodeState<'static, DynamicGraph>> {
-    let init_map: Option<HashMap<usize, usize>> = match init_state {
-        None => None,
-        Some(seeds) => {
-            let mut resolved = HashMap::with_capacity(seeds.len());
-            for (node, label) in seeds {
-                match graph.graph.node(&node) {
-                    Some(n) => {
-                        resolved.insert(n.node.0, label);
-                    }
-                    None => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                            "{node:?} is not a node in the graph"
-                        )))
-                    }
-                }
-            }
-            Some(resolved)
-        }
-    };
+    let init_map = init_state
+        .map(|seeds| resolve_label_prop_init_state(graph, seeds))
+        .transpose()?;
     let result = label_propagation_rs(
+        &graph.graph,
+        iter_count,
+        seed,
+        None,
+        init_map,
+        rel_tol,
+        patience,
+    );
+    Ok(result.to_output_nodestate())
+}
+
+/// Computes components using a label propagation algorithm, bypassing the task framework
+///
+/// Returns the same communities as `label_propagation` called with the same arguments, but only
+/// runs the seeded case, so `init_state` is required.
+///
+/// Arguments:
+///     graph (GraphView): A reference to the graph
+///     init_state (dict[NodeInput, int]): initial community assignment. Nodes omitted from the map start unlabelled and take a label from their neighbours.
+///     iter_count (int): Number of iterations. Defaults to 20.
+///     seed (int, optional): Seeds the tie-break draw. Pass the value back to reproduce a run.
+///     rel_tol (float, optional): Relative-improvement threshold for the plateau stop. An iteration counts as progress only if its changed-node count drops below best * (1 - rel_tol). Defaults to 3e-4.
+///     patience (int, optional): Stop after this many consecutive iterations without progress. Defaults to 10.
+///
+/// Returns:
+///     OutputNodeState: NodeState mapping nodes to community id
+///
+/// Raises:
+///     ValueError: If a key of `init_state` is not a node in `graph`.
+///
+#[pyfunction]
+#[pyo3[signature = (graph, init_state, iter_count=20, seed=None, rel_tol=None, patience=None)]]
+pub fn label_propagation_fast(
+    graph: &PyGraphView,
+    init_state: HashMap<PyNodeRef, usize>,
+    iter_count: usize,
+    seed: Option<u64>,
+    rel_tol: Option<f64>,
+    patience: Option<usize>,
+) -> PyResult<OutputTypedNodeState<'static, DynamicGraph>> {
+    let init_map = resolve_label_prop_init_state(graph, init_state)?;
+    let result = label_propagation_fast_rs(
         &graph.graph,
         iter_count,
         seed,

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -64,14 +64,15 @@ use crate::{
         graph::nodes::Nodes,
     },
     errors::GraphError,
-    prelude::Graph,
+    prelude::{Graph, NodeStateOps, PropUnwrap},
     python::{
         filter::filter_expr::PyFilterExpr,
-        graph::{node::PyNode, views::graph_view::PyGraphView},
+        graph::{node::PyNode, node_state::PyOutputNodeState, views::graph_view::PyGraphView},
         utils::PyNodeRef,
     },
 };
 use pyo3::{prelude::*, types::PyList};
+use std::collections::HashMap;
 use rand::{prelude::StdRng, SeedableRng};
 use raphtory_api::core::{
     entities::{properties::prop::Prop, LayerIds},
@@ -791,18 +792,33 @@ pub fn betweenness_centrality(
 ///     graph (GraphView): A reference to the graph
 ///     iter_count (int): Number of iterations. Defaults to 20.
 ///     seed (bytes, optional): Array of 32 bytes of u8 which is set as the rng seed
+///     init_state (OutputNodeState, optional): Node state from a previous run used as the initial community assignment
 ///
 /// Returns:
 ///     OutputNodeState: NodeState mapping nodes to community id
 ///
 #[pyfunction]
-#[pyo3[signature = (graph, iter_count=20, seed=None)]]
+#[pyo3[signature = (graph, iter_count=20, seed=None, init_state=None)]]
 pub fn label_propagation(
     graph: &PyGraphView,
     iter_count: usize,
     seed: Option<[u8; 32]>,
+    init_state: Option<&PyOutputNodeState>,
 ) -> OutputTypedNodeState<'static, DynamicGraph> {
-    label_propagation_rs(&graph.graph, iter_count, seed, None).to_output_nodestate()
+    let init_map: Option<HashMap<usize, usize>> = init_state.map(|state| {
+        state
+            .inner
+            .iter()
+            .filter_map(|(node, prop_map)| {
+                let cid = prop_map
+                    .get("community_id")
+                    .and_then(|v| v.as_ref())
+                    .map(|p| p.0.unwrap_u64() as usize)?;
+                Some((node.node.0, cid))
+            })
+            .collect()
+    });
+    label_propagation_rs(&graph.graph, iter_count, seed, None, init_map).to_output_nodestate()
     // match  {
     //Ok(result) => Ok(result),
     //Err(err_msg) => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(err_msg)),

--- a/raphtory/src/python/packages/algorithms.rs
+++ b/raphtory/src/python/packages/algorithms.rs
@@ -813,7 +813,7 @@ pub fn label_propagation(
                 let cid = prop_map
                     .get("community_id")
                     .and_then(|v| v.as_ref())
-                    .map(|p| p.0.unwrap_u64() as usize)?;
+                    .map(|p| p.0.clone().unwrap_u64() as usize)?;
                 Some((node.node.0, cid))
             })
             .collect()

--- a/raphtory/src/python/packages/base_modules.rs
+++ b/raphtory/src/python/packages/base_modules.rs
@@ -223,6 +223,7 @@ pub fn base_algorithm_module(py: Python<'_>) -> Result<Bound<'_, PyModule>, PyEr
         hits,
         balance,
         label_propagation,
+        label_propagation_fast,
         k_core,
         temporal_SEIR,
         louvain,


### PR DESCRIPTION
### What changes were proposed in this pull request?

The label propagation algorithm is getting:
- A new initialisation. We can pass `init_state` as a map of node labels, with the idea that we will typically want to do this with an incomplete list of nodes. In this case all the nodes not in the list are considered as having `NO_LABEL` which is a sentinel. Unlabelled nodes don't cast a vote.
- An automatic stopping based on the `rel_tol` and `patience` parameters. The algorithm returns after `patience` iterations where the number of nodes changing isn't more than the `rel_tol` fraction.
- A more sophisticated way of breaking up vote ties. Initially, we were using a hash to randomly break ties between votes, and because this was inefficient it's now combination of hashing and a affine mapping.
- A fast version, which is a complete re-write that doesn't use the Tasks API (`ATask`, `TaskRunner`, etc..).

### Why are the changes needed?

Both for performance and usability. The partial initialisation covers an important use case for us.

### Does this PR introduce any user-facing change? If yes is this documented?

Yes, the signature of the `label_propagation` function is changing. We are also adding the function `label_propagation_fast`. It's documented in the docstrings.

### How was this patch tested?

Some of the changes rely on the existing `lpa_test` (initialised with a different seed in order to recover the expected partitions), while the new fast version has a new test `lpa_fast_matches_lpa`.

### Are there any further changes required?

Not that we are aware of, but surely there will be things to clean up.
